### PR TITLE
feat: Global scrape configs

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -49,7 +49,7 @@ containers:
         location: /otelcol
 
 storage:
- persisted:
+  persisted:
     type: filesystem
     description: Mount point in which Otelcol will persist data
 
@@ -222,6 +222,18 @@ config:
         Comma separated key-value pairs of labels to be added to all alerts.
         This could be useful for differentiating between staging and production environments.
       type: string
+    global_scrape_timeout:
+      description: >
+        How long to wait before timing out a scrape from a target.
+        Supported units: y, w, d, h, m, s.
+      type: string
+      default: "10s"
+    global_scrape_interval:
+      description: >
+        How frequently should instances be scraped.
+        Supported units: y, w, d, h, m, s.
+      type: string
+      default: "1m"
 
 actions:
   reconcile:

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -85,10 +85,18 @@ class ConfigBuilder:
     configuration that can be consumed by the Collector.
     """
 
-    def __init__(self, receiver_tls: bool = False, exporter_skip_verify: bool = False):
+    def __init__(
+        self,
+        global_scrape_interval: str,
+        global_scrape_timeout: str,
+        receiver_tls: bool = False,
+        exporter_skip_verify: bool = False,
+    ):
         """Generate an empty OpenTelemetry collector config.
 
         Args:
+            global_scrape_interval: value for `scrape_interval` in all prometheus receivers
+            global_scrape_timeout: value for `scrape_timeout` in all prometheus receivers
             receiver_tls: whether to inject TLS config in all receivers on build
             exporter_skip_verify: value for `insecure_skip_verify` in all exporters
 
@@ -105,6 +113,8 @@ class ConfigBuilder:
                 "telemetry": {},
             },
         }
+        self._scrape_interval = global_scrape_interval
+        self._scrape_timeout = global_scrape_timeout
         self._receiver_tls = receiver_tls
         self._exporter_skip_verify = exporter_skip_verify
 
@@ -282,3 +292,13 @@ class ConfigBuilder:
             self._config["exporters"][exporter].setdefault("tls", {}).setdefault(
                 "insecure_skip_verify", insecure_skip_verify
             )
+
+    def _set_prometheus_receiver_global_timeout_and_interval(self, interval: str, timeout: str):
+        """Set the `scrape_interval` and `scrape_timeout` for all scrape_configs in every prometheus receiver."""
+        receivers = self._config.get("receivers", {})
+        for name, receiver in receivers.items():
+            if name.split("/")[0] == "prometheus":
+                scrape_configs = receiver.get("config", {}).get("scrape_configs", [])
+                for scrape_cfg in scrape_configs:
+                    scrape_cfg["scrape_interval"] = interval
+                    scrape_cfg["scrape_timeout"] = timeout

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -103,12 +103,22 @@ class ConfigManager:
     methods for common configuration scenarios.
     """
 
-    def __init__(self, receiver_tls: bool = False, insecure_skip_verify: bool = False, queue_size: int = 1000, max_elapsed_time_min: int = 5):
+    def __init__(
+        self,
+        global_scrape_interval: str,
+        global_scrape_timeout: str,
+        receiver_tls: bool = False,
+        insecure_skip_verify: bool = False,
+        queue_size: int = 1000,
+        max_elapsed_time_min: int = 5,
+    ):
         """Generate a default OpenTelemetry collector ConfigManager.
 
         The base configuration is our opinionated default.
 
         Args:
+            global_scrape_interval: set a global scrape interval for all prometheus receivers on build
+            global_scrape_timeout: set a global scrape timeout for all prometheus receivers on build
             receiver_tls: whether to inject TLS config in all receivers on build
             insecure_skip_verify: value for `insecure_skip_verify` in all exporters
             queue_size: size of the sending queue for exporters
@@ -118,6 +128,8 @@ class ConfigManager:
         self._queue_size = queue_size
         self._max_elapsed_time_min = max_elapsed_time_min
         self.config = ConfigBuilder(
+            global_scrape_interval=global_scrape_interval,
+            global_scrape_timeout=global_scrape_timeout,
             receiver_tls=receiver_tls,
             exporter_skip_verify=insecure_skip_verify,
         )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from shutil import copytree
 import pytest
-from ops.testing import Context, Exec, Container
+from ops.testing import Container, Context, Exec
 
 from charm import OpenTelemetryCollectorK8sCharm
+
 
 @pytest.fixture
 def ctx(tmp_path):
@@ -16,13 +17,17 @@ def ctx(tmp_path):
         copytree(source_path, target_path, dirs_exist_ok=True)
     yield Context(OpenTelemetryCollectorK8sCharm, charm_root=tmp_path)
 
+
 @pytest.fixture(scope="function")
 def otelcol_container(execs):
-    return [Container(
-    name="otelcol",
-    can_connect=True,
-    execs=execs,
-)]
+    return [
+        Container(
+            name="otelcol",
+            can_connect=True,
+            execs=execs,
+        )
+    ]
+
 
 @pytest.fixture
 def execs():

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -25,7 +25,7 @@ def test_add_pipeline_component(pipelines, component):
     https://opentelemetry.io/docs/collector/configuration/#basics
     """
     # GIVEN an empty config
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     # WHEN adding a pipeline component with a nested config
     sample_config = {"a": {"b": "c"}}
     config.add_component(
@@ -56,7 +56,7 @@ def test_add_to_pipeline(pipelines, component):
     https://opentelemetry.io/docs/collector/configuration/#basics
     """
     # GIVEN an empty config
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     # WHEN adding a pipeline component
     config._add_to_pipeline("foo", component, pipelines)
     # THEN the pipeline component is added to the pipeline config
@@ -68,7 +68,7 @@ def test_add_to_pipeline(pipelines, component):
 
 def test_add_extension():
     # GIVEN an empty config
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     # WHEN adding a pipeline with a config
     sample_config = {"a": {"b": "c"}}
     config.add_extension("foo", sample_config)
@@ -80,7 +80,7 @@ def test_add_extension():
 
 def test_add_telemetry():
     # GIVEN an empty config
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     # WHEN adding a pipeline with a config
     sample_config = [{"a": {"b": "c"}}]
     config.add_telemetry("logs", {"level": "INFO"})
@@ -96,7 +96,7 @@ def test_add_telemetry():
 def test_rendered_default_is_valid():
     # GIVEN a default config
     # WHEN the config is rendered
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     config.add_default_config()
     config_yaml = yaml.safe_load(config.build())
     # THEN a debug exporter is added for each pipeline missing one
@@ -110,16 +110,16 @@ def test_rendered_default_is_valid():
 
 def test_receivers_tls_empty_config():
     # GIVEN an "empty" config
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     # WHEN tls is enabled
     config._add_tls_to_all_receivers("/some/cert.crt", "/some/private.key")
     # THEN it has no effect on the rendered config
-    assert config.build() == ConfigBuilder().build()
+    assert config.build() == ConfigBuilder("", "").build()
 
 
 def test_receivers_tls_no_protocols():
     # GIVEN a config without any protocols
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     config.add_component(
         Component.receiver, "prometheus", {"config": {"foo": "bar"}}, pipelines=["metrics"]
     )
@@ -138,7 +138,7 @@ def test_receivers_tls_no_protocols():
 
 def test_receivers_tls_unknown_protocols():
     # GIVEN a config with an unknown protocols
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     config.add_component(
         Component.receiver,
         "some_receiver",
@@ -156,7 +156,7 @@ def test_receivers_tls_unknown_protocols():
 
 def test_receivers_tls_known_protocols():
     # GIVEN a config with known protocols (http, grpc)
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     config.add_component(
         Component.receiver,
         "some-http-receiver",
@@ -224,7 +224,7 @@ def test_receivers_tls_known_protocols():
 
 def test_insecure_skip_verify():
     # GIVEN an empty config without exporters
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     config_copy = deepcopy(config)
     # WHEN updating the tls::insecure_skip_verify exporter configuration
     config._add_exporter_insecure_skip_verify(False)
@@ -250,7 +250,7 @@ def test_insecure_skip_verify():
 
 def test_debug_exporter_no_tls_config():
     # GIVEN an empty config without exporters
-    config = ConfigBuilder()
+    config = ConfigBuilder("", "")
     # WHEN multiple debug exporters are added
     config.add_component(Component.exporter, "debug", {"config": {"foo": "bar"}})
     config.add_component(Component.exporter, "debug/descriptor", {"config": {"foo": "bar"}})
@@ -258,3 +258,42 @@ def test_debug_exporter_no_tls_config():
     config._add_exporter_insecure_skip_verify(True)
     # THEN tls::insecure_skip_verify is not set for debug exporters
     assert all("tls" not in exp.keys() for exp in config._config["exporters"].values())
+
+
+def test_global_scrape_timeout_and_interval():
+    # GIVEN a config with multiple prometheus receivers
+    config = ConfigBuilder("", "")
+    config.add_component(Component.receiver, name="prometheus", config={"config": {}})
+    config.add_component(
+        Component.receiver, name="prometheus/empty-cfgs", config={"config": {"scrape_configs": []}}
+    )
+    config.add_component(
+        Component.receiver,
+        name="prometheus/missing-timeout",
+        config={"config": {"scrape_configs": [{"scrape_interval": "1s"}]}},
+    )
+    config.add_component(
+        Component.receiver,
+        name="prometheus/missing-interval",
+        config={"config": {"scrape_configs": [{"scrape_timeout": "1s"}]}},
+    )
+    config.add_component(
+        Component.receiver,
+        name="prometheus/multiple-cfgs",
+        config={
+            "config": {
+                "scrape_configs": [
+                    {"scrape_interval": "1s", "scrape_timeout": "1s"},
+                    {"scrape_interval": "1s", "scrape_timeout": "1s"},
+                ]
+            }
+        },
+    )
+    # WHEN the global scrape interval and timeout is set
+    config._set_prometheus_receiver_global_timeout_and_interval("1m", "10s")
+    # THEN all prometheus receivers are updated
+    for receiver in config._config["receivers"].values():
+        if receiver["config"]:
+            for scrape_cfg in receiver["config"]["scrape_configs"]:
+                assert scrape_cfg["scrape_interval"] == "1m"
+                assert scrape_cfg["scrape_timeout"] == "10s"

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -8,7 +8,7 @@ from config_manager import ConfigManager
 
 def test_add_prometheus_scrape():
     # GIVEN an empty config
-    config_manager = ConfigManager(insecure_skip_verify=True)
+    config_manager = ConfigManager("", "", insecure_skip_verify=True)
 
     # WHEN a scrape job is added to the config
     first_job = [
@@ -62,7 +62,7 @@ def test_add_prometheus_scrape():
 
 def test_add_log_forwarding():
     # GIVEN an empty config
-    config_manager = ConfigManager(insecure_skip_verify=True)
+    config_manager = ConfigManager("", "", insecure_skip_verify=True)
 
     # WHEN a loki exporter is added to the config
     expected_loki_forwarding_cfg = {
@@ -95,7 +95,7 @@ def test_add_log_forwarding():
 
 def test_add_traces_forwarding():
     # GIVEN an empty config
-    config_manager = ConfigManager(insecure_skip_verify=True)
+    config_manager = ConfigManager("", "", insecure_skip_verify=True)
 
     # WHEN a traces exporter is added to the config
     expected_traces_forwarding_cfg = {
@@ -120,7 +120,7 @@ def test_add_traces_forwarding():
 
 def test_add_remote_write():
     # GIVEN an empty config
-    config_manager = ConfigManager(insecure_skip_verify=True)
+    config_manager = ConfigManager("", "", insecure_skip_verify=True)
 
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {

--- a/tests/unit/test_juju_config.py
+++ b/tests/unit/test_juju_config.py
@@ -1,0 +1,31 @@
+from ops.testing import State
+import pytest
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",  # Missing value and unit
+        "1",  # Missing unit
+        "s",  # Missing value
+        "1x",  # Incorrect unit
+        "1sec",  # Incorrect unit
+    ],
+)
+@pytest.mark.parametrize(
+    "global_scrape_config", ["global_scrape_interval", "global_scrape_timeout"]
+)
+def test_invalid_global_scrape_config(ctx, otelcol_container, global_scrape_config, value):
+    # GIVEN the charm has an invalid global_scrape_config set
+    state = State(config={global_scrape_config: value}, containers=otelcol_container)
+
+    # WHEN any event is emitted
+    state_out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN the charm enters BlockedStatus
+    assert state_out.unit_status.name == "blocked"
+    # AND the correct config is identified to the admin
+    assert (
+        state_out.unit_status.message
+        == f"The {global_scrape_config} config requires format: '\\d+[ywdhms]'."
+    )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/opentelemetry-collector-operator/issues/39

## Solution
<!-- A summary of the solution addressing the above issue -->
Add config options for `global_scrape_interval` and `global_scrape_timeout`. Otel-collector's config is different from Grafana-agent's in the sense that it has not context of "global" config options. This option is only configurable at the receiver level, per `prometheus` receiver. For this reason, we have 2 possible approaches:
1. Make sure that each instance of the `add_component` for `prometheus` receiver has this properly implemented
2. Have a pre-render method in the config `build` method, which iterates over all `prometheus` receivers and updates the `global_scrape_interval` and `global_scrape_timeout`.

This PR implements option `#2` since it is more robust and avoids user configuration error.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- `tox -e unit -- tests/unit/test_config_builder.py`