### PR TITLE
fix: add profiling receiver if exporter is configured

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -341,6 +341,10 @@ class ConfigManager:
 
     def add_profile_forwarding(self, endpoints: List[str], tls:bool=False):
         """Configure forwarding profiles to a profiling backend (Pyroscope)."""
+        # if we don't do this, and there is no relation on receive-profiles, otelcol will complain
+        # that there are no receivers configured for this exporter.
+        self.add_profile_ingestion()
+
         for idx, endpoint in enumerate(endpoints):
             self.config.add_component(
                 Component.exporter,

--- a/tests/unit/test_profiling_integration.py
+++ b/tests/unit/test_profiling_integration.py
@@ -88,6 +88,7 @@ def test_send_profiles_integration(ctx, execs, insecure_skip_verify):
     # AND the profiling pipeline contains an exporter to the expected url
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
     assert cfg['service']['pipelines']['profiles']['exporters'][0] == 'otlp/profiling/0'
+    assert cfg['service']['pipelines']['profiles']['receivers'][0] == "otlp"
     assert cfg['exporters']['otlp/profiling/0']['endpoint'] == pyro_url
     assert cfg["exporters"]["otlp/profiling/0"]["tls"] == {"insecure": True, "insecure_skip_verify": insecure_skip_verify}
 


### PR DESCRIPTION
Enables the otlp profiling receiver if the profiling exporter is enabled, otherwise otelcol will error out when there is a send-profiles relation but not a receive-profiles one.
