### PR TITLE
fix(profiling): use & set insecure in the profiling databag

### DIFF
--- a/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -27,7 +27,9 @@ class Endpoint:
     """Profiling endpoint."""
 
     otlp_grpc: str
+    """Ingestion endpoint for otlp_grpc profiling data."""
     insecure: bool = False
+    """Whether the ingestion endpoint accepts/demands TLS-encrypted communications."""
 
 
 class ProfilingAppDatabagModel(pydantic.BaseModel):
@@ -75,7 +77,7 @@ class ProfilingEndpointRequirer:
     def get_endpoints(self) -> List[Endpoint]:
         """Obtain the profiling endpoints from all relations."""
         out = []
-        for relation in self._relations:
+        for relation in sorted(self._relations, key=lambda x: x.id):
             try:
                 data = relation.load(ProfilingAppDatabagModel, relation.app)
             except ops.ModelError:

--- a/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -1,5 +1,5 @@
-"""Profiling integration endpoint wrapper.
-"""
+"""Profiling integration endpoint wrapper."""
+
 import dataclasses
 import logging
 from typing import List
@@ -15,34 +15,41 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 DEFAULT_ENDPOINT_NAME = "profiling"
 
 logger = logging.getLogger()
 
+
 class ProfilingAppDatabagModel(pydantic.BaseModel):
     """Application databag model for the profiling interface."""
+
     otlp_grpc_endpoint_url: str
+    insecure: bool = False
 
 
 class ProfilingEndpointProvider:
     """Wraps a profiling provider endpoint."""
-    def __init__(self, relations:List[ops.Relation], app:ops.Application):
+
+    def __init__(self, relations: List[ops.Relation], app: ops.Application):
         self._relations = relations
         self._app = app
 
-    def publish_endpoint(self,
-                         otlp_grpc_endpoint:str,
-                         ):
+    def publish_endpoint(
+        self,
+        otlp_grpc_endpoint: str,
+        insecure: bool = False,
+    ):
         """Publish profiling ingestion endpoints to all relations."""
         for relation in self._relations:
             try:
                 relation.save(
                     ProfilingAppDatabagModel(
                         otlp_grpc_endpoint_url=otlp_grpc_endpoint,
+                        insecure=insecure,
                     ),
-                    self._app
+                    self._app,
                 )
             except ops.ModelError:
                 logger.debug("failed to validate app data; is the relation still being created?")
@@ -52,28 +59,31 @@ class ProfilingEndpointProvider:
 @dataclasses.dataclass
 class _Endpoint:
     otlp_grpc: str
+    insecure: bool = False
 
 
 class ProfilingEndpointRequirer:
     """Wraps a profiling requirer endpoint."""
-    def __init__(self, relations:List[ops.Relation]):
+
+    def __init__(self, relations: List[ops.Relation]):
         self._relations = relations
 
-    def get_endpoints(self)->List[_Endpoint]:
+    def get_endpoints(self) -> List[_Endpoint]:
         """Obtain the profiling endpoints from all relations."""
         out = []
         for relation in self._relations:
             try:
                 data = relation.load(ProfilingAppDatabagModel, relation.app)
-                otlp_grpc_endpoint_url = data.otlp_grpc_endpoint_url
             except ops.ModelError:
                 logger.debug("failed to validate app data; is the relation still being created?")
                 continue
             except pydantic.ValidationError:
                 logger.debug("failed to validate app data; is the relation still settling?")
                 continue
-            out.append(_Endpoint(
-                otlp_grpc=otlp_grpc_endpoint_url,
-            ))
+            out.append(
+                _Endpoint(
+                    otlp_grpc=data.otlp_grpc_endpoint_url,
+                    insecure=data.insecure,
+                )
+            )
         return out
-

--- a/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -22,6 +22,14 @@ DEFAULT_ENDPOINT_NAME = "profiling"
 logger = logging.getLogger()
 
 
+@dataclasses.dataclass
+class Endpoint:
+    """Profiling endpoint."""
+
+    otlp_grpc: str
+    insecure: bool = False
+
+
 class ProfilingAppDatabagModel(pydantic.BaseModel):
     """Application databag model for the profiling interface."""
 
@@ -52,14 +60,10 @@ class ProfilingEndpointProvider:
                     self._app,
                 )
             except ops.ModelError:
-                logger.debug("failed to validate app data; is the relation still being created?")
+                logger.debug(
+                    "failed to validate app data; is the relation still being created?"
+                )
                 continue
-
-
-@dataclasses.dataclass
-class _Endpoint:
-    otlp_grpc: str
-    insecure: bool = False
 
 
 class ProfilingEndpointRequirer:
@@ -68,20 +72,24 @@ class ProfilingEndpointRequirer:
     def __init__(self, relations: List[ops.Relation]):
         self._relations = relations
 
-    def get_endpoints(self) -> List[_Endpoint]:
+    def get_endpoints(self) -> List[Endpoint]:
         """Obtain the profiling endpoints from all relations."""
         out = []
         for relation in self._relations:
             try:
                 data = relation.load(ProfilingAppDatabagModel, relation.app)
             except ops.ModelError:
-                logger.debug("failed to validate app data; is the relation still being created?")
+                logger.debug(
+                    "failed to validate app data; is the relation still being created?"
+                )
                 continue
             except pydantic.ValidationError:
-                logger.debug("failed to validate app data; is the relation still settling?")
+                logger.debug(
+                    "failed to validate app data; is the relation still settling?"
+                )
                 continue
             out.append(
-                _Endpoint(
+                Endpoint(
                     otlp_grpc=data.otlp_grpc_endpoint_url,
                     insecure=data.insecure,
                 )

--- a/src/charm.py
+++ b/src/charm.py
@@ -197,8 +197,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             integrations.receive_profiles(self, tls=is_tls_ready(container))
         if profiling_endpoints := integrations.send_profiles(self):
             config_manager.add_profile_forwarding(
-                profiling_endpoints,
-                tls=is_tls_ready(container)
+                profiling_endpoints
             )
         if self._incoming_profiles or integrations.send_profiles(self):
             feature_gates = "service.profilesSupport"

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -7,6 +7,7 @@ import yaml
 
 from config_builder import Component, ConfigBuilder, Port
 from constants import FILE_STORAGE_DIRECTORY
+from charms.pyroscope_coordinator_k8s.v0.profiling import Endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -339,7 +340,7 @@ class ConfigManager:
             pipelines=["profiles"],
         )
 
-    def add_profile_forwarding(self, endpoints: List):
+    def add_profile_forwarding(self, endpoints: List[Endpoint]):
         """Configure forwarding profiles to a profiling backend (Pyroscope)."""
         # if we don't do this, and there is no relation on receive-profiles, otelcol will complain
         # that there are no receivers configured for this exporter.

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -339,7 +339,7 @@ class ConfigManager:
             pipelines=["profiles"],
         )
 
-    def add_profile_forwarding(self, endpoints: List[str], tls: bool = False):
+    def add_profile_forwarding(self, endpoints: List):
         """Configure forwarding profiles to a profiling backend (Pyroscope)."""
         # if we don't do this, and there is no relation on receive-profiles, otelcol will complain
         # that there are no receivers configured for this exporter.
@@ -351,17 +351,9 @@ class ConfigManager:
                 # first component of this ID is the exporter type
                 f"otlp/profiling/{idx}",
                 {
-                    "endpoint": endpoint,
-                    # we likely need `insecure` as well as `insecure_skip_verify` because the endpoint
-                    # we're receiving from pyroscope is a grpc one and has no scheme prefix, and probably
-                    # the client defaults to https and fails to handshake unless we set `insecure=False`.
-                    # FIXME: anyway for now pyroscope does not support TLS ingestion,
-                    #  so we hardcode `insecure=True`.
-                    #  once TLS support is implemented, we can uncomment the line below.
-                    #  cfr: https://github.com/canonical/pyroscope-operators/pull/117
+                    "endpoint": endpoint.otlp_grpc,
                     "tls": {
-                        "insecure": True,
-                        # "insecure": not tls,
+                        "insecure": endpoint.insecure,
                         "insecure_skip_verify": self._insecure_skip_verify,
                     },
                     **self.sending_queue_config,

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -269,17 +269,17 @@ def receive_profiles(charm: CharmBase, tls: bool) -> None:
         charm.model.relations["receive-profiles"], app=charm.app
     ).publish_endpoint(
         otlp_grpc_endpoint=grpc_endpoint,
+        insecure=not tls,
     )
 
-
-def send_profiles(charm: CharmBase) -> List[str]:
+def send_profiles(charm: CharmBase) -> List:
     """Integrate with other charms via the send-profiles relation endpoint.
 
     Returns:
         All profiling endpoints that we are receiving over `profiling` integrations.
     """
-    profiling_requirer = ProfilingEndpointRequirer(charm.model.relations["send-profiles"])
-    return [ep.otlp_grpc for ep in profiling_requirer.get_endpoints()]
+    profiling_requirer = ProfilingEndpointRequirer(charm.model.relations['send-profiles'])
+    return profiling_requirer.get_endpoints()
 
 
 def receive_traces(charm: CharmBase, tls: bool) -> Set:

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -55,6 +55,7 @@ from charms.pyroscope_coordinator_k8s.v0.profiling import (
     ProfilingEndpointRequirer,
     ProfilingEndpointProvider,
 )
+from charms.pyroscope_coordinator_k8s.v0.profiling import Endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -272,7 +273,7 @@ def receive_profiles(charm: CharmBase, tls: bool) -> None:
         insecure=not tls,
     )
 
-def send_profiles(charm: CharmBase) -> List:
+def send_profiles(charm: CharmBase) -> List[Endpoint]:
     """Integrate with other charms via the send-profiles relation endpoint.
 
     Returns:


### PR DESCRIPTION
## Issue
Currently, we hard code `insecure: False` in the profiling exporter, but with the new lib updates introduced in https://github.com/canonical/pyroscope-k8s-operator/pull/241, the app databag contains an `insecure` field that informs the requrier whether the endpoints are using TLS or not.


## Solution
- Fetch the latest `profiling` lib
- In the profiling exporter, use `insecure` value from the databag
- In the profiling receiver, if the collector is not configured to use TLS (doesn't have the certs on disk), set `insecure=True` 

