### PR TITLE
fix: remove ops_test and async

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,7 +24,7 @@ def timed_memoizer(func):
     """Cache the result of a function."""
 
     @functools.wraps(func)
-    async def wrapper(*args, **kwargs):
+    def wrapper(*args, **kwargs):
         fname = func.__qualname__
         logger.info("Started: %s" % fname)
         start_time = datetime.now()
@@ -32,7 +32,7 @@ def timed_memoizer(func):
             ret = store[fname]
         else:
             logger.info("Return for {} not cached".format(fname))
-            ret = await func(*args, **kwargs)
+            ret = func(*args, **kwargs)
             store[fname] = ret
         logger.info("Finished: {} in: {} seconds".format(fname, datetime.now() - start_time))
         return ret
@@ -42,12 +42,12 @@ def timed_memoizer(func):
 
 @pytest.fixture(scope="module")
 @timed_memoizer
-async def charm(ops_test: OpsTest) -> str:
+def charm(ops_test: OpsTest) -> str:
     """Charm used for integration testing."""
     if charm_file := os.environ.get("CHARM_PATH"):
         return str(charm_file)
 
-    charm = await ops_test.build_charm(".")
+    charm = ops_test.build_charm(".")
     assert charm
     return str(charm)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -32,7 +32,7 @@ def test_pebble_checks(juju: jubilant.Juju, charm: str, charm_resources: Dict[st
     """Deploy the charm."""
     sh.juju.switch(juju.model)
     app_name = "otel-collector-k8s"
-    juju.deploy(charm, app_name, trust=True)
+    juju.deploy(charm, app_name, resources=charm_resources)
     juju.wait(jubilant.all_active, delay=10, timeout=60)
     pebble_checks = _get_pebble_checks(model=juju.model, app_name=app_name)
     assert "down" not in pebble_checks

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -17,7 +17,7 @@ import sh
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
 
 
-async def test_logs_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
+def test_logs_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: loki-to-loki formatted log forwarding."""
     sh.juju.switch(juju.model)
     # GIVEN a model with flog, otel-collector, and loki charms

--- a/tests/integration/test_recv_ca_cert.py
+++ b/tests/integration/test_recv_ca_cert.py
@@ -40,7 +40,7 @@ def logs_contain_no_errors(logs):
     assert "context deadline exceeded" not in logs
 
 
-async def test_unknown_authority(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
+def test_unknown_authority(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: Otelcol fails to scrape metrics from a server signed by unknown authority."""
     sh.juju.switch(juju.model)
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Using async methods makes it hard to debug the itests. Since we are already supporting jubilant which is not async, we should move away from async entirely.

Packing the charm with OpsTest is done async and there are some alternatives.


## Solution
<!-- A summary of the solution addressing the above issue -->
The `timed_memoizer` and `charm` packing are currently async, but they can be replaced with Pietro's [pytest-jubilant](https://pypi.org/project/pytest-jubilant/) like [in Tempo](https://github.com/canonical/tempo-coordinator-k8s-operator/blob/e6e18fe53023fb968ebf43dec67a18b851143a13/tests/integration/test_integration.py#L23).


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
- [pytest-jubilant](https://pypi.org/project/pytest-jubilant/) is likely too immature to implement in production but it solves the asnyc charmcraft packing.
- We could also solve this with the `sh` module


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox`
`tox -e integration`


## Upgrade Notes
<!-- To upgrade from an older revision of the charm, ... -->
