### PR TITLE
feat: add extra_alert_labels functionality to log alerts

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -131,6 +131,9 @@ def send_loki_logs(charm: CharmBase) -> List[Dict]:
         relation_name="send-loki-logs",
         alert_rules_path=LOKI_RULES_DEST_PATH,
         forward_alert_rules=forward_alert_rules,
+        extra_alert_labels=key_value_pair_string_to_dict(
+            cast(str, charm.model.config.get("extra_alert_labels", ""))
+        ),
     )
     charm.__setattr__("loki_consumer", loki_consumer)
     # TODO: Luca: probably don't need this anymore

--- a/tests/integration/test_profiling.py
+++ b/tests/integration/test_profiling.py
@@ -55,7 +55,7 @@ async def test_smoke(juju: jubilant.Juju, charm: str, charm_resources: Dict[str,
     # WHEN we add relations to send profiles to pyroscope
     juju.integrate("otelcol:send-profiles", "pyroscope:profiling")
     # THEN otelcol and pyroscope are active
-    juju.wait(jubilant.all_active, delay=10, timeout=600)
+    juju.wait(jubilant.all_active, delay=10, timeout=900)
 
 
 # https://github.com/canonical/pyroscope-operators/issues/232

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -68,14 +68,14 @@ async def test_traces_pipeline(juju: jubilant.Juju, charm: str, charm_resources:
     juju.integrate("otelcol:send-charm-traces", "tempo:tracing")
     # THEN charm traces arrive in tempo
     tempo_ip = juju.status().apps["tempo"].units["tempo/0"].address
-    juju.wait(jubilant.all_active, delay=10, timeout=600)
+    juju.wait(jubilant.all_active, delay=10, timeout=900)
     await check_traces_from_app(tempo_ip=tempo_ip, app="otelcol")
 
     # AND WHEN we add relations to send traces to tempo
     juju.integrate("otelcol:receive-traces", "grafana:charm-tracing")
     juju.integrate("otelcol:receive-traces", "grafana:workload-tracing")
     juju.integrate("otelcol:send-traces", "tempo:tracing")
-    juju.wait(jubilant.all_active, delay=10, timeout=600)
+    juju.wait(jubilant.all_active, delay=10, timeout=900)
     # AND some traces are produced
     juju.run("grafana/0", "get-admin-password")
     juju.integrate("otelcol:grafana-dashboards-provider", "grafana")
@@ -96,10 +96,10 @@ async def test_traces_with_tls(juju: jubilant.Juju):
     juju.integrate("tempo:certificates", "ssc")
     juju.integrate("otelcol:receive-ca-cert", "ssc")
     # Make sure tempo and otelcol are using TLS before sending new traces
-    juju.wait(jubilant.all_active, delay=10, timeout=600)
+    juju.wait(jubilant.all_active, delay=10, timeout=900)
     juju.integrate("otelcol:receive-traces", "coconut:charm-tracing")
     juju.integrate("otelcol:receive-traces", "coconut:workload-tracing")
-    juju.wait(jubilant.all_active, delay=10, timeout=600)
+    juju.wait(jubilant.all_active, delay=10, timeout=900)
 
     # AND some traces are produced
     juju.run("coconut/0", "get-admin-password")

--- a/tests/unit/test_extra_alert_labels.py
+++ b/tests/unit/test_extra_alert_labels.py
@@ -9,35 +9,42 @@ from ops.testing import Relation, State
 ConfigDict = Dict[str, Union[str, int, float, bool]]
 
 zinc_alerts = {
-    "alert_rules": json.dumps({
-        'groups': [
-            {
-                'name': 'alertgroup',
-                'rules': [
-                    {
-                        'alert': 'Missing',
-                        'expr': 'up == 0',
-                        'for': '0m',
-                        'labels': {
-                            'juju_model': 'my_model',
-                            'juju_model_uuid': '74a5690b-89c9-44dd-984b-f69f26a6b751',
-                            'juju_application': 'zinc',
-                            'juju_charm' : 'zinc-k8s',
-                        },
-                    }
-                ],
-            }
-        ]
-    })
+    "alert_rules": json.dumps(
+        {
+            "groups": [
+                {
+                    "name": "alertgroup",
+                    "rules": [
+                        {
+                            "alert": "Missing",
+                            "expr": "up == 0",
+                            "for": "0m",
+                            "labels": {
+                                "juju_model": "my_model",
+                                "juju_model_uuid": "74a5690b-89c9-44dd-984b-f69f26a6b751",
+                                "juju_application": "zinc",
+                                "juju_charm": "zinc-k8s",
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+    )
 }
+
 
 def test_extra_alerts_config(ctx, otelcol_container):
     # GIVEN a new key-value pair of extra alerts labels, for instance:
     # juju config otelcol extra_alerts_labels="environment: PRODUCTION, zone=Mars"
-    config1: ConfigDict = {"extra_alert_labels": "environment: PRODUCTION, zone=Mars",}
+    config1: ConfigDict = {
+        "extra_alert_labels": "environment: PRODUCTION, zone=Mars",
+    }
 
     # THEN The extra_alert_labels MUST be added to the alert rules.
-    metrics_endpoint_relation = Relation("metrics-endpoint", remote_app_name="zinc", remote_app_data=zinc_alerts)
+    metrics_endpoint_relation = Relation(
+        "metrics-endpoint", remote_app_name="zinc", remote_app_data=zinc_alerts
+    )
     remote_write_relation = Relation("send-remote-write", remote_app_name="prometheus")
     state = State(
         leader=True,
@@ -46,7 +53,7 @@ def test_extra_alerts_config(ctx, otelcol_container):
             remote_write_relation,
         ],
         containers=otelcol_container,
-        config=config1, # type: ignore
+        config=config1,  # type: ignore
     )
     out_0 = ctx.run(ctx.on.relation_changed(relation=metrics_endpoint_relation), state)
     out_1 = ctx.run(
@@ -66,6 +73,70 @@ def test_extra_alerts_config(ctx, otelcol_container):
                 assert rule["labels"]["juju_model"] == "my_model"
                 assert rule["labels"]["juju_model_uuid"] == "74a5690b-89c9-44dd-984b-f69f26a6b751"
 
+    # GIVEN the config option for extra alert labels is unset
+    config2: ConfigDict = {"extra_alert_labels": ""}
+
+    # THEN the only labels present in the alert are the JujuTopology labels
+    next_state = State(
+        leader=True,
+        relations=out_1.relations,
+        containers=out_1.containers,
+        config=config2,
+    )
+    out_2 = ctx.run(ctx.on.config_changed(), next_state)
+    alert_rules_mod = json.loads(
+        out_2.get_relation(remote_write_relation.id).local_app_data["alert_rules"]
+    )
+
+    for group in alert_rules_mod["groups"]:
+        for rule in group["rules"]:
+            if "opentelemetry_collector_k8s_alertgroup_alerts" in group["name"]:
+                assert "environment" not in rule["labels"].keys()
+                assert "zone" not in rule["labels"].keys()
+                assert rule["labels"]["juju_application"] == "zinc"
+                assert rule["labels"]["juju_charm"] == "zinc-k8s"
+                assert rule["labels"]["juju_model"] == "my_model"
+                assert rule["labels"]["juju_model_uuid"] == "74a5690b-89c9-44dd-984b-f69f26a6b751"
+
+
+def test_extra_loki_alerts_config(ctx, otelcol_container):
+    # GIVEN a new key-value pair of extra alerts labels, for instance:
+    # juju config otelcol extra_alerts_labels="environment: PRODUCTION, zone=Mars"
+    config1: ConfigDict = {
+        "extra_alert_labels": "environment: PRODUCTION, zone=Mars",
+    }
+
+    # THEN The extra_alert_labels MUST be added to the alert rules.
+    receive_loki_logs_relation = Relation(
+        "receive-loki-logs", remote_app_name="zinc", remote_app_data=zinc_alerts
+    )
+    send_loki_logs_relation = Relation("send-loki-logs", remote_app_name="loki")
+    state = State(
+        leader=True,
+        relations=[
+            receive_loki_logs_relation,
+            send_loki_logs_relation,
+        ],
+        containers=otelcol_container,
+        config=config1,  # type: ignore
+    )
+    out_0 = ctx.run(ctx.on.relation_changed(relation=receive_loki_logs_relation), state)
+    out_1 = ctx.run(
+        ctx.on.relation_joined(relation=out_0.get_relation(send_loki_logs_relation.id)), out_0
+    )
+    alert_rules = json.loads(
+        out_1.get_relation(send_loki_logs_relation.id).local_app_data["alert_rules"]
+    )
+
+    for group in alert_rules["groups"]:
+        for rule in group["rules"]:
+            assert rule["labels"]["environment"] == "PRODUCTION"
+            assert rule["labels"]["zone"] == "Mars"
+            if "opentelemetry_collector_k8s_alertgroup_alerts" in group["name"]:
+                assert rule["labels"]["juju_application"] == "zinc"
+                assert rule["labels"]["juju_charm"] == "zinc-k8s"
+                assert rule["labels"]["juju_model"] == "my_model"
+                assert rule["labels"]["juju_model_uuid"] == "74a5690b-89c9-44dd-984b-f69f26a6b751"
 
     # GIVEN the config option for extra alert labels is unset
     config2: ConfigDict = {"extra_alert_labels": ""}
@@ -79,7 +150,7 @@ def test_extra_alerts_config(ctx, otelcol_container):
     )
     out_2 = ctx.run(ctx.on.config_changed(), next_state)
     alert_rules_mod = json.loads(
-         out_2.get_relation(remote_write_relation.id).local_app_data["alert_rules"]
+        out_2.get_relation(send_loki_logs_relation.id).local_app_data["alert_rules"]
     )
 
     for group in alert_rules_mod["groups"]:


### PR DESCRIPTION
Like #111 but for log alerts.

Relates to https://github.com/canonical/loki-k8s-operator/issues/529
