### PR TITLE
feat: add keep-models feature to jubilant tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -62,7 +62,8 @@ def charm_resources(metadata_file="charmcraft.yaml") -> Dict[str, str]:
     return resources
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def juju():
-    with jubilant.temp_model() as juju:
+    keep_models: bool = os.environ.get("KEEP_MODELS") is not None
+    with jubilant.temp_model(keep=keep_models) as juju:
         yield juju


### PR DESCRIPTION
## Issue
Currently, when running CI in "debug mode" for integration tests, we pass `--keep-models` as an argument to `pytest`. However, this does nothing for `jubilant` tests. As shown [here](https://canonical-jubilant.readthedocs-hosted.com/how-to/migrate-from-pytest-operator/#a-juju-model-fixture), we need to pass a boolean to the instantiation of the Juju model.


## Solution
Pair with https://github.com/canonical/observability/commit/404613a6bd43150263b651890a8556221333eb99 to enable debugging itests in CI.
