### PR TITLE
fix: Remove the WAL config for the PrometheusRemoteWrite exporter

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -152,12 +152,17 @@ class ConfigManager:
 
     @property
     def prometheus_remotewrite_wal_config(self) -> Dict[str, Any]:
-        """Return the default WAL configuration for Prometheus remote write."""
-        return {
-            "wal": {
-                "directory": FILE_STORAGE_DIRECTORY,
-            },
-        }
+        """Return the default WAL configuration for Prometheus remote write.
+
+        FIXME The WAL is broken upstream, so we remove it until this is fixed:
+        https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/105
+        """
+        return {}
+        # return {
+        #     "wal": {
+        #         "directory": FILE_STORAGE_DIRECTORY,
+        #     },
+        # }
 
     def add_log_ingestion(self) -> None:
         """Configure the collector to receive logs via Loki protocol.
@@ -339,7 +344,7 @@ class ConfigManager:
             pipelines=["profiles"],
         )
 
-    def add_profile_forwarding(self, endpoints: List[str], tls:bool=False):
+    def add_profile_forwarding(self, endpoints: List[str], tls: bool = False):
         """Configure forwarding profiles to a profiling backend (Pyroscope)."""
         # if we don't do this, and there is no relation on receive-profiles, otelcol will complain
         # that there are no receivers configured for this exporter.
@@ -362,8 +367,8 @@ class ConfigManager:
                     "tls": {
                         "insecure": True,
                         # "insecure": not tls,
-                        "insecure_skip_verify": self._insecure_skip_verify
-                        },
+                        "insecure_skip_verify": self._insecure_skip_verify,
+                    },
                     **self.sending_queue_config,
                 },
                 pipelines=["profiles"],

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -154,15 +154,10 @@ class ConfigManager:
     def prometheus_remotewrite_wal_config(self) -> Dict[str, Any]:
         """Return the default WAL configuration for Prometheus remote write.
 
-        FIXME The WAL is broken upstream, so we remove it until this is fixed:
+        FIXME The WAL config is broken upstream, so we remove it until this is fixed:
         https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/105
         """
         return {}
-        # return {
-        #     "wal": {
-        #         "directory": FILE_STORAGE_DIRECTORY,
-        #     },
-        # }
 
     def add_log_ingestion(self) -> None:
         """Configure the collector to receive logs via Loki protocol.

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -74,18 +74,14 @@ def test_add_log_forwarding():
         "retry_on_failure": {
             "max_elapsed_time": "5m",
         },
-        "sending_queue": {
-            "enabled": True,
-            "queue_size": 1000,
-            "storage": "file_storage"
-        },
+        "sending_queue": {"enabled": True, "queue_size": 1000, "storage": "file_storage"},
         "tls": {
             "insecure_skip_verify": False,
-        }
+        },
     }
     config_manager.add_log_forwarding(
         endpoints=[{"url": "http://192.168.1.244/cos-loki-0/loki/api/v1/push"}],
-        insecure_skip_verify=False
+        insecure_skip_verify=False,
     )
     # THEN it exists in the loki exporter config
     config = dict(sorted(config_manager.config._config["exporters"]["loki/0"].items()))
@@ -103,11 +99,7 @@ def test_add_traces_forwarding():
         "retry_on_failure": {
             "max_elapsed_time": "5m",
         },
-        "sending_queue": {
-            "enabled": True,
-            "queue_size": 1000,
-            "storage": "file_storage"
-        },
+        "sending_queue": {"enabled": True, "queue_size": 1000, "storage": "file_storage"},
     }
     config_manager.add_traces_forwarding(
         endpoint="http://192.168.1.244:4318",
@@ -125,18 +117,16 @@ def test_add_remote_write():
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {
         "endpoint": "http://192.168.1.244/cos-prometheus-0/api/v1/write",
-        # FIXME https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/105
-        # "wal": {
-        #     "directory": "/otelcol",
-        # },
         "tls": {
             "insecure_skip_verify": True,
-        }
+        },
     }
     config_manager.add_remote_write(
         endpoints=[{"url": "http://192.168.1.244/cos-prometheus-0/api/v1/write"}],
     )
     # THEN it exists in the remote write exporter config
-    config = dict(sorted(config_manager.config._config["exporters"]["prometheusremotewrite/0"].items()))
+    config = dict(
+        sorted(config_manager.config._config["exporters"]["prometheusremotewrite/0"].items())
+    )
     expected_config = dict(sorted(expected_remote_write_cfg.items()))
     assert config == expected_config

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -125,9 +125,10 @@ def test_add_remote_write():
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {
         "endpoint": "http://192.168.1.244/cos-prometheus-0/api/v1/write",
-        "wal": {
-            "directory": "/otelcol",
-        },
+        # FIXME https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/105
+        # "wal": {
+        #     "directory": "/otelcol",
+        # },
         "tls": {
             "insecure_skip_verify": True,
         }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/105

TL;DR the PrometheusRemoteWrite (PRW) exporter WAL config is broken, causing some error logs.

## Solution
<!-- A summary of the solution addressing the above issue -->
Remove the WAL config from the PrometheusRemoteWrite (PRW) exporter.
