### PR TITLE
feat: receive-server-cert endpoint name

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -94,7 +94,7 @@ requires:
     optional: true
     limit: 1
     description: Forward telemetry to another Observability stack (Grafana Cloud, COS, etc.).
-  certificates:
+  receive-server-cert:
     interface: tls-certificates
     optional: true
     limit: 1

--- a/src/charm.py
+++ b/src/charm.py
@@ -160,7 +160,7 @@ def server_cert(charm: CharmBase, container: Container) -> str:
     csr_attrs = CertificateRequestAttributes(common_name=common_name, sans_dns=frozenset({domain}))
     certificates = TLSCertificatesRequiresV4(
         charm=charm,
-        relationship_name="certificates",
+        relationship_name="receive-server-cert",
         certificate_requests=[csr_attrs],
         mode=Mode.UNIT,
     )
@@ -337,7 +337,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         # TODO Conditionally open ports based on the otelcol config file rather than opening all ports
         self.unit.set_ports(*self.otel_config.ports)
 
-        if bool(self.model.relations.get("certificates")) and not server_cert_on_disk:
+        if bool(self.model.relations.get("receive-server-cert")) and not server_cert_on_disk:
             # A tls relation to a CA was formed, but we didn't get the cert yet.
             container.stop(SERVICE_NAME)
             self.unit.status = WaitingStatus("Waiting for cert")

--- a/tests/manual/bundle-tls.yaml
+++ b/tests/manual/bundle-tls.yaml
@@ -31,7 +31,7 @@ applications:
     scale: 1
 relations:
 - - ssc:certificates
-  - otelcol:certificates
+  - otelcol:receive-server-cert
 - - ssc:send-ca-cert
   - otelcol:receive-ca-cert
 - - ssc:certificates

--- a/tests/unit/test_tls_certificates.py
+++ b/tests/unit/test_tls_certificates.py
@@ -52,7 +52,7 @@ def test_waiting_for_cert(ctx, execs):
     container = Container(name="otelcol", can_connect=True, execs=execs)
     # WHEN a tls-certificates relation joins but the CA didn't reply with a cert yet
     ssc = Relation(
-        endpoint="certificates",
+        endpoint="receive-server-cert",
         interface="tls-certificate",
     )
     state_in = State(relations=[ssc], containers=[container])
@@ -66,7 +66,7 @@ def test_transitioned_from_http_to_https_to_http(ctx, execs, cert, cert_obj, pri
     # GIVEN otelcol has received a cert
     container = Container(name="otelcol", can_connect=True, execs=execs)
     ssc = Relation(
-        endpoint="certificates",
+        endpoint="receive-server-cert",
         interface="tls-certificate",
     )
     data_sink = Relation(
@@ -112,7 +112,7 @@ def test_https_endpoint_is_provided(ctx, execs, cert, cert_obj, private_key):
     # GIVEN otelcol is in TLS mode
     container = Container(name="otelcol", can_connect=True, execs=execs)
     ssc = Relation(
-        endpoint="certificates",
+        endpoint="receive-server-cert",
         interface="tls-certificate",
     )
     data_source = Relation(


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We have a `tls-certificates` relation in our charm and were thinking of renaming the endpoint to `receive-server-cert` instead of the common `certificates` which, as a plural word, provides a weird context to the Juju admin. The TLS matrix channel provided some confidence, stating that "each relation is supposed to create one CSR for a specific purpose".


## Solution
<!-- A summary of the solution addressing the above issue -->
@simskij and @sed-i support `receive-server-cert`, current thinking is that "server" could be useful in the future to differentiate from other cert types such as mTLS cert.
