### PR TITLE
fix: housekeeping

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -83,6 +83,60 @@ def test_add_telemetry():
     assert cfg._config["service"]["telemetry"]["logs"] == {"level": "INFO"}
 
 
+def test_add_prometheus_scrape():
+    # GIVEN an empty config
+    cfg = Config()
+    # WHEN attempting to add scrape jobs without incoming metrics
+    cfg.add_prometheus_scrape([{"foo": "bar"}], incoming_metrics=False)
+    # THEN the prometheus receiver config is not added (or updated if existing config)
+    with pytest.raises(KeyError):
+        cfg._config["receivers"]["prometheus"]
+
+    # WHEN a scrape job is added to the config
+    first_job = [
+        {
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": ["*:9001"]}],
+            "job_name": "first_job",
+            "scrape_interval": "15s",
+        }
+    ]
+    expected_prom_recv_cfg = {
+        "config": {
+            "scrape_configs": [
+                {
+                    "metrics_path": "/metrics",
+                    "static_configs": [{"targets": ["*:9001"]}],
+                    "job_name": "first_job",
+                    "scrape_interval": "15s",
+                },
+            ]
+        }
+    }
+    cfg.add_prometheus_scrape(first_job, True)
+    # THEN it exists in the prometheus receiver config
+    assert cfg._config["receivers"]["prometheus"] == expected_prom_recv_cfg
+
+    # WHEN more scrape jobs are added to the config
+    more_jobs = [
+        {
+            "metrics_path": "/metrics",
+            "job_name": "second_job",
+        },
+        {
+            "metrics_path": "/metrics",
+            "job_name": "third_job",
+        },
+    ]
+    cfg.add_prometheus_scrape(more_jobs, True)
+    # THEN the original scrape job wasn't overwritten and the newly added scrape jobs were added
+    job_names = [
+        job["job_name"]
+        for job in cfg._config["receivers"]["prometheus"]["config"]["scrape_configs"]
+    ]
+    assert job_names == ["first_job", "second_job", "third_job"]
+
+
 def test_rendered_default_is_valid():
     # GIVEN a default config
     # WHEN the config is rendered

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ setenv =
 passenv =
   PYTHONPATH
   CHARM_PATH
+  KEEP_MODELS
 
 [testenv:lock]
 description = Update uv.lock with the latest deps


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
1. We are missing tests for the `add_prometheus_scrape` method
2. We forgot to add `KEEP_MODELS` to `passenv` in the `tox.ini` so that way jubilant does not always tear down models in CI for when we want to shell in using TMate.

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Add the unit tests
2. Update the tox.ini

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e unit -- tests/unit/test_config.py::test_add_prometheus_scrape`

## Upgrade Notes
<!-- To upgrade from an older revision of the charm, ... -->
