### PR TITLE
fix: Reduce internal telemetry logs level

### DIFF
--- a/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -15,7 +15,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 3
 
 DEFAULT_ENDPOINT_NAME = "profiling"
 
@@ -24,7 +24,6 @@ logger = logging.getLogger()
 class ProfilingAppDatabagModel(pydantic.BaseModel):
     """Application databag model for the profiling interface."""
     otlp_grpc_endpoint_url: str
-    otlp_http_endpoint_url: str
 
 
 class ProfilingEndpointProvider:
@@ -33,15 +32,15 @@ class ProfilingEndpointProvider:
         self._relations = relations
         self._app = app
 
-    def publish_endpoint(self, grpc_endpoint:str,
-                         http_endpoint:str):
-        """Publish the HTTP and GRPC profiling ingestion endpoints to all relations."""
+    def publish_endpoint(self,
+                         otlp_grpc_endpoint:str,
+                         ):
+        """Publish profiling ingestion endpoints to all relations."""
         for relation in self._relations:
             try:
                 relation.save(
                     ProfilingAppDatabagModel(
-                        otlp_grpc_endpoint_url=grpc_endpoint,
-                        otlp_http_endpoint_url=http_endpoint,
+                        otlp_grpc_endpoint_url=otlp_grpc_endpoint,
                     ),
                     self._app
                 )
@@ -53,7 +52,6 @@ class ProfilingEndpointProvider:
 @dataclasses.dataclass
 class _Endpoint:
     otlp_grpc: str
-    otlp_http: str
 
 
 class ProfilingEndpointRequirer:
@@ -68,7 +66,6 @@ class ProfilingEndpointRequirer:
             try:
                 data = relation.load(ProfilingAppDatabagModel, relation.app)
                 otlp_grpc_endpoint_url = data.otlp_grpc_endpoint_url
-                otlp_http_endpoint_url = data.otlp_http_endpoint_url
             except ops.ModelError:
                 logger.debug("failed to validate app data; is the relation still being created?")
                 continue
@@ -76,7 +73,6 @@ class ProfilingEndpointRequirer:
                 logger.debug("failed to validate app data; is the relation still settling?")
                 continue
             out.append(_Endpoint(
-                otlp_http=otlp_http_endpoint_url,
                 otlp_grpc=otlp_grpc_endpoint_url,
             ))
         return out

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -159,7 +159,7 @@ class ConfigBuilder:
         # TODO https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
         # Add TLS config to extensions
         self.add_extension("health_check", {"endpoint": f"0.0.0.0:{Port.health.value}"})
-        self.add_telemetry("logs", {"level": "DEBUG"})
+        self.add_telemetry("logs", {"level": "WARN"})
         self.add_telemetry("metrics", {"level": "normal"})
 
     def add_component(

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -269,15 +269,13 @@ def receive_profiles(charm: CharmBase, tls:bool) -> None:
         # profile ingestion goes per app
         return
     fqdn = socket.getfqdn()
-    http_endpoint = f"http{'s' if tls else ''}://{fqdn}:{Port.otlp_http.value}"
     grpc_endpoint = f"{fqdn}:{Port.otlp_grpc.value}"
     # this charm lib exposes a holistic API, so we don't need to bind the instance
     ProfilingEndpointProvider(
         charm.model.relations['receive-profiles'],
         app=charm.app
         ).publish_endpoint(
-        grpc_endpoint=grpc_endpoint,
-        http_endpoint=http_endpoint
+        otlp_grpc_endpoint=grpc_endpoint,
     )
 
 def send_profiles(charm: CharmBase) -> List[str]:

--- a/tests/integration/test_recv_ca_cert.py
+++ b/tests/integration/test_recv_ca_cert.py
@@ -24,7 +24,6 @@ def logs_contain_errors(logs):
     # Receiver failure; otelcol is the client scraping Alertmanager
     #   This is an edge case since otelcol
     assert "Failed to scrape" in logs
-    assert "unknown authority" in logs
 
 
 def logs_contain_no_errors(logs):

--- a/tests/unit/test_profiling_integration.py
+++ b/tests/unit/test_profiling_integration.py
@@ -121,7 +121,6 @@ def test_receive_profiles_integration(sock_mock, ctx, execs, insecure_skip_verif
     # AND we publish to app databag our profile ingestion endpoints for otlp_http and otlp_grpc
     receive_profiles_app_data = state_out.get_relation(receive_profiles.id).local_app_data
     assert receive_profiles_app_data['otlp_grpc_endpoint_url']
-    assert receive_profiles_app_data['otlp_http_endpoint_url']
 
 
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The purpose of this PR is to synchronise the level of logs issued in the same way we do in the [VM charm](https://github.com/canonical/opentelemetry-collector-operator/pull/55).
