### PR TITLE
feat: add mandatory relation pairs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ from constants import (
 
 
 from cosl import JujuTopology
-from ops import CharmBase, main, Container
+from ops import BlockedStatus, CharmBase, main, Container
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import CheckDict, ExecDict, HttpDict, Layer
 
@@ -71,6 +71,11 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         container = self.unit.get_container(self._container_name)
         insecure_skip_verify = cast(bool, self.config.get("tls_insecure_skip_verify"))
         integrations.cleanup()
+
+        # Mandatory relation pairs
+        missing_relations = integrations.get_missing_mandatory_relations(self)
+        if missing_relations:
+            self.unit.status = BlockedStatus(missing_relations)
 
         # Integrate with TLS relations
         receive_ca_certs_hash = integrations.receive_ca_cert(

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -485,22 +485,24 @@ def get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
         pairs={
             "metrics-endpoint": [  # must be paired with:
                 {"send-remote-write"},  # or
-                {"grafana-cloud-config"},
+                {"cloud-config"},
             ],
-            "logging-provider": [  # must be paired with:
-                {"logging-consumer"},  # or
-                {"grafana-cloud-config"},
+            "receive-loki-logs": [  # must be paired with:
+                {"send-loki-logs"},  # or
+                {"cloud-config"},
             ],
-            "tracing-provider": [  # must be paired with:
-                {"tracing"},  # or
-                {"grafana-cloud-config"},
+            "receive-traces": [  # must be paired with:
+                {"send-traces"},  # or
+                {"cloud-config"},
             ],
             "grafana-dashboards-consumer": [  # must be paired with:
                 {"grafana-dashboards-provider"},  # or
-                {"grafana-cloud-config"},
+                {"cloud-config"},
             ],
         }
     )
     active_relations = {name for name, relation in charm.model.relations.items() if relation}
+    logger.info(f"+++ Active relations: {active_relations}")
     missing_str = relation_pairs.get_missing_as_str(*active_relations)
+    logger.info(f"+++ Missing relations: {missing_str}")
     return missing_str or None

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -44,7 +44,7 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     Mode,
     TLSCertificatesRequiresV4,
 )
-from cosl import LZMABase64
+from cosl import LZMABase64, MandatoryRelationPairs
 from ops import CharmBase
 from ops.model import Relation
 
@@ -467,3 +467,40 @@ def receive_ca_cert(
 
     # A hot-reload doesn't pick up new system certs - need to restart the service
     return sha256(yaml.safe_dump(ca_certs))
+
+
+def get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
+    """Check whether mandatory relations are in place.
+
+    The charm can use this information to set BlockedStatus.
+    Without any matching outgoing relation, the collector could incur data loss.
+
+    Incoming relations are evaluated with AND, while outgoing relations with OR.
+
+    Returns:
+        A string containing the missing relations in string format, or None if
+        all the mandatory relation pairs are present.
+    """
+    relation_pairs = MandatoryRelationPairs(
+        pairs={
+            "metrics-endpoint": [  # must be paired with:
+                {"send-remote-write"},  # or
+                {"grafana-cloud-config"},
+            ],
+            "logging-provider": [  # must be paired with:
+                {"logging-consumer"},  # or
+                {"grafana-cloud-config"},
+            ],
+            "tracing-provider": [  # must be paired with:
+                {"tracing"},  # or
+                {"grafana-cloud-config"},
+            ],
+            "grafana-dashboards-consumer": [  # must be paired with:
+                {"grafana-dashboards-provider"},  # or
+                {"grafana-cloud-config"},
+            ],
+        }
+    )
+    active_relations = {name for name, relation in charm.model.relations.items() if relation}
+    missing_str = relation_pairs.get_missing_as_str(*active_relations)
+    return missing_str or None

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -502,7 +502,5 @@ def get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
         }
     )
     active_relations = {name for name, relation in charm.model.relations.items() if relation}
-    logger.info(f"+++ Active relations: {active_relations}")
     missing_str = relation_pairs.get_missing_as_str(*active_relations)
-    logger.info(f"+++ Missing relations: {missing_str}")
     return missing_str or None

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,7 +15,6 @@ from pytest_operator.plugin import OpsTest
 # pyright: reportAttributeAccessIssue = false
 
 
-
 def _get_pebble_checks(ops_test: OpsTest, app_name: str):
     """Get the pebble checks results."""
     assert ops_test.model
@@ -32,6 +31,6 @@ async def test_pebble_checks(ops_test: OpsTest, charm: str, charm_resources: Dic
     assert ops_test.model
     app_name = "otel-collector-k8s"
     await ops_test.model.deploy(charm, app_name, resources=charm_resources)
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active")
+    await ops_test.model.wait_for_idle(apps=[app_name], status="blocked")
     pebble_checks = _get_pebble_checks(ops_test=ops_test, app_name=app_name)
     assert "down" not in pebble_checks

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -31,6 +31,6 @@ async def test_pebble_checks(ops_test: OpsTest, charm: str, charm_resources: Dic
     assert ops_test.model
     app_name = "otel-collector-k8s"
     await ops_test.model.deploy(charm, app_name, resources=charm_resources)
-    await ops_test.model.wait_for_idle(apps=[app_name], status="blocked")
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active")
     pebble_checks = _get_pebble_checks(ops_test=ops_test, app_name=app_name)
     assert "down" not in pebble_checks

--- a/tests/integration/test_mandatory_relation_pairs.py
+++ b/tests/integration/test_mandatory_relation_pairs.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Feature: Ingested logs are forwarded."""
+
+import pathlib
+from typing import Dict
+
+import jubilant
+
+# pyright: reportAttributeAccessIssue = false
+
+# Juju is a strictly confined snap that cannot see /tmp, so we need to use something else
+TEMP_DIR = pathlib.Path(__file__).parent.resolve()
+
+
+async def test_logs_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
+    """Scenario: loki-to-loki formatted log forwarding."""
+    # GIVEN a model with flog, otel-collector, and loki charms
+    juju.deploy("flog-k8s", app="flog", channel="latest/stable", trust=True)
+    juju.deploy("loki-k8s", app="loki", channel="2/edge", trust=True)
+    juju.deploy(charm, app="otelcol", resources=charm_resources, trust=True)
+    juju.wait(jubilant.all_active, delay=10, timeout=600)
+    # WHEN only a source relation is established with otelcol
+    juju.integrate("flog", "otelcol:receive-loki-logs")
+    # THEN otelcol goes to Blocked
+    juju.wait(lambda status: jubilant.all_active(status, "flog"), delay=10, timeout=600)
+    juju.wait(lambda status: jubilant.all_blocked(status, "otelcol"), delay=10, timeout=600)
+    # AND WHEN we add a sink relation
+    juju.integrate("otelcol:send-loki-logs", "loki")
+    # THEN otelcol goes to Active
+    juju.wait(jubilant.all_active, delay=10, timeout=600)


### PR DESCRIPTION
## Issue
Closes #67 


## Solution
Use the `MandatoryRelationPairs` class from `cosl` to potentially set a `BlockedStatus` with the relevant message. The status setting is at the end to still allow for tests using the debug exporter.

## Testing Instructions
The integration tests have been updated to reflect the charm status.

