### PR TITLE
feat: add profiling ingestion

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -75,6 +75,11 @@ provides:
   # TODO https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37277
   # receive-remote-write:
   #   interface: prometheus_remote_write
+  receive-profiles:
+    interface: profiling
+    optional: true
+    description: Receive profiles from other charms.
+
 
 requires:
   send-profiles:

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -325,8 +325,8 @@ class ConfigManager:
         # TODO Receive alert rules via remote write
         # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37277
 
-    def add_profiling(self, endpoints: List[str], tls:bool=False):
-        """Configure ingesting profiles and forwarding to a profiling backend (Pyroscope)."""
+    def add_profile_ingestion(self):
+        """Configure ingesting profiles."""
         self.config.add_component(
             Component.receiver,
             "otlp",
@@ -339,6 +339,8 @@ class ConfigManager:
             pipelines=["profiles"],
         )
 
+    def add_profile_forwarding(self, endpoints: List[str], tls:bool=False):
+        """Configure forwarding profiles to a profiling backend (Pyroscope)."""
         for idx, endpoint in enumerate(endpoints):
             self.config.add_component(
                 Component.exporter,

--- a/tests/unit/test_profiling_integration.py
+++ b/tests/unit/test_profiling_integration.py
@@ -23,12 +23,12 @@ def tls_mock(cert_obj, private_key):
 
 
 @pytest.mark.parametrize("relation_joined", (True, False))
-def test_waiting_for_profiling_endpoint(ctx, execs, relation_joined):
-    """Scenario: a profiling relation joined, but we didn't get the grpc endpoint yet."""
+def test_waiting_for_send_profiles_endpoint(ctx, execs, relation_joined):
+    """Scenario: a send_profiles relation joined, but we didn't get the grpc endpoint yet."""
     # GIVEN otelcol deployed in isolation
     container = Container(name="otelcol", can_connect=True, execs=execs)
 
-    # WHEN a profiling relation joins but pyroscope didn't reply with an endpoint yet,
+    # WHEN a send_profiles relation joins but pyroscope didn't reply with an endpoint yet,
     # or the relation didn't join yet at all
     relations = {Relation(
         endpoint="send-profiles",
@@ -43,22 +43,40 @@ def test_waiting_for_profiling_endpoint(ctx, execs, relation_joined):
     assert plan_out.checks["valid-config"].exec['command'] == f"otelcol validate --config={CONFIG_PATH}"
 
 
+@pytest.mark.parametrize("relation_joined", (True, False))
+def test_waiting_for_receive_profiles_endpoint(ctx, execs, relation_joined):
+    """Scenario: a receive_profiles relation joined."""
+    # GIVEN otelcol deployed in isolation
+    container = Container(name="otelcol", can_connect=True, execs=execs)
+
+    # WHEN a receive_profiles relation joins
+    state_in = State(relations={Relation(
+        endpoint="receive-profiles",
+    )}, containers=[container])
+    state_out = ctx.run(ctx.on.update_status(), state=state_in)
+
+    # THEN the pebble layer command and check contain the feature gate
+    plan_out = state_out.get_container("otelcol").plan
+    assert plan_out.services[SERVICE_NAME].command == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    assert plan_out.checks["valid-config"].exec['command'] == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+
+
 @pytest.mark.parametrize("insecure_skip_verify", (True, False))
-def test_profiling_integration(ctx, execs, insecure_skip_verify):
+def test_send_profiles_integration(ctx, execs, insecure_skip_verify):
     """Scenario: a profiling relation joined and sent us a grpc endpoint."""
     # GIVEN otelcol deployed in isolation
     container = Container(name="otelcol", can_connect=True, execs=execs)
 
     pyro_url = "my.fqdn.cluster.local:12345"
     # WHEN a profiling relation joins and pyroscope sent an endpoint
-    profiling = Relation(
+    send_profiles = Relation(
         endpoint="send-profiles",
         remote_app_data={
             "otlp_grpc_endpoint_url": json.dumps(pyro_url),
             "otlp_http_endpoint_url": json.dumps("foobar"),
         }
     )
-    state_in = State(relations=[profiling], containers=[container],
+    state_in = State(relations=[send_profiles], containers=[container],
                      config={"tls_insecure_skip_verify": insecure_skip_verify})
     state_out = ctx.run(ctx.on.update_status(), state=state_in)
 
@@ -72,6 +90,37 @@ def test_profiling_integration(ctx, execs, insecure_skip_verify):
     assert cfg['service']['pipelines']['profiles']['exporters'][0] == 'otlp/profiling/0'
     assert cfg['exporters']['otlp/profiling/0']['endpoint'] == pyro_url
     assert cfg["exporters"]["otlp/profiling/0"]["tls"] == {"insecure": True, "insecure_skip_verify": insecure_skip_verify}
+
+
+@patch("socket.getfqdn", return_value="localhost")
+@pytest.mark.parametrize("insecure_skip_verify", (True, False))
+def test_receive_profiles_integration(sock_mock, ctx, execs, insecure_skip_verify):
+    """Scenario: a receive-profiles relation joined."""
+    # GIVEN otelcol deployed in isolation
+    container = Container(name="otelcol", can_connect=True, execs=execs)
+
+    # WHEN a receive-profiles relation joins and pyroscope sent an endpoint
+    receive_profiles = Relation(
+        endpoint="receive-profiles"
+    )
+    state_in = State(relations=[receive_profiles], containers=[container],
+                     config={"tls_insecure_skip_verify": insecure_skip_verify},
+                     leader=True)
+    state_out = ctx.run(ctx.on.update_status(), state=state_in)
+
+    # THEN the pebble layer command and check contain the profilesSupport feature gate
+    plan_out = state_out.get_container("otelcol").plan
+    assert plan_out.services[SERVICE_NAME].command == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    assert plan_out.checks["valid-config"].exec['command'] == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+
+    # AND the profiling pipeline contains a profiling pipeline, but no exporters other than debug
+    cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
+    assert cfg['service']['pipelines']['profiles']['exporters'] == ['debug']
+
+    # AND we publish to app databag our profile ingestion endpoints for otlp_http and otlp_grpc
+    receive_profiles_app_data = state_out.get_relation(receive_profiles.id).local_app_data
+    assert receive_profiles_app_data['otlp_grpc_endpoint_url']
+    assert receive_profiles_app_data['otlp_http_endpoint_url']
 
 
 


### PR DESCRIPTION
Follow-up on #89, this PR adds a receive-profiles integration using the same `profiling` interface.
Same testing caveats apply as in #89.