### PR TITLE
feat: use uv plugin

### DIFF
--- a/.github/workflows/quality-gates.yaml
+++ b/.github/workflows/quality-gates.yaml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
   # Run the quality checks periodically
   # FIXME: adjust the frequency as needed once we have actual gates in place
-  schedule:
-    - cron: "0 0 * * Tue"
+  # schedule:
+  #   - cron: "0 0 * * Tue"
 
 
 jobs:

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -8,5 +8,5 @@ on:
 jobs:
     tics:
         name: TiCs
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
         secrets: inherit

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,10 +3,6 @@
 
 name: opentelemetry-collector-k8s
 type: charm
-assumes:
-  - k8s-api
-  - juju >= 3.6
-
 summary: Vendor-agnostic way to receive, process and export telemetry data.
 description: |
   The OpenTelemetry Collector offers a vendor-agnostic implementation on how to receive, 
@@ -15,10 +11,14 @@ description: |
   (e.g. Jaeger, Prometheus, etc.) to multiple open-source or commercial back-ends.
 
 links:
+  # documentation: https://discourse.charmhub.io/
   website: https://charmhub.io/opentelemetry-collector-k8s
   source: https://github.com/canonical/opentelemetry-collector-k8s-operator
   issues: https://github.com/canonical/opentelemetry-collector-k8s-operator/issues
-  # documentation: https://discourse.charmhub.io/
+
+assumes:
+  - k8s-api
+  - juju >= 3.6
 
 platforms:
   ubuntu@24.04:amd64:
@@ -26,21 +26,17 @@ platforms:
 
 parts:
   charm:
-    charm-binary-python-packages: [cryptography, jsonschema, pydantic, pydantic-core, maturin]
+    source: .
+    plugin: uv
     build-packages: [git]
     build-snaps: [astral-uv]
     override-build: |
-      uv export --frozen --no-hashes --format=requirements-txt -o requirements.txt
-      git describe --always > version
       craftctl default
-    charm-requirements: [requirements.txt]
+      git describe --always > $CRAFT_PART_INSTALL/version
   cos-tool:
     plugin: dump
-    source: .
-    build-packages:
-      - curl
-    override-pull: |
-      curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_ARCH_BUILD_FOR}
+    source: https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_ARCH_BUILD_FOR}
+    source-type: file
     permissions:
       - path: cos-tool-${CRAFT_ARCH_BUILD_FOR}
         mode: "755"
@@ -55,17 +51,11 @@ resources:
     description: OCI image for opentelemetry-collector
     upstream-source: ghcr.io/canonical/opentelemetry-collector:dev
 
-actions:
-  reconcile:
-    description: >
-      Regenerate the world state from scratch. This includes the configuration file,
-      but also relation data set by the charm.
-
 provides:
   receive-loki-logs:
     interface: loki_push_api
+    optional: true
     description: To receive logs by allowing Promtail instances to specify the Otelcol as their Loki address.
-
   # TODO https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37277
   # receive-remote-write:
   #   interface: prometheus_remote_write
@@ -73,12 +63,15 @@ provides:
 requires:
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
     description: To scrape other charms' metrics endpoints.
   send-remote-write:
     interface: prometheus_remote_write
+    optional: true
     description: To forward collected metrics to a Prometheus backend.
   send-loki-logs:
     interface: loki_push_api
+    optional: true
     description: To forward collected logs to a Loki backend.
 
 config:
@@ -88,3 +81,9 @@ config:
         Toggle forwarding of alert rules.
       type: boolean
       default: true
+
+actions:
+  reconcile:
+    description: >
+      Regenerate the world state from scratch. This includes the configuration file,
+      but also relation data set by the charm.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 convention = "google"
 
 [tool.pyright]
-extraPaths = ["lib"]
+extraPaths = ["src", "lib"]
 pythonVersion = "3.8"
 pythonPlatform = "All"
 


### PR DESCRIPTION
This PR switches `charmcraft.yaml` to use the `uv` plugin.

It also has the following minor changes:
- re-order keys in `charmcraft.yaml` to be consistent with our other repositories
- add `optional: true` to all relations
- disable quality gates for now (there are no quality gates yet), in line with other charms
- switch the tiobe scan workflow from `main` to `v1`