### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,3 +16,9 @@
 
 ## Upgrade Notes
 <!-- To upgrade from an older revision of the charm, ... -->
+
+
+## Checklist
+<!-- Common tasks related to charm modifications, ... -->
+- Are you adding an exporter or receiver to the config?
+  - [ ] If exporter (or a receiver which makes client-like requests to a server, i.e. prometheus scraping), did you add a `"tls": {"insecure_skip_verify": ...}` section to its config?


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
In [this PR discussion](https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/31#discussion_r2043874989), we decided to leave the `insecure_skip_verify` juju config option functionality inside the individual exporter and receiver configs. This creates the possibility that a contributor who is adding an exporter (or client-like receiver) will not know that they need to add a `"tls": {"insecure_skip_verify": ...}` section to the config to maintain the juju config functionality. We could solve this in 3 ways:
1. Have an integration test which attempts to create all possible relations (since relations dynamically create receivers and exporters in the otelcol config). Then see if every exporter and receiver has this configuration.
	- We want to minimize the amount of intensive integration tests, and this is a convoluted test to write.
2. Add it to the PR template as a checklist item.
	- This is fragile as there is no assertion proving it is done correctly
3. Have a [sweeping method inside the render method](https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/31/commits/b57acf693d6c7c60edc867c103bbf844dd353f91#diff-217a439192bc495c66132a58a1bf7a92ee70f0eb9702c6b00f60644e726479b5R127)

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of the charm, ... -->
