### PR TITLE
chore: align shared code with the machine charm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ convention = "google"
 
 [tool.pyright]
 extraPaths = ["src", "lib"]
-pythonVersion = "3.8"
+pythonVersion = "3.12"
 pythonPlatform = "All"
 
 [tool.pytest.ini_options]

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -153,7 +153,7 @@ class ConfigBuilder:
         least one pipeline, and it must have a valid receiver exporter pair.
         """
         # NOTE: We omit the unit identifier in the receiver name to avoid duplicate OTLP receivers
-        #       fighting for port bindings.
+        #       fighting for port bindings. This is only for relevant for the vm charm
         self.add_component(
             Component.receiver,
             "otlp",

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -87,6 +87,7 @@ class ConfigBuilder:
 
     def __init__(
         self,
+        unit_name: str,
         global_scrape_interval: str,
         global_scrape_timeout: str,
         receiver_tls: bool = False,
@@ -95,11 +96,11 @@ class ConfigBuilder:
         """Generate an empty OpenTelemetry collector config.
 
         Args:
+            unit_name: the name of the unit
             global_scrape_interval: value for `scrape_interval` in all prometheus receivers
             global_scrape_timeout: value for `scrape_timeout` in all prometheus receivers
             receiver_tls: whether to inject TLS config in all receivers on build
             exporter_skip_verify: value for `insecure_skip_verify` in all exporters
-
         """
         self._config = {
             "extensions": {},
@@ -113,10 +114,11 @@ class ConfigBuilder:
                 "telemetry": {},
             },
         }
-        self._scrape_interval = global_scrape_interval
-        self._scrape_timeout = global_scrape_timeout
+        self._unit_name = unit_name
         self._receiver_tls = receiver_tls
         self._exporter_skip_verify = exporter_skip_verify
+        self._scrape_interval = global_scrape_interval
+        self._scrape_timeout = global_scrape_timeout
 
     def build(self) -> str:
         """Build the final configuration and return it as a YAML string.
@@ -132,6 +134,10 @@ class ConfigBuilder:
         self._add_missing_debug_exporters()
         if self._receiver_tls:
             self._add_tls_to_all_receivers()
+        self._set_prometheus_receiver_global_timeout_and_interval(
+            self._scrape_interval,
+            self._scrape_timeout,
+        )
         self._add_exporter_insecure_skip_verify(self._exporter_skip_verify)
         return yaml.safe_dump(self._config)
 
@@ -141,10 +147,13 @@ class ConfigBuilder:
         return sha256(yaml.safe_dump(self.build()))
 
     def add_default_config(self):
-        """Return the default config for OpenTelemetry Collector."""
-        # Currently, we always include the OTLP receiver to ensure the config is valid at all times.
-        # We also need these receivers for tracing.
-        # There must be at least one pipeline, and it must have a valid receiver exporter pair.
+        """Return the default config for OpenTelemetry Collector.
+
+        We always include the OTLP receiver to ensure the config is valid, i.e. there must be at
+        least one pipeline, and it must have a valid receiver exporter pair.
+        """
+        # NOTE: We omit the unit identifier in the receiver name to avoid duplicate OTLP receivers
+        #       fighting for port bindings.
         self.add_component(
             Component.receiver,
             "otlp",
@@ -154,7 +163,11 @@ class ConfigBuilder:
                     "grpc": {"endpoint": f"0.0.0.0:{Port.otlp_grpc.value}"},
                 },
             },
-            pipelines=["logs", "metrics", "traces"],
+            pipelines=[
+                    f"logs/{self._unit_name}",
+                    f"metrics/{self._unit_name}",
+                    f"traces/{self._unit_name}",
+                ],
         )
         # TODO https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
         # Add TLS config to extensions
@@ -248,14 +261,14 @@ class ConfigBuilder:
         exporters.
         """
         debug_exporter_required = False
-        for signal in ["logs", "metrics", "traces", "profiles"]:
-            pipeline = self._config["service"]["pipelines"].get(signal, {})
+        for name in self._config["service"]["pipelines"].keys():
+            pipeline = self._config["service"]["pipelines"].get(name, {})
             if pipeline:
                 if pipeline.get("receivers", []) and not pipeline.get("exporters", []):
-                    self._add_to_pipeline("debug", Component.exporter, [signal])
+                    self._add_to_pipeline(f"debug/{self._unit_name}", Component.exporter, [name])
                     debug_exporter_required = True
         if debug_exporter_required:
-            self.add_component(Component.exporter, "debug", {"verbosity": "basic"})
+            self.add_component(Component.exporter, f"debug/{self._unit_name}", {"verbosity": "normal"})
 
     def _add_tls_to_all_receivers(
         self,

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -162,11 +162,6 @@ class ConfigManager:
         FIXME The WAL config is broken upstream, so we remove it until this is fixed:
         https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/105
         """
-        # return {
-        #     "wal": {
-        #         "directory": FILE_STORAGE_DIRECTORY,
-        #     },
-        # }
         return {}
 
     def add_log_ingestion(self) -> None:

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -181,7 +181,7 @@ class ConfigManager:
         """
         self.config.add_component(
             Component.receiver,
-            f"loki/send-loki-logs/{self._unit_name}",
+            f"loki/receive-loki-logs/{self._unit_name}",
             {
                 "protocols": {
                     "http": {
@@ -284,8 +284,8 @@ class ConfigManager:
                     # the client defaults to https and fails to handshake unless we set `insecure=False`.
                     "tls": {
                         "insecure": endpoint.insecure,
-                        "insecure_skip_verify": self._insecure_skip_verify
-                        },
+                        "insecure_skip_verify": self._insecure_skip_verify,
+                    },
                 },
                 pipelines=["profiles"],
             )
@@ -342,18 +342,19 @@ class ConfigManager:
             The scrape jobs will be added to the Prometheus receiver configuration
             with TLS verification settings inherited from the ConfigManager instance.
         """
-        # create the scrape_configs key path if it does not exist
-        if jobs:
-            self.config._config["receivers"].setdefault("prometheus", {}).setdefault(
-                "config", {}
-            ).setdefault("scrape_configs", [])
+        if not jobs:
+            return
         for scrape_job in jobs:
             # Otelcol acts as a client and scrapes the metrics-generating server, so we enable
             # toggling of skipping the validation of the server certificate
             scrape_job.update({"tls_config": {"insecure_skip_verify": self._insecure_skip_verify}})
-            self.config._config["receivers"]["prometheus"]["config"]["scrape_configs"].append(
-                scrape_job
-            )
+
+        self.config.add_component(
+            Component.receiver,
+            f"prometheus/metrics-endpoint/{self._unit_name}",
+            config={"scrape_configs": jobs},
+            pipelines=[f"metrics/{self._unit_name}"],
+        )
 
     def add_remote_write(self, endpoints: List[Dict[str, str]]):
         """Configure forwarding alert rules to prometheus/mimir via remote-write."""

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -352,7 +352,7 @@ class ConfigManager:
         self.config.add_component(
             Component.receiver,
             f"prometheus/metrics-endpoint/{self._unit_name}",
-            config={"scrape_configs": jobs},
+            config={"config": {"scrape_configs": jobs}},
             pipelines=[f"metrics/{self._unit_name}"],
         )
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -6,8 +6,8 @@ from typing import Any, Optional, Dict, List, Literal, Set
 import yaml
 
 from config_builder import Component, ConfigBuilder, Port
+from integrations import ProfilingEndpoint
 from constants import FILE_STORAGE_DIRECTORY
-from charms.pyroscope_coordinator_k8s.v0.profiling import Endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +106,7 @@ class ConfigManager:
 
     def __init__(
         self,
+        unit_name: str,
         global_scrape_interval: str,
         global_scrape_timeout: str,
         receiver_tls: bool = False,
@@ -118,6 +119,7 @@ class ConfigManager:
         The base configuration is our opinionated default.
 
         Args:
+            unit_name: the name of the unit
             global_scrape_interval: set a global scrape interval for all prometheus receivers on build
             global_scrape_timeout: set a global scrape timeout for all prometheus receivers on build
             receiver_tls: whether to inject TLS config in all receivers on build
@@ -125,10 +127,12 @@ class ConfigManager:
             queue_size: size of the sending queue for exporters
             max_elapsed_time_min: maximum elapsed time for retrying failed requests in minutes
         """
+        self._unit_name = unit_name
         self._insecure_skip_verify = insecure_skip_verify
         self._queue_size = queue_size
         self._max_elapsed_time_min = max_elapsed_time_min
         self.config = ConfigBuilder(
+            unit_name=self._unit_name,
             global_scrape_interval=global_scrape_interval,
             global_scrape_timeout=global_scrape_timeout,
             receiver_tls=receiver_tls,
@@ -158,6 +162,11 @@ class ConfigManager:
         FIXME The WAL config is broken upstream, so we remove it until this is fixed:
         https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/105
         """
+        # return {
+        #     "wal": {
+        #         "directory": FILE_STORAGE_DIRECTORY,
+        #     },
+        # }
         return {}
 
     def add_log_ingestion(self) -> None:
@@ -172,7 +181,7 @@ class ConfigManager:
         """
         self.config.add_component(
             Component.receiver,
-            "loki",
+            f"loki/send-loki-logs/{self._unit_name}",
             {
                 "protocols": {
                     "http": {
@@ -181,7 +190,7 @@ class ConfigManager:
                 },
                 "use_incoming_timestamp": True,
             },
-            pipelines=["logs"],
+            pipelines=[f"logs/{self._unit_name}"],
         )
 
     def add_log_forwarding(self, endpoints: List[dict], insecure_skip_verify: bool) -> None:
@@ -203,19 +212,19 @@ class ConfigManager:
         for idx, endpoint in enumerate(endpoints):
             self.config.add_component(
                 Component.exporter,
-                f"loki/{idx}",
+                f"loki/send-loki-logs/{idx}",
                 {
                     "endpoint": endpoint["url"],
                     "default_labels_enabled": {"exporter": False, "job": True},
                     "tls": {"insecure_skip_verify": insecure_skip_verify},
                     **self.sending_queue_config,
                 },
-                pipelines=["logs"],
+                pipelines=[f"logs/{self._unit_name}"],
             )
         # TODO: Luca: this was gated by having outgoing logs. Do we need that?
         self.config.add_component(
             Component.processor,
-            "resource",
+            "resource/send-loki-logs",
             {
                 "attributes": [
                     {
@@ -225,11 +234,11 @@ class ConfigManager:
                     },
                 ]
             },
-            pipelines=["logs"],
+            pipelines=[f"logs/{self._unit_name}"],
         )
         self.config.add_component(
             Component.processor,
-            "attributes",
+            "attributes/send-loki-logs",
             {
                 "actions": [
                     {
@@ -240,8 +249,46 @@ class ConfigManager:
                     },
                 ]
             },
-            pipelines=["logs"],
+            pipelines=[f"logs/{self._unit_name}"],
         )
+
+    def add_profile_ingestion(self):
+        """Configure ingesting profiles."""
+        self.config.add_component(
+            Component.receiver,
+            "otlp",
+            {
+                "protocols": {
+                    "http": {"endpoint": f"0.0.0.0:{Port.otlp_http.value}"},
+                    "grpc": {"endpoint": f"0.0.0.0:{Port.otlp_grpc.value}"},
+                },
+            },
+            pipelines=["profiles"],
+        )
+
+    def add_profile_forwarding(self, endpoints: List[ProfilingEndpoint]):
+        """Configure forwarding profiles to a profiling backend (Pyroscope)."""
+        # if we don't do this, and there is no relation on receive-profiles, otelcol will complain
+        # that there are no receivers configured for this exporter.
+        self.add_profile_ingestion()
+
+        for idx, endpoint in enumerate(endpoints):
+            self.config.add_component(
+                Component.exporter,
+                # first component of this ID is the exporter type
+                f"otlp/profiling/{idx}",
+                {
+                    "endpoint": endpoint.endpoint,
+                    # we need `insecure` as well as `insecure_skip_verify` because the endpoint
+                    # we're receiving from pyroscope is a grpc one and has no scheme prefix, and
+                    # the client defaults to https and fails to handshake unless we set `insecure=False`.
+                    "tls": {
+                        "insecure": endpoint.insecure,
+                        "insecure_skip_verify": self._insecure_skip_verify
+                        },
+                },
+                pipelines=["profiles"],
+            )
 
     def add_self_scrape(self, identifier: str, labels: Dict) -> None:
         """Configure the collector to scrape its own metrics.
@@ -259,7 +306,7 @@ class ConfigManager:
         """
         self.config.add_component(
             Component.receiver,
-            "prometheus",
+            f"prometheus/self-monitoring/{self._unit_name}",
             {
                 "config": {
                     "scrape_configs": [
@@ -277,7 +324,7 @@ class ConfigManager:
                     ]
                 }
             },
-            pipelines=["metrics"],
+            pipelines=[f"metrics/{self._unit_name}"],
         )
 
     def add_prometheus_scrape_jobs(self, jobs: List[Dict]):
@@ -314,53 +361,17 @@ class ConfigManager:
         for idx, endpoint in enumerate(endpoints):
             self.config.add_component(
                 Component.exporter,
-                f"prometheusremotewrite/{idx}",
+                f"prometheusremotewrite/send-remote-write/{idx}",
                 {
                     "endpoint": endpoint["url"],
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
                     **self.prometheus_remotewrite_wal_config,
                 },
-                pipelines=["metrics"],
+                pipelines=[f"metrics/{self._unit_name}"],
             )
 
         # TODO Receive alert rules via remote write
         # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37277
-
-    def add_profile_ingestion(self):
-        """Configure ingesting profiles."""
-        self.config.add_component(
-            Component.receiver,
-            "otlp",
-            {
-                "protocols": {
-                    "http": {"endpoint": f"0.0.0.0:{Port.otlp_http.value}"},
-                    "grpc": {"endpoint": f"0.0.0.0:{Port.otlp_grpc.value}"},
-                },
-            },
-            pipelines=["profiles"],
-        )
-
-    def add_profile_forwarding(self, endpoints: List[Endpoint]):
-        """Configure forwarding profiles to a profiling backend (Pyroscope)."""
-        # if we don't do this, and there is no relation on receive-profiles, otelcol will complain
-        # that there are no receivers configured for this exporter.
-        self.add_profile_ingestion()
-
-        for idx, endpoint in enumerate(endpoints):
-            self.config.add_component(
-                Component.exporter,
-                # first component of this ID is the exporter type
-                f"otlp/profiling/{idx}",
-                {
-                    "endpoint": endpoint.otlp_grpc,
-                    "tls": {
-                        "insecure": endpoint.insecure,
-                        "insecure_skip_verify": self._insecure_skip_verify,
-                    },
-                    **self.sending_queue_config,
-                },
-                pipelines=["profiles"],
-            )
 
     def add_traces_ingestion(
         self,
@@ -388,10 +399,10 @@ class ConfigManager:
 
         if "zipkin" in requested_tracing_protocols:
             self.config.add_component(
-                component=Component.receiver,
-                name="zipkin",
-                config={"endpoint": f"0.0.0.0:{Port.zipkin.value}"},
-                pipelines=["traces"],
+                Component.receiver,
+                f"zipkin/receive-traces/{self._unit_name}",
+                {"endpoint": f"0.0.0.0:{Port.zipkin.value}"},
+                pipelines=[f"traces/{self._unit_name}"],
             )
         if (
             "jaeger_grpc" in requested_tracing_protocols
@@ -407,10 +418,10 @@ class ConfigManager:
                     {"thrift_http": {"endpoint": f"0.0.0.0:{Port.jaeger_thrift_http.value}"}}
                 )
             self.config.add_component(
-                component=Component.receiver,
-                name="jaeger",
-                config=jaeger_config,
-                pipelines=["traces"],
+                Component.receiver,
+                f"jaeger/receive-traces/{self._unit_name}",
+                jaeger_config,
+                pipelines=[f"traces/{self._unit_name}"],
             )
 
     def add_traces_processing(
@@ -436,14 +447,14 @@ class ConfigManager:
             traces are distinguished by the 'service.name' attribute.
         """
         self.config.add_component(
-            component=Component.processor,
-            name="tail_sampling",
-            config=tail_sampling_config(
+            Component.processor,
+            "tail_sampling",
+            tail_sampling_config(
                 tracing_sampling_rate_charm=sampling_rate_charm,
                 tracing_sampling_rate_workload=sampling_rate_workload,
                 tracing_sampling_rate_error=sampling_rate_error,
             ),
-            pipelines=["traces"],
+            pipelines=[f"traces/{self._unit_name}"],
         )
 
     def add_traces_forwarding(self, endpoint: str) -> None:
@@ -459,13 +470,13 @@ class ConfigManager:
             Tempo charm. The exporter will be added to the 'traces' pipeline.
         """
         self.config.add_component(
-            component=Component.exporter,
-            name="otlphttp/tempo",
-            config={
+            Component.exporter,
+            "otlphttp/send-traces",
+            {
                 "endpoint": endpoint,
                 **self.sending_queue_config,
             },
-            pipelines=["traces"],
+            pipelines=[f"traces/{self._unit_name}"],
         )
 
     def add_cloud_integrator(
@@ -505,19 +516,19 @@ class ConfigManager:
         if prometheus_url:
             self.config.add_component(
                 Component.exporter,
-                "prometheusremotewrite/cloud-integrator",
+                "prometheusremotewrite/cloud-config",
                 {
                     "endpoint": prometheus_url,
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
                     **exporter_auth_config,
                     **self.prometheus_remotewrite_wal_config,
                 },
-                pipelines=["metrics"],
+                pipelines=[f"metrics/{self._unit_name}"],
             )
         if loki_url:
             self.config.add_component(
                 Component.exporter,
-                "loki/cloud-integrator",
+                "loki/cloud-config",
                 {
                     "endpoint": loki_url,
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
@@ -526,19 +537,19 @@ class ConfigManager:
                     **exporter_auth_config,
                     **self.sending_queue_config,
                 },
-                pipelines=["logs"],
+                pipelines=[f"logs/{self._unit_name}"],
             )
         if tempo_url:
             self.config.add_component(
-                component=Component.exporter,
-                name="otlphttp/cloud-integrator",
-                config={
+                Component.exporter,
+                "otlphttp/cloud-config",
+                {
                     "endpoint": tempo_url,
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
                     **exporter_auth_config,
                     **self.sending_queue_config,
                 },
-                pipelines=["traces"],
+                pipelines=[f"traces/{self._unit_name}"],
             )
 
     def add_custom_processors(self, processors_raw: str) -> None:
@@ -549,8 +560,12 @@ class ConfigManager:
         """
         for processor_name, processor_config in yaml.safe_load(processors_raw).items():
             self.config.add_component(
-                component=Component.processor,
-                name=processor_name,
-                config=processor_config,
-                pipelines=["metrics", "logs", "traces"],
+                Component.processor,
+                f"{processor_name}/{self._unit_name}/_custom",
+                processor_config,
+                pipelines=[
+                    f"metrics/{self._unit_name}",
+                    f"logs/{self._unit_name}",
+                    f"traces/{self._unit_name}",
+                ],
             )

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -17,7 +17,7 @@ import jubilant
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
 
 
-@retry(stop=stop_after_attempt(10), wait=wait_fixed(5))
+@retry(stop=stop_after_attempt(10), wait=wait_fixed(10))
 async def _retry_prom_alerts_api(endpoint: str):
     response = request("GET", endpoint).text
     data = json.loads(response)["data"]
@@ -25,14 +25,14 @@ async def _retry_prom_alerts_api(endpoint: str):
     assert any("avalanche-k8s" in item for item in charm_names)
 
 
-@retry(stop=stop_after_attempt(10), wait=wait_fixed(5))
+@retry(stop=stop_after_attempt(10), wait=wait_fixed(10))
 async def _retry_prom_jobs_api(endpoint: str):
     job_names = json.loads(request("GET", endpoint).text)["data"]
     assert any("avalanche" in item for item in job_names)
     assert any("otelcol" in item for item in job_names)
 
 
-@retry(stop=stop_after_attempt(10), wait=wait_fixed(5))
+@retry(stop=stop_after_attempt(10), wait=wait_fixed(10))
 async def _retry_avalanche_metrics_arrive_prom(prom_ip: str):
     params = {"query": 'count({__name__=~"avalanche_metric_.+"})'}
     data = json.loads(request("GET", f"http://{prom_ip}:9090/api/v1/query", params=params).text)[

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -4,9 +4,6 @@
 """Feature: Scraped metrics are remote-written."""
 
 import pathlib
-import tempfile
-import textwrap
-import sh
 import json
 from typing import Dict
 from tenacity import retry, stop_after_attempt, wait_fixed

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -36,7 +36,7 @@ async def _retry_prom_jobs_api(endpoint: str):
 
 
 @retry(stop=stop_after_attempt(7), wait=wait_fixed(5))
-async def _retry_avalanche_metrics_arrive_proom(prom_ip: str):
+async def _retry_avalanche_metrics_arrive_prom(prom_ip: str):
     params = {"query": 'count({__name__=~"avalanche_metric_.+"})'}
     data = json.loads(request("GET", f"http://{prom_ip}:9090/api/v1/query", params=params).text)[
         "data"
@@ -91,4 +91,4 @@ async def test_metrics_pipeline(juju: jubilant.Juju, charm: str, charm_resources
     # AND juju_application labels in prometheus contain otel-collector and avalanche
     await _retry_prom_jobs_api(f"http://{prom_ip}:9090/api/v1/label/juju_application/values")
     # AND avalanche metrics arrive in prometheus
-    await _retry_avalanche_metrics_arrive_proom(prom_ip)
+    await _retry_avalanche_metrics_arrive_prom(prom_ip)

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -13,7 +13,7 @@ import pytest
 import jubilant
 
 
-@retry(stop=stop_after_attempt(15), wait=wait_fixed(10))
+@retry(stop=stop_after_attempt(24), wait=wait_fixed(10))
 async def check_traces_from_app(tempo_ip: str, app: str):
     response = request(
         "GET", f"http://{tempo_ip}:3200/api/search", params={"juju_application": app}

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -25,7 +25,7 @@ def test_add_pipeline_component(pipelines, component):
     https://opentelemetry.io/docs/collector/configuration/#basics
     """
     # GIVEN an empty config
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     # WHEN adding a pipeline component with a nested config
     sample_config = {"a": {"b": "c"}}
     config.add_component(
@@ -56,7 +56,7 @@ def test_add_to_pipeline(pipelines, component):
     https://opentelemetry.io/docs/collector/configuration/#basics
     """
     # GIVEN an empty config
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     # WHEN adding a pipeline component
     config._add_to_pipeline("foo", component, pipelines)
     # THEN the pipeline component is added to the pipeline config
@@ -68,7 +68,7 @@ def test_add_to_pipeline(pipelines, component):
 
 def test_add_extension():
     # GIVEN an empty config
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     # WHEN adding a pipeline with a config
     sample_config = {"a": {"b": "c"}}
     config.add_extension("foo", sample_config)
@@ -80,7 +80,7 @@ def test_add_extension():
 
 def test_add_telemetry():
     # GIVEN an empty config
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     # WHEN adding a pipeline with a config
     sample_config = [{"a": {"b": "c"}}]
     config.add_telemetry("logs", {"level": "INFO"})
@@ -96,7 +96,7 @@ def test_add_telemetry():
 def test_rendered_default_is_valid():
     # GIVEN a default config
     # WHEN the config is rendered
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config.add_default_config()
     config_yaml = yaml.safe_load(config.build())
     # THEN a debug exporter is added for each pipeline missing one
@@ -110,16 +110,21 @@ def test_rendered_default_is_valid():
 
 def test_receivers_tls_empty_config():
     # GIVEN an "empty" config
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     # WHEN tls is enabled
     config._add_tls_to_all_receivers("/some/cert.crt", "/some/private.key")
     # THEN it has no effect on the rendered config
-    assert config.build() == ConfigBuilder("", "").build()
+    assert (
+        config.build()
+        == ConfigBuilder(
+            unit_name="fake/0", global_scrape_interval="", global_scrape_timeout=""
+        ).build()
+    )
 
 
 def test_receivers_tls_no_protocols():
     # GIVEN a config without any protocols
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config.add_component(
         Component.receiver, "prometheus", {"config": {"foo": "bar"}}, pipelines=["metrics"]
     )
@@ -138,7 +143,7 @@ def test_receivers_tls_no_protocols():
 
 def test_receivers_tls_unknown_protocols():
     # GIVEN a config with an unknown protocols
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config.add_component(
         Component.receiver,
         "some_receiver",
@@ -156,7 +161,7 @@ def test_receivers_tls_unknown_protocols():
 
 def test_receivers_tls_known_protocols():
     # GIVEN a config with known protocols (http, grpc)
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config.add_component(
         Component.receiver,
         "some-http-receiver",
@@ -224,7 +229,7 @@ def test_receivers_tls_known_protocols():
 
 def test_insecure_skip_verify():
     # GIVEN an empty config without exporters
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config_copy = deepcopy(config)
     # WHEN updating the tls::insecure_skip_verify exporter configuration
     config._add_exporter_insecure_skip_verify(False)
@@ -250,7 +255,7 @@ def test_insecure_skip_verify():
 
 def test_debug_exporter_no_tls_config():
     # GIVEN an empty config without exporters
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     # WHEN multiple debug exporters are added
     config.add_component(Component.exporter, "debug", {"config": {"foo": "bar"}})
     config.add_component(Component.exporter, "debug/descriptor", {"config": {"foo": "bar"}})
@@ -262,7 +267,7 @@ def test_debug_exporter_no_tls_config():
 
 def test_global_scrape_timeout_and_interval():
     # GIVEN a config with multiple prometheus receivers
-    config = ConfigBuilder("", "")
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config.add_component(Component.receiver, name="prometheus", config={"config": {}})
     config.add_component(
         Component.receiver, name="prometheus/empty-cfgs", config={"config": {"scrape_configs": []}}

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -10,7 +10,7 @@ def test_add_prometheus_scrape():
     # GIVEN an empty config
     config_manager = ConfigManager(
         unit_name="fake/0",
-        global_scrape_interval="",
+        global_scrape_interval="15s",
         global_scrape_timeout="",
         insecure_skip_verify=True,
     )
@@ -41,7 +41,10 @@ def test_add_prometheus_scrape():
     config_manager.add_prometheus_scrape_jobs(first_job)
     # THEN it exists in the prometheus receiver config
     # AND insecure_skip_verify is injected into the config
-    assert config_manager.config._config["receivers"]["prometheus"] == expected_prom_recv_cfg
+    assert (
+        config_manager.config._config["receivers"]["prometheus/metrics-endpoint/fake/0"]
+        == expected_prom_recv_cfg
+    )
 
     # AND WHEN more scrape jobs are added to the config
     more_jobs = [
@@ -55,14 +58,14 @@ def test_add_prometheus_scrape():
         },
     ]
     config_manager.add_prometheus_scrape_jobs(more_jobs)
-    # THEN the original scrape job wasn't overwritten and the newly added scrape jobs were added
+    # THEN the original scrape job was overwritten and the newly added scrape jobs were added
     job_names = [
         job["job_name"]
-        for job in config_manager.config._config["receivers"]["prometheus"]["config"][
-            "scrape_configs"
-        ]
+        for job in config_manager.config._config["receivers"][
+            "prometheus/metrics-endpoint/fake/0"
+        ]["config"]["scrape_configs"]
     ]
-    assert job_names == ["first_job", "second_job", "third_job"]
+    assert job_names == ["second_job", "third_job"]
 
 
 def test_add_log_forwarding():

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -8,7 +8,12 @@ from config_manager import ConfigManager
 
 def test_add_prometheus_scrape():
     # GIVEN an empty config
-    config_manager = ConfigManager("", "", insecure_skip_verify=True)
+    config_manager = ConfigManager(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        insecure_skip_verify=True,
+    )
 
     # WHEN a scrape job is added to the config
     first_job = [
@@ -62,7 +67,12 @@ def test_add_prometheus_scrape():
 
 def test_add_log_forwarding():
     # GIVEN an empty config
-    config_manager = ConfigManager("", "", insecure_skip_verify=True)
+    config_manager = ConfigManager(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        insecure_skip_verify=True,
+    )
 
     # WHEN a loki exporter is added to the config
     expected_loki_forwarding_cfg = {
@@ -84,14 +94,21 @@ def test_add_log_forwarding():
         insecure_skip_verify=False,
     )
     # THEN it exists in the loki exporter config
-    config = dict(sorted(config_manager.config._config["exporters"]["loki/0"].items()))
+    config = dict(
+        sorted(config_manager.config._config["exporters"]["loki/send-loki-logs/0"].items())
+    )
     expected_config = dict(sorted(expected_loki_forwarding_cfg.items()))
     assert config == expected_config
 
 
 def test_add_traces_forwarding():
     # GIVEN an empty config
-    config_manager = ConfigManager("", "", insecure_skip_verify=True)
+    config_manager = ConfigManager(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        insecure_skip_verify=True,
+    )
 
     # WHEN a traces exporter is added to the config
     expected_traces_forwarding_cfg = {
@@ -105,14 +122,21 @@ def test_add_traces_forwarding():
         endpoint="http://192.168.1.244:4318",
     )
     # THEN it exists in the traces exporter config
-    config = dict(sorted(config_manager.config._config["exporters"]["otlphttp/tempo"].items()))
+    config = dict(
+        sorted(config_manager.config._config["exporters"]["otlphttp/send-traces"].items())
+    )
     expected_config = dict(sorted(expected_traces_forwarding_cfg.items()))
     assert config == expected_config
 
 
 def test_add_remote_write():
     # GIVEN an empty config
-    config_manager = ConfigManager("", "", insecure_skip_verify=True)
+    config_manager = ConfigManager(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        insecure_skip_verify=True,
+    )
 
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {
@@ -126,7 +150,11 @@ def test_add_remote_write():
     )
     # THEN it exists in the remote write exporter config
     config = dict(
-        sorted(config_manager.config._config["exporters"]["prometheusremotewrite/0"].items())
+        sorted(
+            config_manager.config._config["exporters"][
+                "prometheusremotewrite/send-remote-write/0"
+            ].items()
+        )
     )
     expected_config = dict(sorted(expected_remote_write_cfg.items()))
     assert config == expected_config

--- a/tests/unit/test_profiling_integration.py
+++ b/tests/unit/test_profiling_integration.py
@@ -14,11 +14,15 @@ from tests.unit.helpers import get_otelcol_file
 
 @pytest.fixture
 def tls_mock(cert_obj, private_key):
-    with patch.object(
-        TLSCertificatesRequiresV4, "_find_available_certificates", return_value=None
-    ), patch.object(
-        TLSCertificatesRequiresV4, "get_assigned_certificate", return_value=(cert_obj, private_key)
-    ), patch.object(Certificate, "from_string", return_value=cert_obj):
+    with (
+        patch.object(TLSCertificatesRequiresV4, "_find_available_certificates", return_value=None),
+        patch.object(
+            TLSCertificatesRequiresV4,
+            "get_assigned_certificate",
+            return_value=(cert_obj, private_key),
+        ),
+        patch.object(Certificate, "from_string", return_value=cert_obj),
+    ):
         yield
 
 
@@ -30,9 +34,15 @@ def test_waiting_for_send_profiles_endpoint(ctx, execs, relation_joined):
 
     # WHEN a send_profiles relation joins but pyroscope didn't reply with an endpoint yet,
     # or the relation didn't join yet at all
-    relations = {Relation(
-        endpoint="send-profiles",
-    )} if relation_joined else {}
+    relations = (
+        {
+            Relation(
+                endpoint="send-profiles",
+            )
+        }
+        if relation_joined
+        else {}
+    )
 
     state_in = State(relations=relations, containers=[container])
     state_out = ctx.run(ctx.on.update_status(), state=state_in)
@@ -40,7 +50,10 @@ def test_waiting_for_send_profiles_endpoint(ctx, execs, relation_joined):
     # THEN the pebble layer command and check contain no feature gate
     plan_out = state_out.get_container("otelcol").plan
     assert plan_out.services[SERVICE_NAME].command == f"/usr/bin/otelcol --config={CONFIG_PATH}"
-    assert plan_out.checks["valid-config"].exec['command'] == f"otelcol validate --config={CONFIG_PATH}"
+    assert (
+        plan_out.checks["valid-config"].exec["command"]
+        == f"otelcol validate --config={CONFIG_PATH}"
+    )
 
 
 @pytest.mark.parametrize("relation_joined", (True, False))
@@ -50,15 +63,26 @@ def test_waiting_for_receive_profiles_endpoint(ctx, execs, relation_joined):
     container = Container(name="otelcol", can_connect=True, execs=execs)
 
     # WHEN a receive_profiles relation joins
-    state_in = State(relations={Relation(
-        endpoint="receive-profiles",
-    )}, containers=[container])
+    state_in = State(
+        relations={
+            Relation(
+                endpoint="receive-profiles",
+            )
+        },
+        containers=[container],
+    )
     state_out = ctx.run(ctx.on.update_status(), state=state_in)
 
     # THEN the pebble layer command and check contain the feature gate
     plan_out = state_out.get_container("otelcol").plan
-    assert plan_out.services[SERVICE_NAME].command == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
-    assert plan_out.checks["valid-config"].exec['command'] == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    assert (
+        plan_out.services[SERVICE_NAME].command
+        == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    )
+    assert (
+        plan_out.checks["valid-config"].exec["command"]
+        == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    )
 
 
 @pytest.mark.parametrize("insecure_skip_verify", (True, False))
@@ -75,23 +99,35 @@ def test_send_profiles_integration(ctx, execs, insecure_skip_verify, remote_inse
         remote_app_data={
             "otlp_grpc_endpoint_url": json.dumps(pyro_url),
             "insecure": json.dumps(remote_insecure),
-        }
+        },
     )
-    state_in = State(relations=[send_profiles], containers=[container],
-                     config={"tls_insecure_skip_verify": insecure_skip_verify})
+    state_in = State(
+        relations=[send_profiles],
+        containers=[container],
+        config={"tls_insecure_skip_verify": insecure_skip_verify},
+    )
     state_out = ctx.run(ctx.on.update_status(), state=state_in)
 
     # THEN the pebble layer command and check contain the profilesSupport feature gate
     plan_out = state_out.get_container("otelcol").plan
-    assert plan_out.services[SERVICE_NAME].command == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
-    assert plan_out.checks["valid-config"].exec['command'] == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    assert (
+        plan_out.services[SERVICE_NAME].command
+        == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    )
+    assert (
+        plan_out.checks["valid-config"].exec["command"]
+        == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    )
 
     # AND the profiling pipeline contains an exporter to the expected url
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
-    assert cfg['service']['pipelines']['profiles']['exporters'][0] == 'otlp/profiling/0'
-    assert cfg['service']['pipelines']['profiles']['receivers'][0] == "otlp"
-    assert cfg['exporters']['otlp/profiling/0']['endpoint'] == pyro_url
-    assert cfg["exporters"]["otlp/profiling/0"]["tls"] == {"insecure": remote_insecure, "insecure_skip_verify": insecure_skip_verify}
+    assert cfg["service"]["pipelines"]["profiles"]["exporters"][0] == "otlp/profiling/0"
+    assert cfg["service"]["pipelines"]["profiles"]["receivers"][0] == "otlp"
+    assert cfg["exporters"]["otlp/profiling/0"]["endpoint"] == pyro_url
+    assert cfg["exporters"]["otlp/profiling/0"]["tls"] == {
+        "insecure": remote_insecure,
+        "insecure_skip_verify": insecure_skip_verify,
+    }
 
 
 @patch("socket.getfqdn", return_value="localhost")
@@ -102,26 +138,35 @@ def test_receive_profiles_integration(sock_mock, ctx, execs, insecure_skip_verif
     container = Container(name="otelcol", can_connect=True, execs=execs)
 
     # WHEN a receive-profiles relation joins and pyroscope sent an endpoint
-    receive_profiles = Relation(
-        endpoint="receive-profiles"
+    receive_profiles = Relation(endpoint="receive-profiles")
+    state_in = State(
+        relations=[receive_profiles],
+        containers=[container],
+        config={"tls_insecure_skip_verify": insecure_skip_verify},
+        leader=True,
     )
-    state_in = State(relations=[receive_profiles], containers=[container],
-                     config={"tls_insecure_skip_verify": insecure_skip_verify},
-                     leader=True)
     state_out = ctx.run(ctx.on.update_status(), state=state_in)
 
     # THEN the pebble layer command and check contain the profilesSupport feature gate
     plan_out = state_out.get_container("otelcol").plan
-    assert plan_out.services[SERVICE_NAME].command == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
-    assert plan_out.checks["valid-config"].exec['command'] == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    assert (
+        plan_out.services[SERVICE_NAME].command
+        == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    )
+    assert (
+        plan_out.checks["valid-config"].exec["command"]
+        == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    )
 
     # AND the profiling pipeline contains a profiling pipeline, but no exporters other than debug
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
-    assert cfg['service']['pipelines']['profiles']['exporters'] == ['debug']
+    assert cfg["service"]["pipelines"]["profiles"]["exporters"] == [
+        "debug/opentelemetry-collector-k8s/0"
+    ]
 
     # AND we publish to app databag our profile ingestion endpoints for otlp_grpc
     receive_profiles_app_data = state_out.get_relation(receive_profiles.id).local_app_data
-    assert  receive_profiles_app_data['otlp_grpc_endpoint_url']
+    assert receive_profiles_app_data["otlp_grpc_endpoint_url"]
 
 
 @pytest.mark.parametrize("insecure_skip_verify", (True, False))
@@ -141,21 +186,31 @@ def test_profiling_integration_tls(ctx, execs, insecure_skip_verify, tls_mock):
         endpoint="send-profiles",
         remote_app_data={
             "otlp_grpc_endpoint_url": json.dumps(pyro_url),
-        }
+        },
     )
-    state_in = State(relations=[profiling, ssc], containers=[container],
-                     config={"tls_insecure_skip_verify": insecure_skip_verify})
+    state_in = State(
+        relations=[profiling, ssc],
+        containers=[container],
+        config={"tls_insecure_skip_verify": insecure_skip_verify},
+    )
     state_out = ctx.run(ctx.on.update_status(), state=state_in)
 
     # THEN the pebble layer command and check contain the profilesSupport feature gate
     plan_out = state_out.get_container("otelcol").plan
-    assert plan_out.services[SERVICE_NAME].command == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
-    assert plan_out.checks["valid-config"].exec['command'] == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    assert (
+        plan_out.services[SERVICE_NAME].command
+        == f"/usr/bin/otelcol --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    )
+    assert (
+        plan_out.checks["valid-config"].exec["command"]
+        == f"otelcol validate --config={CONFIG_PATH} --feature-gates=service.profilesSupport"
+    )
 
     # AND the profiling pipeline contains an exporter to the expected url
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
-    assert cfg['service']['pipelines']['profiles']['exporters'][0] == 'otlp/profiling/0'
-    assert cfg['exporters']['otlp/profiling/0']['endpoint'] == pyro_url
-    assert cfg["exporters"]["otlp/profiling/0"]["tls"] == {"insecure": False, "insecure_skip_verify": insecure_skip_verify}
-
-
+    assert cfg["service"]["pipelines"]["profiles"]["exporters"][0] == "otlp/profiling/0"
+    assert cfg["exporters"]["otlp/profiling/0"]["endpoint"] == pyro_url
+    assert cfg["exporters"]["otlp/profiling/0"]["tls"] == {
+        "insecure": False,
+        "insecure_skip_verify": insecure_skip_verify,
+    }

--- a/tests/unit/test_relational_config.py
+++ b/tests/unit/test_relational_config.py
@@ -49,8 +49,8 @@ def test_loki_exporter(ctx, execs):
     # THEN the config file exists and the pebble service is running
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
     # AND one exporter per loki unit in relation exists in the config
-    prom_exporters = [f"loki/{idx}" for idx in range(len(remote_units_data))]
-    assert set(prom_exporters).issubset(set(cfg["exporters"].keys()))
+    loki_exporters = [f"loki/send-loki-logs/{idx}" for idx in range(len(remote_units_data))]
+    assert set(loki_exporters).issubset(set(cfg["exporters"].keys()))
     # AND the pipelines are valid
     check_valid_pipelines(cfg)
 
@@ -77,7 +77,9 @@ def test_prometheus_exporter(ctx, execs):
     # THEN the config file exists and the pebble service is running
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
     # AND one exporter per prometheus unit in relation exists in the config
-    prom_exporters = [f"prometheusremotewrite/{idx}" for idx in range(len(remote_units_data))]
+    prom_exporters = [
+        f"prometheusremotewrite/send-remote-write/{idx}" for idx in range(len(remote_units_data))
+    ]
     assert set(prom_exporters).issubset(set(cfg["exporters"].keys()))
     # AND the pipelines are valid
     check_valid_pipelines(cfg)
@@ -107,17 +109,17 @@ def test_cloud_integrator(ctx, execs):
     # THEN the config file exists and the pebble service is running
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
     # AND the exporters for the cloud-integrator exists in the config
-    expected_exporters = {"loki/cloud-integrator", "prometheusremotewrite/cloud-integrator"}
+    expected_exporters = {"loki/cloud-config", "prometheusremotewrite/cloud-config"}
     assert expected_exporters.issubset(set(cfg["exporters"].keys()))
     # AND the basicauth extension is configured
     assert "basicauth/cloud-integrator" in cfg["extensions"]
     # AND the exporters are using the basicauth configuration
     assert (
-        cfg["exporters"]["loki/cloud-integrator"]["auth"]["authenticator"]
+        cfg["exporters"]["loki/cloud-config"]["auth"]["authenticator"]
         == "basicauth/cloud-integrator"
     )
     assert (
-        cfg["exporters"]["prometheusremotewrite/cloud-integrator"]["auth"]["authenticator"]
+        cfg["exporters"]["prometheusremotewrite/cloud-config"]["auth"]["authenticator"]
         == "basicauth/cloud-integrator"
     )
     # AND the pipelines are valid
@@ -162,7 +164,7 @@ def test_traces_receivers(ctx, execs):
     # THEN the config file exists and the pebble service is running
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
     # AND the receivers for tracing exists in the config
-    expected_receivers = {"otlp", "jaeger"}
+    expected_receivers = {"otlp", "jaeger/receive-traces/opentelemetry-collector-k8s/0"}
     assert expected_receivers.issubset(set(cfg["receivers"].keys()))
     # AND the pipelines are valid
     check_valid_pipelines(cfg)
@@ -206,7 +208,7 @@ def test_traces_exporters(ctx, execs):
     # THEN the config file exists and the pebble service is running
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
     # AND the exporters for tracing exists in the config
-    expected_exporters = {"otlphttp/tempo"}
+    expected_exporters = {"otlphttp/send-traces"}
     assert expected_exporters.issubset(set(cfg["exporters"].keys()))
     # AND the pipelines are valid
     check_valid_pipelines(cfg)

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
@@ -204,64 +204,64 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/13/ca147298721702679f2a286022184fd12b9d5236124308bf363e7184e5b5/cosl-1.0.0.tar.gz", hash = "sha256:5cef884faac1313ae6d234fcd6f40db0cbdd44bcdacfd9a6e9ecf9cede219359", size = 40818, upload-time = "2025-05-22T13:26:16.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/c5/7e2ce9f3b0579784ca6dd0ce7eb11d171c445e086fa9d0fe7b4c944d0774/cosl-1.1.0.tar.gz", hash = "sha256:7a04e32c95cdc2d556bb43517eaadf6fc177bc8449bd9359989a24056b34c9aa", size = 44268, upload-time = "2025-08-18T08:54:09.62Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/58/e80bd8436e2a6bb80b62b0317711d48ef1cab4b38e0e9f1efe73d13c0187/cosl-1.0.0-py3-none-any.whl", hash = "sha256:4ed54e818a5614a5164011253c12441cd0bffacfd99c8bd6b5b9740a397e482d", size = 33525, upload-time = "2025-05-22T13:26:14.804Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ff/8f1415de3877b6b6f1a71345506e4daab7555a357a7ee27122ce6d167714/cosl-1.1.0-py3-none-any.whl", hash = "sha256:e5313e6753db057b32fd41a493735b9eb152d38d1e2f688e54ef0b974ba99934", size = 35373, upload-time = "2025-08-18T08:54:08.712Z" },
 ]
 
 [[package]]
 name = "coverage"
-version = "7.10.3"
+version = "7.10.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/2c/253cc41cd0f40b84c1c34c5363e0407d73d4a1cae005fed6db3b823175bd/coverage-7.10.3.tar.gz", hash = "sha256:812ba9250532e4a823b070b0420a36499859542335af3dca8f47fc6aa1a05619", size = 822936, upload-time = "2025-08-10T21:27:39.968Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/70/025b179c993f019105b79575ac6edb5e084fb0f0e63f15cdebef4e454fb5/coverage-7.10.6.tar.gz", hash = "sha256:f644a3ae5933a552a29dbb9aa2f90c677a875f80ebea028e5a52a4f429044b90", size = 823736, upload-time = "2025-08-29T15:35:16.668Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/62/13c0b66e966c43d7aa64dadc8cd2afa1f5a2bf9bb863bdabc21fb94e8b63/coverage-7.10.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:449c1e2d3a84d18bd204258a897a87bc57380072eb2aded6a5b5226046207b42", size = 216262, upload-time = "2025-08-10T21:25:55.367Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/f0/59fdf79be7ac2f0206fc739032f482cfd3f66b18f5248108ff192741beae/coverage-7.10.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1d4f9ce50b9261ad196dc2b2e9f1fbbee21651b54c3097a25ad783679fd18294", size = 216496, upload-time = "2025-08-10T21:25:56.759Z" },
-    { url = "https://files.pythonhosted.org/packages/34/b1/bc83788ba31bde6a0c02eb96bbc14b2d1eb083ee073beda18753fa2c4c66/coverage-7.10.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4dd4564207b160d0d45c36a10bc0a3d12563028e8b48cd6459ea322302a156d7", size = 247989, upload-time = "2025-08-10T21:25:58.067Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/29/f8bdf88357956c844bd872e87cb16748a37234f7f48c721dc7e981145eb7/coverage-7.10.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ca3c9530ee072b7cb6a6ea7b640bcdff0ad3b334ae9687e521e59f79b1d0437", size = 250738, upload-time = "2025-08-10T21:25:59.406Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/df/6396301d332b71e42bbe624670af9376f63f73a455cc24723656afa95796/coverage-7.10.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b6df359e59fa243c9925ae6507e27f29c46698359f45e568fd51b9315dbbe587", size = 251868, upload-time = "2025-08-10T21:26:00.65Z" },
-    { url = "https://files.pythonhosted.org/packages/91/21/d760b2df6139b6ef62c9cc03afb9bcdf7d6e36ed4d078baacffa618b4c1c/coverage-7.10.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a181e4c2c896c2ff64c6312db3bda38e9ade2e1aa67f86a5628ae85873786cea", size = 249790, upload-time = "2025-08-10T21:26:02.009Z" },
-    { url = "https://files.pythonhosted.org/packages/69/91/5dcaa134568202397fa4023d7066d4318dc852b53b428052cd914faa05e1/coverage-7.10.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a374d4e923814e8b72b205ef6b3d3a647bb50e66f3558582eda074c976923613", size = 247907, upload-time = "2025-08-10T21:26:03.757Z" },
-    { url = "https://files.pythonhosted.org/packages/38/ed/70c0e871cdfef75f27faceada461206c1cc2510c151e1ef8d60a6fedda39/coverage-7.10.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:daeefff05993e5e8c6e7499a8508e7bd94502b6b9a9159c84fd1fe6bce3151cb", size = 249344, upload-time = "2025-08-10T21:26:05.11Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/55/c8a273ed503cedc07f8a00dcd843daf28e849f0972e4c6be4c027f418ad6/coverage-7.10.3-cp312-cp312-win32.whl", hash = "sha256:187ecdcac21f9636d570e419773df7bd2fda2e7fa040f812e7f95d0bddf5f79a", size = 218693, upload-time = "2025-08-10T21:26:06.534Z" },
-    { url = "https://files.pythonhosted.org/packages/94/58/dd3cfb2473b85be0b6eb8c5b6d80b6fc3f8f23611e69ef745cef8cf8bad5/coverage-7.10.3-cp312-cp312-win_amd64.whl", hash = "sha256:4a50ad2524ee7e4c2a95e60d2b0b83283bdfc745fe82359d567e4f15d3823eb5", size = 219501, upload-time = "2025-08-10T21:26:08.195Z" },
-    { url = "https://files.pythonhosted.org/packages/56/af/7cbcbf23d46de6f24246e3f76b30df099d05636b30c53c158a196f7da3ad/coverage-7.10.3-cp312-cp312-win_arm64.whl", hash = "sha256:c112f04e075d3495fa3ed2200f71317da99608cbb2e9345bdb6de8819fc30571", size = 218135, upload-time = "2025-08-10T21:26:09.584Z" },
-    { url = "https://files.pythonhosted.org/packages/84/19/e67f4ae24e232c7f713337f3f4f7c9c58afd0c02866fb07c7b9255a19ed7/coverage-7.10.3-py3-none-any.whl", hash = "sha256:416a8d74dc0adfd33944ba2f405897bab87b7e9e84a391e09d241956bd953ce1", size = 207921, upload-time = "2025-08-10T21:27:38.254Z" },
+    { url = "https://files.pythonhosted.org/packages/26/06/263f3305c97ad78aab066d116b52250dd316e74fcc20c197b61e07eb391a/coverage-7.10.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5b2dd6059938063a2c9fee1af729d4f2af28fd1a545e9b7652861f0d752ebcea", size = 217324, upload-time = "2025-08-29T15:33:29.06Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/60/1e1ded9a4fe80d843d7d53b3e395c1db3ff32d6c301e501f393b2e6c1c1f/coverage-7.10.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:388d80e56191bf846c485c14ae2bc8898aa3124d9d35903fef7d907780477634", size = 217560, upload-time = "2025-08-29T15:33:30.748Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/52136173c14e26dfed8b106ed725811bb53c30b896d04d28d74cb64318b3/coverage-7.10.6-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:90cb5b1a4670662719591aa92d0095bb41714970c0b065b02a2610172dbf0af6", size = 249053, upload-time = "2025-08-29T15:33:32.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1d/ae25a7dc58fcce8b172d42ffe5313fc267afe61c97fa872b80ee72d9515a/coverage-7.10.6-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:961834e2f2b863a0e14260a9a273aff07ff7818ab6e66d2addf5628590c628f9", size = 251802, upload-time = "2025-08-29T15:33:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7a/1f561d47743710fe996957ed7c124b421320f150f1d38523d8d9102d3e2a/coverage-7.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf9a19f5012dab774628491659646335b1928cfc931bf8d97b0d5918dd58033c", size = 252935, upload-time = "2025-08-29T15:33:34.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ad/8b97cd5d28aecdfde792dcbf646bac141167a5cacae2cd775998b45fabb5/coverage-7.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99c4283e2a0e147b9c9cc6bc9c96124de9419d6044837e9799763a0e29a7321a", size = 250855, upload-time = "2025-08-29T15:33:36.922Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6a/95c32b558d9a61858ff9d79580d3877df3eb5bc9eed0941b1f187c89e143/coverage-7.10.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:282b1b20f45df57cc508c1e033403f02283adfb67d4c9c35a90281d81e5c52c5", size = 248974, upload-time = "2025-08-29T15:33:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/8ce95dee640a38e760d5b747c10913e7a06554704d60b41e73fdea6a1ffd/coverage-7.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8cdbe264f11afd69841bd8c0d83ca10b5b32853263ee62e6ac6a0ab63895f972", size = 250409, upload-time = "2025-08-29T15:33:39.447Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/7a55b0bdde78a98e2eb2356771fd2dcddb96579e8342bb52aa5bc52e96f0/coverage-7.10.6-cp312-cp312-win32.whl", hash = "sha256:a517feaf3a0a3eca1ee985d8373135cfdedfbba3882a5eab4362bda7c7cf518d", size = 219724, upload-time = "2025-08-29T15:33:41.172Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/32b185b8b8e327802c9efce3d3108d2fe2d9d31f153a0f7ecfd59c773705/coverage-7.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:856986eadf41f52b214176d894a7de05331117f6035a28ac0016c0f63d887629", size = 220536, upload-time = "2025-08-29T15:33:42.524Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3a/d5d8dc703e4998038c3099eaf77adddb00536a3cec08c8dcd556a36a3eb4/coverage-7.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:acf36b8268785aad739443fa2780c16260ee3fa09d12b3a70f772ef100939d80", size = 219171, upload-time = "2025-08-29T15:33:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/50db5379b615854b5cf89146f8f5bd1d5a9693d7f3a987e269693521c404/coverage-7.10.6-py3-none-any.whl", hash = "sha256:92c4ecf6bf11b2e85fd4d8204814dc26e6a19f0c9d938c207c5cb0eadfcabbe3", size = 208986, upload-time = "2025-08-29T15:35:14.506Z" },
 ]
 
 [[package]]
 name = "cryptography"
-version = "45.0.6"
+version = "45.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/0d/d13399c94234ee8f3df384819dc67e0c5ce215fb751d567a55a1f4b028c7/cryptography-45.0.6.tar.gz", hash = "sha256:5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719", size = 744949, upload-time = "2025-08-05T23:59:27.93Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", size = 744980, upload-time = "2025-09-01T11:15:03.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/29/2793d178d0eda1ca4a09a7c4e09a5185e75738cc6d526433e8663b460ea6/cryptography-45.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:048e7ad9e08cf4c0ab07ff7f36cc3115924e22e2266e034450a890d9e312dd74", size = 7042702, upload-time = "2025-08-05T23:58:23.464Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/b6/cabd07410f222f32c8d55486c464f432808abaa1f12af9afcbe8f2f19030/cryptography-45.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44647c5d796f5fc042bbc6d61307d04bf29bccb74d188f18051b635f20a9c75f", size = 4206483, upload-time = "2025-08-05T23:58:27.132Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/f9c7d36a38b1cfeb1cc74849aabe9bf817990f7603ff6eb485e0d70e0b27/cryptography-45.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e40b80ecf35ec265c452eea0ba94c9587ca763e739b8e559c128d23bff7ebbbf", size = 4429679, upload-time = "2025-08-05T23:58:29.152Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/2a/4434c17eb32ef30b254b9e8b9830cee4e516f08b47fdd291c5b1255b8101/cryptography-45.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:00e8724bdad672d75e6f069b27970883179bd472cd24a63f6e620ca7e41cc0c5", size = 4210553, upload-time = "2025-08-05T23:58:30.596Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/1d/09a5df8e0c4b7970f5d1f3aff1b640df6d4be28a64cae970d56c6cf1c772/cryptography-45.0.6-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7a3085d1b319d35296176af31c90338eeb2ddac8104661df79f80e1d9787b8b2", size = 3894499, upload-time = "2025-08-05T23:58:32.03Z" },
-    { url = "https://files.pythonhosted.org/packages/79/62/120842ab20d9150a9d3a6bdc07fe2870384e82f5266d41c53b08a3a96b34/cryptography-45.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1b7fa6a1c1188c7ee32e47590d16a5a0646270921f8020efc9a511648e1b2e08", size = 4458484, upload-time = "2025-08-05T23:58:33.526Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/80/1bc3634d45ddfed0871bfba52cf8f1ad724761662a0c792b97a951fb1b30/cryptography-45.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:275ba5cc0d9e320cd70f8e7b96d9e59903c815ca579ab96c1e37278d231fc402", size = 4210281, upload-time = "2025-08-05T23:58:35.445Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/fe/ffb12c2d83d0ee625f124880a1f023b5878f79da92e64c37962bbbe35f3f/cryptography-45.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f4028f29a9f38a2025abedb2e409973709c660d44319c61762202206ed577c42", size = 4456890, upload-time = "2025-08-05T23:58:36.923Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/8e/b3f3fe0dc82c77a0deb5f493b23311e09193f2268b77196ec0f7a36e3f3e/cryptography-45.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ee411a1b977f40bd075392c80c10b58025ee5c6b47a822a33c1198598a7a5f05", size = 4333247, upload-time = "2025-08-05T23:58:38.781Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/a6/c3ef2ab9e334da27a1d7b56af4a2417d77e7806b2e0f90d6267ce120d2e4/cryptography-45.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e2a21a8eda2d86bb604934b6b37691585bd095c1f788530c1fcefc53a82b3453", size = 4565045, upload-time = "2025-08-05T23:58:40.415Z" },
-    { url = "https://files.pythonhosted.org/packages/31/c3/77722446b13fa71dddd820a5faab4ce6db49e7e0bf8312ef4192a3f78e2f/cryptography-45.0.6-cp311-abi3-win32.whl", hash = "sha256:d063341378d7ee9c91f9d23b431a3502fc8bfacd54ef0a27baa72a0843b29159", size = 2928923, upload-time = "2025-08-05T23:58:41.919Z" },
-    { url = "https://files.pythonhosted.org/packages/38/63/a025c3225188a811b82932a4dcc8457a26c3729d81578ccecbcce2cb784e/cryptography-45.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:833dc32dfc1e39b7376a87b9a6a4288a10aae234631268486558920029b086ec", size = 3403805, upload-time = "2025-08-05T23:58:43.792Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/af/bcfbea93a30809f126d51c074ee0fac5bd9d57d068edf56c2a73abedbea4/cryptography-45.0.6-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:3436128a60a5e5490603ab2adbabc8763613f638513ffa7d311c900a8349a2a0", size = 7020111, upload-time = "2025-08-05T23:58:45.316Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c6/ea5173689e014f1a8470899cd5beeb358e22bb3cf5a876060f9d1ca78af4/cryptography-45.0.6-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d9ef57b6768d9fa58e92f4947cea96ade1233c0e236db22ba44748ffedca394", size = 4198169, upload-time = "2025-08-05T23:58:47.121Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/73/b12995edc0c7e2311ffb57ebd3b351f6b268fed37d93bfc6f9856e01c473/cryptography-45.0.6-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea3c42f2016a5bbf71825537c2ad753f2870191134933196bee408aac397b3d9", size = 4421273, upload-time = "2025-08-05T23:58:48.557Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/6e/286894f6f71926bc0da67408c853dd9ba953f662dcb70993a59fd499f111/cryptography-45.0.6-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:20ae4906a13716139d6d762ceb3e0e7e110f7955f3bc3876e3a07f5daadec5f3", size = 4199211, upload-time = "2025-08-05T23:58:50.139Z" },
-    { url = "https://files.pythonhosted.org/packages/de/34/a7f55e39b9623c5cb571d77a6a90387fe557908ffc44f6872f26ca8ae270/cryptography-45.0.6-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dac5ec199038b8e131365e2324c03d20e97fe214af051d20c49db129844e8b3", size = 3883732, upload-time = "2025-08-05T23:58:52.253Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/b9/c6d32edbcba0cd9f5df90f29ed46a65c4631c4fbe11187feb9169c6ff506/cryptography-45.0.6-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:18f878a34b90d688982e43f4b700408b478102dd58b3e39de21b5ebf6509c301", size = 4450655, upload-time = "2025-08-05T23:58:53.848Z" },
-    { url = "https://files.pythonhosted.org/packages/77/2d/09b097adfdee0227cfd4c699b3375a842080f065bab9014248933497c3f9/cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5", size = 4198956, upload-time = "2025-08-05T23:58:55.209Z" },
-    { url = "https://files.pythonhosted.org/packages/55/66/061ec6689207d54effdff535bbdf85cc380d32dd5377173085812565cf38/cryptography-45.0.6-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:eccddbd986e43014263eda489abbddfbc287af5cddfd690477993dbb31e31016", size = 4449859, upload-time = "2025-08-05T23:58:56.639Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ff/e7d5a2ad2d035e5a2af116e1a3adb4d8fcd0be92a18032917a089c6e5028/cryptography-45.0.6-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:550ae02148206beb722cfe4ef0933f9352bab26b087af00e48fdfb9ade35c5b3", size = 4320254, upload-time = "2025-08-05T23:58:58.833Z" },
-    { url = "https://files.pythonhosted.org/packages/82/27/092d311af22095d288f4db89fcaebadfb2f28944f3d790a4cf51fe5ddaeb/cryptography-45.0.6-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b64e668fc3528e77efa51ca70fadcd6610e8ab231e3e06ae2bab3b31c2b8ed9", size = 4554815, upload-time = "2025-08-05T23:59:00.283Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/01/aa2f4940262d588a8fdf4edabe4cda45854d00ebc6eaac12568b3a491a16/cryptography-45.0.6-cp37-abi3-win32.whl", hash = "sha256:780c40fb751c7d2b0c6786ceee6b6f871e86e8718a8ff4bc35073ac353c7cd02", size = 2912147, upload-time = "2025-08-05T23:59:01.716Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/bc/16e0276078c2de3ceef6b5a34b965f4436215efac45313df90d55f0ba2d2/cryptography-45.0.6-cp37-abi3-win_amd64.whl", hash = "sha256:20d15aed3ee522faac1a39fbfdfee25d17b1284bafd808e1640a74846d7c4d1b", size = 3390459, upload-time = "2025-08-05T23:59:03.358Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/925c0ac74362172ae4516000fe877912e33b5983df735ff290c653de4913/cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee", size = 7041105, upload-time = "2025-09-01T11:13:59.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/63/43641c5acce3a6105cf8bd5baeceeb1846bb63067d26dae3e5db59f1513a/cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6", size = 4205799, upload-time = "2025-09-01T11:14:02.517Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/29/c238dd9107f10bfde09a4d1c52fd38828b1aa353ced11f358b5dd2507d24/cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339", size = 4430504, upload-time = "2025-09-01T11:14:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/62/62/24203e7cbcc9bd7c94739428cd30680b18ae6b18377ae66075c8e4771b1b/cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8", size = 4209542, upload-time = "2025-09-01T11:14:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e3/e7de4771a08620eef2389b86cd87a2c50326827dea5528feb70595439ce4/cryptography-45.0.7-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:465ccac9d70115cd4de7186e60cfe989de73f7bb23e8a7aa45af18f7412e75bf", size = 3889244, upload-time = "2025-09-01T11:14:08.152Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b8/bca71059e79a0bb2f8e4ec61d9c205fbe97876318566cde3b5092529faa9/cryptography-45.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16ede8a4f7929b4b7ff3642eba2bf79aa1d71f24ab6ee443935c0d269b6bc513", size = 4461975, upload-time = "2025-09-01T11:14:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/58/67/3f5b26937fe1218c40e95ef4ff8d23c8dc05aa950d54200cc7ea5fb58d28/cryptography-45.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8978132287a9d3ad6b54fcd1e08548033cc09dc6aacacb6c004c73c3eb5d3ac3", size = 4209082, upload-time = "2025-09-01T11:14:11.229Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e4/b3e68a4ac363406a56cf7b741eeb80d05284d8c60ee1a55cdc7587e2a553/cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3", size = 4460397, upload-time = "2025-09-01T11:14:12.924Z" },
+    { url = "https://files.pythonhosted.org/packages/22/49/2c93f3cd4e3efc8cb22b02678c1fad691cff9dd71bb889e030d100acbfe0/cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6", size = 4337244, upload-time = "2025-09-01T11:14:14.431Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/030f400de0bccccc09aa262706d90f2ec23d56bc4eb4f4e8268d0ddf3fb8/cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd", size = 4568862, upload-time = "2025-09-01T11:14:16.185Z" },
+    { url = "https://files.pythonhosted.org/packages/29/56/3034a3a353efa65116fa20eb3c990a8c9f0d3db4085429040a7eef9ada5f/cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8", size = 2936578, upload-time = "2025-09-01T11:14:17.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/61/0ab90f421c6194705a99d0fa9f6ee2045d916e4455fdbb095a9c2c9a520f/cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443", size = 3405400, upload-time = "2025-09-01T11:14:18.958Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e8/c436233ddf19c5f15b25ace33979a9dd2e7aa1a59209a0ee8554179f1cc0/cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2", size = 7021824, upload-time = "2025-09-01T11:14:20.954Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/4c/8f57f2500d0ccd2675c5d0cc462095adf3faa8c52294ba085c036befb901/cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691", size = 4202233, upload-time = "2025-09-01T11:14:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ac/59b7790b4ccaed739fc44775ce4645c9b8ce54cbec53edf16c74fd80cb2b/cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59", size = 4423075, upload-time = "2025-09-01T11:14:24.287Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/d4f07ea21434bf891faa088a6ac15d6d98093a66e75e30ad08e88aa2b9ba/cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4", size = 4204517, upload-time = "2025-09-01T11:14:25.679Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ac/924a723299848b4c741c1059752c7cfe09473b6fd77d2920398fc26bfb53/cryptography-45.0.7-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce7a453385e4c4693985b4a4a3533e041558851eae061a58a5405363b098fcd3", size = 3882893, upload-time = "2025-09-01T11:14:27.1Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/4dab2ff0a871cc2d81d3ae6d780991c0192b259c35e4d83fe1de18b20c70/cryptography-45.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b04f85ac3a90c227b6e5890acb0edbaf3140938dbecf07bff618bf3638578cf1", size = 4450132, upload-time = "2025-09-01T11:14:28.58Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dd/b2882b65db8fc944585d7fb00d67cf84a9cef4e77d9ba8f69082e911d0de/cryptography-45.0.7-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:48c41a44ef8b8c2e80ca4527ee81daa4c527df3ecbc9423c41a420a9559d0e27", size = 4204086, upload-time = "2025-09-01T11:14:30.572Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/fa/1d5745d878048699b8eb87c984d4ccc5da4f5008dfd3ad7a94040caca23a/cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17", size = 4449383, upload-time = "2025-09-01T11:14:32.046Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8b/fc61f87931bc030598e1876c45b936867bb72777eac693e905ab89832670/cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b", size = 4332186, upload-time = "2025-09-01T11:14:33.95Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/11/09700ddad7443ccb11d674efdbe9a832b4455dc1f16566d9bd3834922ce5/cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c", size = 4561639, upload-time = "2025-09-01T11:14:35.343Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/8f4c1337e9d3b94d8e50ae0b08ad0304a5709d483bfcadfcc77a23dbcb52/cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5", size = 2926552, upload-time = "2025-09-01T11:14:36.929Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ff/026513ecad58dacd45d1d24ebe52b852165a26e287177de1d545325c0c25/cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90", size = 3392742, upload-time = "2025-09-01T11:14:38.368Z" },
 ]
 
 [[package]]
@@ -368,7 +368,7 @@ wheels = [
 
 [[package]]
 name = "jsonschema"
-version = "4.25.0"
+version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -376,9 +376,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/00/a297a868e9d0784450faa7365c2172a7d6110c763e30ba861867c32ae6a9/jsonschema-4.25.0.tar.gz", hash = "sha256:e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f", size = 356830, upload-time = "2025-07-18T15:39:45.11Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/54/c86cd8e011fe98803d7e382fd67c0df5ceab8d2b7ad8c5a81524f791551c/jsonschema-4.25.0-py3-none-any.whl", hash = "sha256:24c2e8da302de79c8b9382fee3e76b355e44d2a4364bb207159ce10b517bd716", size = 89184, upload-time = "2025-07-18T15:39:42.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
 ]
 
 [[package]]
@@ -395,14 +395,14 @@ wheels = [
 
 [[package]]
 name = "jubilant"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/49/9ea5efac9127c76247d42e286e56e26d9b5c01edbf9f24bcfae9aab3cf81/jubilant-1.3.0.tar.gz", hash = "sha256:ff43d6eb67a986958db6317d7ff3df1c8c160d0c56736628919ac1f7319d444e", size = 26842, upload-time = "2025-07-24T22:31:55.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1a/ba5838825ac99db4ceec68fa146b594c97b682cf3ccf670b1ecf1261209d/jubilant-1.4.0.tar.gz", hash = "sha256:aa377699a8811fea29bfe0febb6b552d4593c02e666f5ba8c3fba24258700199", size = 27502, upload-time = "2025-08-27T00:11:46.295Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/97/ad9cbc4718cdc4feed0e841ccb2a3d15de7cb1187d63d1e2ba419cc34f51/jubilant-1.3.0-py3-none-any.whl", hash = "sha256:a5ea4a3bf487ab0286eaad0de9df145761657c08beb834931340b9ebb1f41292", size = 26484, upload-time = "2025-07-24T22:31:54.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/4965ed70d4b9d405c8bdefc4926d94cae202014b4488a25aa8c1fe9fb462/jubilant-1.4.0-py3-none-any.whl", hash = "sha256:1df7eaf125fad8d0d3d35e6d83eca43bfbb7884debcd6c7f4b0822600e2a485c", size = 27185, upload-time = "2025-08-27T00:11:44.851Z" },
 ]
 
 [[package]]
@@ -461,11 +461,11 @@ wheels = [
 
 [[package]]
 name = "lightkube-models"
-version = "1.33.1.8"
+version = "1.34.0.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/d0/e9fef6407c9663bd294e69faada7bd8aa966894b8e945181bec214cf7316/lightkube-models-1.33.1.8.tar.gz", hash = "sha256:5106c49138bea2eb0ab884fb6edf368f21744b6678f0766a682b4424a6b41cd0", size = 226968, upload-time = "2025-05-18T10:41:06.094Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/b6/306ed471d79768052b5c2139e45f7eb91f00e45612ee9dace2d7ce40a568/lightkube-models-1.34.0.8.tar.gz", hash = "sha256:eb23c762a87bb63e274d8f6ad50b84aa99ccadf4221868fc3b75ab8982ec015a", size = 242698, upload-time = "2025-08-31T09:47:12.242Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/ce/e0bc7e43f41ea434ba8e59aaecc111a87033201c149b466afce571eb627f/lightkube_models-1.33.1.8-py3-none-any.whl", hash = "sha256:cb6343388eb6f03c968ca4f23678743223cdf8f841f9c07f8bd603718e771f83", size = 287479, upload-time = "2025-05-18T10:41:03.558Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/16/e1e9103d66a9d442824d6a478462620bec3b5bc7b5efe9a85a0e1b82fc4d/lightkube_models-1.34.0.8-py3-none-any.whl", hash = "sha256:7731233ff4e69b6ffd8f7c6dde0788196a0adb76ac7eedc8383f88d4545ff19c", size = 304175, upload-time = "2025-08-31T09:46:59.681Z" },
 ]
 
 [[package]]
@@ -630,17 +630,16 @@ wheels = [
 
 [[package]]
 name = "ops"
-version = "3.1.0"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "opentelemetry-api" },
     { name = "pyyaml" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/fb/7ec08c56511b108cedd92b2eb978419d982b0b87776d8e860cd981e10b9e/ops-3.1.0.tar.gz", hash = "sha256:49bc8ce4f24815dae57aec752d7d0c9cd34e7942c29966f29a9f9774d1b97512", size = 531550, upload-time = "2025-07-30T02:26:49.875Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/e7/1e8009ead8c9ea52af27d9b7dc02612530b69c89ae6716d8f6fbfcc4e7d2/ops-3.2.0.tar.gz", hash = "sha256:1974a002a64e88665f4b23187fb2b1534be15507c2cb6523a5acb5d933b45815", size = 537349, upload-time = "2025-08-27T22:58:37.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/c4/db1450da4cb5ac49da1a814bf6b6ffcff873dfd15abd39520370d85848ab/ops-3.1.0-py3-none-any.whl", hash = "sha256:4553052c881c9e2ba76209dc01be48915330e4d05287fca0fc5ae05ae0d20f0a", size = 188440, upload-time = "2025-07-30T02:26:44.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5b/ea7b25780e2d83c5e679fb626674e97e9f7969cc9c8419a716cd093e2010/ops-3.2.0-py3-none-any.whl", hash = "sha256:2227acceef8f60432b17287f1130135690dd0f6b44edcd025c413ee25f5de010", size = 189782, upload-time = "2025-08-27T22:58:33.302Z" },
 ]
 
 [package.optional-dependencies]
@@ -653,20 +652,20 @@ tracing = [
 
 [[package]]
 name = "ops-scenario"
-version = "8.1.0"
+version = "8.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/c9/260d8c7a62894e80ba1e16857d7e4ab539b7559fc5d28f0636909570652e/ops_scenario-8.1.0.tar.gz", hash = "sha256:6b199d882710f3950348a885ff3b1d371806cb678f58e2c077b33029c6db9857", size = 109375, upload-time = "2025-07-30T02:26:51.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/9f/03f711869e9b8ebc993a0686c38201ca738c61958db4795c65093d7e9cc9/ops_scenario-8.2.0.tar.gz", hash = "sha256:33eb2ad46f6ee916747a2a0c5d6691454f23c9a7dc03dce24d0be4370c54d45a", size = 109715, upload-time = "2025-08-27T22:58:39.463Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/7b/7dd20a749e4c5d2317344a803c5c815af48a0d39b05ea5b2af1c81bbbf3f/ops_scenario-8.1.0-py3-none-any.whl", hash = "sha256:740df042474bdfed6836be184c9f9cc1f92af7a3a9d2ab234276e4291aa8312c", size = 63745, upload-time = "2025-07-30T02:26:46.383Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d6/6129b8852dd1e14e3332bc9299d4be39d3c5944f15dc80b2d541b97456ad/ops_scenario-8.2.0-py3-none-any.whl", hash = "sha256:35e0786b50f8ddd2067c78dbaff2d9219ef701cbebbbace50f8330aaa1fa91f0", size = 63901, upload-time = "2025-08-27T22:58:34.996Z" },
 ]
 
 [[package]]
 name = "ops-tracing"
-version = "3.1.0"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -674,9 +673,9 @@ dependencies = [
     { name = "ops" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/27/cffa0e90ad099ca83b15dee7acd015f7ab51c69ff8a460fda7fac72c4e98/ops_tracing-3.1.0.tar.gz", hash = "sha256:0e5f376961eb7a123aafb7d87e67d1f061f68ba87f19980e210172e9bd759a9e", size = 28520, upload-time = "2025-07-30T02:26:53.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/5b/e9244b5a5324fbf9a327af710801afb3ef04afddefdffb4c60d112fa50e8/ops_tracing-3.2.0.tar.gz", hash = "sha256:e1e965bcbba18ba140e2befb17105604a47bfc28e7fce8473214f39d1eb3a339", size = 28478, upload-time = "2025-08-27T22:58:40.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/54/f53df860fc635325b4cec15f7f815e30bdab58c2171c740df0ff68e61d6f/ops_tracing-3.1.0-py3-none-any.whl", hash = "sha256:f315be6fbebba43ef7ae0dc2009fb6f29484b851636f41295b1fcfa80b74c71f", size = 31459, upload-time = "2025-07-30T02:26:48.082Z" },
+    { url = "https://files.pythonhosted.org/packages/89/45/f9f680ce479ce59002b3351a1ad659fddf08f71739fd0fc3fbed4fb60f54/ops_tracing-3.2.0-py3-none-any.whl", hash = "sha256:2b503247120025df8e866e5f489fd0d750471ddb20dc400675de7eea06b80eb2", size = 31444, upload-time = "2025-08-27T22:58:36.613Z" },
 ]
 
 [[package]]
@@ -714,16 +713,16 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.31.1"
+version = "6.32.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/f3/b9655a711b32c19720253f6f06326faf90580834e2e83f840472d752bc8b/protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a", size = 441797, upload-time = "2025-05-28T19:25:54.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/df/fb4a8eeea482eca989b51cffd274aac2ee24e825f0bf3cbce5281fa1567b/protobuf-6.32.0.tar.gz", hash = "sha256:a81439049127067fc49ec1d36e25c6ee1d1a2b7be930675f919258d03c04e7d2", size = 440614, upload-time = "2025-08-14T21:21:25.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/6f/6ab8e4bf962fd5570d3deaa2d5c38f0a363f57b4501047b5ebeb83ab1125/protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9", size = 423603, upload-time = "2025-05-28T19:25:41.198Z" },
-    { url = "https://files.pythonhosted.org/packages/44/3a/b15c4347dd4bf3a1b0ee882f384623e2063bb5cf9fa9d57990a4f7df2fb6/protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447", size = 435283, upload-time = "2025-05-28T19:25:44.275Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c9/b9689a2a250264a84e66c46d8862ba788ee7a641cdca39bccf64f59284b7/protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402", size = 425604, upload-time = "2025-05-28T19:25:45.702Z" },
-    { url = "https://files.pythonhosted.org/packages/76/a1/7a5a94032c83375e4fe7e7f56e3976ea6ac90c5e85fac8576409e25c39c3/protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39", size = 322115, upload-time = "2025-05-28T19:25:47.128Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/b1/b59d405d64d31999244643d88c45c8241c58f17cc887e73bcb90602327f8/protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6", size = 321070, upload-time = "2025-05-28T19:25:50.036Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/af/ab3c51ab7507a7325e98ffe691d9495ee3d3aa5f589afad65ec920d39821/protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e", size = 168724, upload-time = "2025-05-28T19:25:53.926Z" },
+    { url = "https://files.pythonhosted.org/packages/33/18/df8c87da2e47f4f1dcc5153a81cd6bca4e429803f4069a299e236e4dd510/protobuf-6.32.0-cp310-abi3-win32.whl", hash = "sha256:84f9e3c1ff6fb0308dbacb0950d8aa90694b0d0ee68e75719cb044b7078fe741", size = 424409, upload-time = "2025-08-14T21:21:12.366Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/59/0a820b7310f8139bd8d5a9388e6a38e1786d179d6f33998448609296c229/protobuf-6.32.0-cp310-abi3-win_amd64.whl", hash = "sha256:a8bdbb2f009cfc22a36d031f22a625a38b615b5e19e558a7b756b3279723e68e", size = 435735, upload-time = "2025-08-14T21:21:15.046Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5b/0d421533c59c789e9c9894683efac582c06246bf24bb26b753b149bd88e4/protobuf-6.32.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d52691e5bee6c860fff9a1c86ad26a13afbeb4b168cd4445c922b7e2cf85aaf0", size = 426449, upload-time = "2025-08-14T21:21:16.687Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/607764ebe6c7a23dcee06e054fd1de3d5841b7648a90fd6def9a3bb58c5e/protobuf-6.32.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:501fe6372fd1c8ea2a30b4d9be8f87955a64d6be9c88a973996cef5ef6f0abf1", size = 322869, upload-time = "2025-08-14T21:21:18.282Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/2e730bd1c25392fc32e3268e02446f0d77cb51a2c3a8486b1798e34d5805/protobuf-6.32.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:75a2aab2bd1aeb1f5dc7c5f33bcb11d82ea8c055c9becbb41c26a8c43fd7092c", size = 322009, upload-time = "2025-08-14T21:21:19.893Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f2/80ffc4677aac1bc3519b26bc7f7f5de7fce0ee2f7e36e59e27d8beb32dd1/protobuf-6.32.0-py3-none-any.whl", hash = "sha256:ba377e5b67b908c8f3072a57b63e2c6a4cbd18aea4ed98d2584350dbf46f2783", size = 169287, upload-time = "2025-08-14T21:21:23.515Z" },
 ]
 
 [[package]]
@@ -871,15 +870,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.403"
+version = "1.1.404"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/6e/026be64c43af681d5632722acd100b06d3d39f383ec382ff50a71a6d5bce/pyright-1.1.404.tar.gz", hash = "sha256:455e881a558ca6be9ecca0b30ce08aa78343ecc031d37a198ffa9a7a1abeb63e", size = 4065679, upload-time = "2025-08-20T18:46:14.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/84/30/89aa7f7d7a875bbb9a577d4b1dc5a3e404e3d2ae2657354808e905e358e0/pyright-1.1.404-py3-none-any.whl", hash = "sha256:c7b7ff1fdb7219c643079e4c3e7d4125f0dafcc19d253b47e898d130ea426419", size = 5902951, upload-time = "2025-08-20T18:46:12.096Z" },
 ]
 
 [[package]]
@@ -964,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -972,9 +971,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]
@@ -992,25 +991,25 @@ wheels = [
 
 [[package]]
 name = "rpds-py"
-version = "0.27.0"
+version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/d9/991a0dee12d9fc53ed027e26a26a64b151d77252ac477e22666b9688bc16/rpds_py-0.27.0.tar.gz", hash = "sha256:8b23cf252f180cda89220b378d917180f29d313cd6a07b2431c0d3b776aae86f", size = 27420, upload-time = "2025-08-07T08:26:39.624Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/dd/2c0cbe774744272b0ae725f44032c77bdcab6e8bcf544bffa3b6e70c8dba/rpds_py-0.27.1.tar.gz", hash = "sha256:26a1c73171d10b7acccbded82bf6a586ab8203601e565badc74bbbf8bc5a10f8", size = 27479, upload-time = "2025-08-27T12:16:36.024Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/17/e67309ca1ac993fa1888a0d9b2f5ccc1f67196ace32e76c9f8e1dbbbd50c/rpds_py-0.27.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:19c990fdf5acecbf0623e906ae2e09ce1c58947197f9bced6bbd7482662231c4", size = 362611, upload-time = "2025-08-07T08:23:44.773Z" },
-    { url = "https://files.pythonhosted.org/packages/93/2e/28c2fb84aa7aa5d75933d1862d0f7de6198ea22dfd9a0cca06e8a4e7509e/rpds_py-0.27.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6c27a7054b5224710fcfb1a626ec3ff4f28bcb89b899148c72873b18210e446b", size = 347680, upload-time = "2025-08-07T08:23:46.014Z" },
-    { url = "https://files.pythonhosted.org/packages/44/3e/9834b4c8f4f5fe936b479e623832468aa4bd6beb8d014fecaee9eac6cdb1/rpds_py-0.27.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09965b314091829b378b60607022048953e25f0b396c2b70e7c4c81bcecf932e", size = 384600, upload-time = "2025-08-07T08:23:48Z" },
-    { url = "https://files.pythonhosted.org/packages/19/78/744123c7b38865a965cd9e6f691fde7ef989a00a256fa8bf15b75240d12f/rpds_py-0.27.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:14f028eb47f59e9169bfdf9f7ceafd29dd64902141840633683d0bad5b04ff34", size = 400697, upload-time = "2025-08-07T08:23:49.407Z" },
-    { url = "https://files.pythonhosted.org/packages/32/97/3c3d32fe7daee0a1f1a678b6d4dfb8c4dcf88197fa2441f9da7cb54a8466/rpds_py-0.27.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6168af0be75bba990a39f9431cdfae5f0ad501f4af32ae62e8856307200517b8", size = 517781, upload-time = "2025-08-07T08:23:50.557Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/be/28f0e3e733680aa13ecec1212fc0f585928a206292f14f89c0b8a684cad1/rpds_py-0.27.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ab47fe727c13c09d0e6f508e3a49e545008e23bf762a245b020391b621f5b726", size = 406449, upload-time = "2025-08-07T08:23:51.732Z" },
-    { url = "https://files.pythonhosted.org/packages/95/ae/5d15c83e337c082d0367053baeb40bfba683f42459f6ebff63a2fd7e5518/rpds_py-0.27.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fa01b3d5e3b7d97efab65bd3d88f164e289ec323a8c033c5c38e53ee25c007e", size = 386150, upload-time = "2025-08-07T08:23:52.822Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/65/944e95f95d5931112829e040912b25a77b2e7ed913ea5fe5746aa5c1ce75/rpds_py-0.27.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:6c135708e987f46053e0a1246a206f53717f9fadfba27174a9769ad4befba5c3", size = 406100, upload-time = "2025-08-07T08:23:54.339Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a4/1664b83fae02894533cd11dc0b9f91d673797c2185b7be0f7496107ed6c5/rpds_py-0.27.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc327f4497b7087d06204235199daf208fd01c82d80465dc5efa4ec9df1c5b4e", size = 421345, upload-time = "2025-08-07T08:23:55.832Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/26/b7303941c2b0823bfb34c71378249f8beedce57301f400acb04bb345d025/rpds_py-0.27.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e57906e38583a2cba67046a09c2637e23297618dc1f3caddbc493f2be97c93f", size = 561891, upload-time = "2025-08-07T08:23:56.951Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/c8/48623d64d4a5a028fa99576c768a6159db49ab907230edddc0b8468b998b/rpds_py-0.27.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f4f69d7a4300fbf91efb1fb4916421bd57804c01ab938ab50ac9c4aa2212f03", size = 591756, upload-time = "2025-08-07T08:23:58.146Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/51/18f62617e8e61cc66334c9fb44b1ad7baae3438662098efbc55fb3fda453/rpds_py-0.27.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b4c4fbbcff474e1e5f38be1bf04511c03d492d42eec0babda5d03af3b5589374", size = 557088, upload-time = "2025-08-07T08:23:59.6Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/4c/e84c3a276e2496a93d245516be6b49e20499aa8ca1c94d59fada0d79addc/rpds_py-0.27.0-cp312-cp312-win32.whl", hash = "sha256:27bac29bbbf39601b2aab474daf99dbc8e7176ca3389237a23944b17f8913d97", size = 221926, upload-time = "2025-08-07T08:24:00.695Z" },
-    { url = "https://files.pythonhosted.org/packages/83/89/9d0fbcef64340db0605eb0a0044f258076f3ae0a3b108983b2c614d96212/rpds_py-0.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:8a06aa1197ec0281eb1d7daf6073e199eb832fe591ffa329b88bae28f25f5fe5", size = 233235, upload-time = "2025-08-07T08:24:01.846Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b0/e177aa9f39cbab060f96de4a09df77d494f0279604dc2f509263e21b05f9/rpds_py-0.27.0-cp312-cp312-win_arm64.whl", hash = "sha256:e14aab02258cb776a108107bd15f5b5e4a1bbaa61ef33b36693dfab6f89d54f9", size = 223315, upload-time = "2025-08-07T08:24:03.337Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/fe/38de28dee5df58b8198c743fe2bea0c785c6d40941b9950bac4cdb71a014/rpds_py-0.27.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ae2775c1973e3c30316892737b91f9283f9908e3cc7625b9331271eaaed7dc90", size = 361887, upload-time = "2025-08-27T12:13:10.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/4b6c7eedc7dd90986bf0fab6ea2a091ec11c01b15f8ba0a14d3f80450468/rpds_py-0.27.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2643400120f55c8a96f7c9d858f7be0c88d383cd4653ae2cf0d0c88f668073e5", size = 345795, upload-time = "2025-08-27T12:13:11.65Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0e/e650e1b81922847a09cca820237b0edee69416a01268b7754d506ade11ad/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16323f674c089b0360674a4abd28d5042947d54ba620f72514d69be4ff64845e", size = 385121, upload-time = "2025-08-27T12:13:13.008Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ea/b306067a712988e2bff00dcc7c8f31d26c29b6d5931b461aa4b60a013e33/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a1f4814b65eacac94a00fc9a526e3fdafd78e439469644032032d0d63de4881", size = 398976, upload-time = "2025-08-27T12:13:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0a/26dc43c8840cb8fe239fe12dbc8d8de40f2365e838f3d395835dde72f0e5/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ba32c16b064267b22f1850a34051121d423b6f7338a12b9459550eb2096e7ec", size = 525953, upload-time = "2025-08-27T12:13:15.774Z" },
+    { url = "https://files.pythonhosted.org/packages/22/14/c85e8127b573aaf3a0cbd7fbb8c9c99e735a4a02180c84da2a463b766e9e/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5c20f33fd10485b80f65e800bbe5f6785af510b9f4056c5a3c612ebc83ba6cb", size = 407915, upload-time = "2025-08-27T12:13:17.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/7b/8f4fee9ba1fb5ec856eb22d725a4efa3deb47f769597c809e03578b0f9d9/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:466bfe65bd932da36ff279ddd92de56b042f2266d752719beb97b08526268ec5", size = 386883, upload-time = "2025-08-27T12:13:18.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/47/28fa6d60f8b74fcdceba81b272f8d9836ac0340570f68f5df6b41838547b/rpds_py-0.27.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:41e532bbdcb57c92ba3be62c42e9f096431b4cf478da9bc3bc6ce5c38ab7ba7a", size = 405699, upload-time = "2025-08-27T12:13:20.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/fd/c5987b5e054548df56953a21fe2ebed51fc1ec7c8f24fd41c067b68c4a0a/rpds_py-0.27.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f149826d742b406579466283769a8ea448eed82a789af0ed17b0cd5770433444", size = 423713, upload-time = "2025-08-27T12:13:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ba/3c4978b54a73ed19a7d74531be37a8bcc542d917c770e14d372b8daea186/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80c60cfb5310677bd67cb1e85a1e8eb52e12529545441b43e6f14d90b878775a", size = 562324, upload-time = "2025-08-27T12:13:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6c/6943a91768fec16db09a42b08644b960cff540c66aab89b74be6d4a144ba/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7ee6521b9baf06085f62ba9c7a3e5becffbc32480d2f1b351559c001c38ce4c1", size = 593646, upload-time = "2025-08-27T12:13:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/11/73/9d7a8f4be5f4396f011a6bb7a19fe26303a0dac9064462f5651ced2f572f/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a512c8263249a9d68cac08b05dd59d2b3f2061d99b322813cbcc14c3c7421998", size = 558137, upload-time = "2025-08-27T12:13:25.557Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/96/6772cbfa0e2485bcceef8071de7821f81aeac8bb45fbfd5542a3e8108165/rpds_py-0.27.1-cp312-cp312-win32.whl", hash = "sha256:819064fa048ba01b6dadc5116f3ac48610435ac9a0058bbde98e569f9e785c39", size = 221343, upload-time = "2025-08-27T12:13:26.967Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b6/c82f0faa9af1c6a64669f73a17ee0eeef25aff30bb9a1c318509efe45d84/rpds_py-0.27.1-cp312-cp312-win_amd64.whl", hash = "sha256:d9199717881f13c32c4046a15f024971a3b78ad4ea029e8da6b86e5aa9cf4594", size = 232497, upload-time = "2025-08-27T12:13:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/96/2817b44bd2ed11aebacc9251da03689d56109b9aba5e311297b6902136e2/rpds_py-0.27.1-cp312-cp312-win_arm64.whl", hash = "sha256:33aa65b97826a0e885ef6e278fbd934e98cdcfed80b63946025f01e2f5b29502", size = 222790, upload-time = "2025-08-27T12:13:29.71Z" },
 ]
 
 [[package]]
@@ -1027,27 +1026,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.12.8"
+version = "0.12.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/da/5bd7565be729e86e1442dad2c9a364ceeff82227c2dece7c29697a9795eb/ruff-0.12.8.tar.gz", hash = "sha256:4cb3a45525176e1009b2b64126acf5f9444ea59066262791febf55e40493a033", size = 5242373, upload-time = "2025-08-07T19:05:47.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/55/16ab6a7d88d93001e1ae4c34cbdcfb376652d761799459ff27c1dc20f6fa/ruff-0.12.11.tar.gz", hash = "sha256:c6b09ae8426a65bbee5425b9d0b82796dbb07cb1af045743c79bfb163001165d", size = 5347103, upload-time = "2025-08-28T13:59:08.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/1e/c843bfa8ad1114fab3eb2b78235dda76acd66384c663a4e0415ecc13aa1e/ruff-0.12.8-py3-none-linux_armv6l.whl", hash = "sha256:63cb5a5e933fc913e5823a0dfdc3c99add73f52d139d6cd5cc8639d0e0465513", size = 11675315, upload-time = "2025-08-07T19:05:06.15Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ee/af6e5c2a8ca3a81676d5480a1025494fd104b8896266502bb4de2a0e8388/ruff-0.12.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a9bbe28f9f551accf84a24c366c1aa8774d6748438b47174f8e8565ab9dedbc", size = 12456653, upload-time = "2025-08-07T19:05:09.759Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9d/e91f84dfe3866fa648c10512904991ecc326fd0b66578b324ee6ecb8f725/ruff-0.12.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2fae54e752a3150f7ee0e09bce2e133caf10ce9d971510a9b925392dc98d2fec", size = 11659690, upload-time = "2025-08-07T19:05:12.551Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ac/a363d25ec53040408ebdd4efcee929d48547665858ede0505d1d8041b2e5/ruff-0.12.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0acbcf01206df963d9331b5838fb31f3b44fa979ee7fa368b9b9057d89f4a53", size = 11896923, upload-time = "2025-08-07T19:05:14.821Z" },
-    { url = "https://files.pythonhosted.org/packages/58/9f/ea356cd87c395f6ade9bb81365bd909ff60860975ca1bc39f0e59de3da37/ruff-0.12.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ae3e7504666ad4c62f9ac8eedb52a93f9ebdeb34742b8b71cd3cccd24912719f", size = 11477612, upload-time = "2025-08-07T19:05:16.712Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/46/92e8fa3c9dcfd49175225c09053916cb97bb7204f9f899c2f2baca69e450/ruff-0.12.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb82efb5d35d07497813a1c5647867390a7d83304562607f3579602fa3d7d46f", size = 13182745, upload-time = "2025-08-07T19:05:18.709Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/c4/f2176a310f26e6160deaf661ef60db6c3bb62b7a35e57ae28f27a09a7d63/ruff-0.12.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dbea798fc0065ad0b84a2947b0aff4233f0cb30f226f00a2c5850ca4393de609", size = 14206885, upload-time = "2025-08-07T19:05:21.025Z" },
-    { url = "https://files.pythonhosted.org/packages/87/9d/98e162f3eeeb6689acbedbae5050b4b3220754554526c50c292b611d3a63/ruff-0.12.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49ebcaccc2bdad86fd51b7864e3d808aad404aab8df33d469b6e65584656263a", size = 13639381, upload-time = "2025-08-07T19:05:23.423Z" },
-    { url = "https://files.pythonhosted.org/packages/81/4e/1b7478b072fcde5161b48f64774d6edd59d6d198e4ba8918d9f4702b8043/ruff-0.12.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ac9c570634b98c71c88cb17badd90f13fc076a472ba6ef1d113d8ed3df109fb", size = 12613271, upload-time = "2025-08-07T19:05:25.507Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/67/0c3c9179a3ad19791ef1b8f7138aa27d4578c78700551c60d9260b2c660d/ruff-0.12.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:560e0cd641e45591a3e42cb50ef61ce07162b9c233786663fdce2d8557d99818", size = 12847783, upload-time = "2025-08-07T19:05:28.14Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/2a/0b6ac3dd045acf8aa229b12c9c17bb35508191b71a14904baf99573a21bd/ruff-0.12.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:71c83121512e7743fba5a8848c261dcc454cafb3ef2934a43f1b7a4eb5a447ea", size = 11702672, upload-time = "2025-08-07T19:05:30.413Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ee/f9fdc9f341b0430110de8b39a6ee5fa68c5706dc7c0aa940817947d6937e/ruff-0.12.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:de4429ef2ba091ecddedd300f4c3f24bca875d3d8b23340728c3cb0da81072c3", size = 11440626, upload-time = "2025-08-07T19:05:32.492Z" },
-    { url = "https://files.pythonhosted.org/packages/89/fb/b3aa2d482d05f44e4d197d1de5e3863feb13067b22c571b9561085c999dc/ruff-0.12.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a2cab5f60d5b65b50fba39a8950c8746df1627d54ba1197f970763917184b161", size = 12462162, upload-time = "2025-08-07T19:05:34.449Z" },
-    { url = "https://files.pythonhosted.org/packages/18/9f/5c5d93e1d00d854d5013c96e1a92c33b703a0332707a7cdbd0a4880a84fb/ruff-0.12.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:45c32487e14f60b88aad6be9fd5da5093dbefb0e3e1224131cb1d441d7cb7d46", size = 12913212, upload-time = "2025-08-07T19:05:36.541Z" },
-    { url = "https://files.pythonhosted.org/packages/71/13/ab9120add1c0e4604c71bfc2e4ef7d63bebece0cfe617013da289539cef8/ruff-0.12.8-py3-none-win32.whl", hash = "sha256:daf3475060a617fd5bc80638aeaf2f5937f10af3ec44464e280a9d2218e720d3", size = 11694382, upload-time = "2025-08-07T19:05:38.468Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/dc/a2873b7c5001c62f46266685863bee2888caf469d1edac84bf3242074be2/ruff-0.12.8-py3-none-win_amd64.whl", hash = "sha256:7209531f1a1fcfbe8e46bcd7ab30e2f43604d8ba1c49029bb420b103d0b5f76e", size = 12740482, upload-time = "2025-08-07T19:05:40.391Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/5c/799a1efb8b5abab56e8a9f2a0b72d12bd64bb55815e9476c7d0a2887d2f7/ruff-0.12.8-py3-none-win_arm64.whl", hash = "sha256:c90e1a334683ce41b0e7a04f41790c429bf5073b62c1ae701c9dc5b3d14f0749", size = 11884718, upload-time = "2025-08-07T19:05:42.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a2/3b3573e474de39a7a475f3fbaf36a25600bfeb238e1a90392799163b64a0/ruff-0.12.11-py3-none-linux_armv6l.whl", hash = "sha256:93fce71e1cac3a8bf9200e63a38ac5c078f3b6baebffb74ba5274fb2ab276065", size = 11979885, upload-time = "2025-08-28T13:58:26.654Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e4/235ad6d1785a2012d3ded2350fd9bc5c5af8c6f56820e696b0118dfe7d24/ruff-0.12.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b8e33ac7b28c772440afa80cebb972ffd823621ded90404f29e5ab6d1e2d4b93", size = 12742364, upload-time = "2025-08-28T13:58:30.256Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0d/15b72c5fe6b1e402a543aa9d8960e0a7e19dfb079f5b0b424db48b7febab/ruff-0.12.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d69fb9d4937aa19adb2e9f058bc4fbfe986c2040acb1a4a9747734834eaa0bfd", size = 11920111, upload-time = "2025-08-28T13:58:33.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/f66339d7893798ad3e17fa5a1e587d6fd9806f7c1c062b63f8b09dda6702/ruff-0.12.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:411954eca8464595077a93e580e2918d0a01a19317af0a72132283e28ae21bee", size = 12160060, upload-time = "2025-08-28T13:58:35.74Z" },
+    { url = "https://files.pythonhosted.org/packages/03/69/9870368326db26f20c946205fb2d0008988aea552dbaec35fbacbb46efaa/ruff-0.12.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6a2c0a2e1a450f387bf2c6237c727dd22191ae8c00e448e0672d624b2bbd7fb0", size = 11799848, upload-time = "2025-08-28T13:58:38.051Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8c/dd2c7f990e9b3a8a55eee09d4e675027d31727ce33cdb29eab32d025bdc9/ruff-0.12.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ca4c3a7f937725fd2413c0e884b5248a19369ab9bdd850b5781348ba283f644", size = 13536288, upload-time = "2025-08-28T13:58:40.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/30/d5496fa09aba59b5e01ea76775a4c8897b13055884f56f1c35a4194c2297/ruff-0.12.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4d1df0098124006f6a66ecf3581a7f7e754c4df7644b2e6704cd7ca80ff95211", size = 14490633, upload-time = "2025-08-28T13:58:42.285Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2f/81f998180ad53445d403c386549d6946d0748e536d58fce5b5e173511183/ruff-0.12.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a8dd5f230efc99a24ace3b77e3555d3fbc0343aeed3fc84c8d89e75ab2ff793", size = 13888430, upload-time = "2025-08-28T13:58:44.641Z" },
+    { url = "https://files.pythonhosted.org/packages/87/71/23a0d1d5892a377478c61dbbcffe82a3476b050f38b5162171942a029ef3/ruff-0.12.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4dc75533039d0ed04cd33fb8ca9ac9620b99672fe7ff1533b6402206901c34ee", size = 12913133, upload-time = "2025-08-28T13:58:47.039Z" },
+    { url = "https://files.pythonhosted.org/packages/80/22/3c6cef96627f89b344c933781ed38329bfb87737aa438f15da95907cbfd5/ruff-0.12.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fc58f9266d62c6eccc75261a665f26b4ef64840887fc6cbc552ce5b29f96cc8", size = 13169082, upload-time = "2025-08-28T13:58:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b5/68b3ff96160d8b49e8dd10785ff3186be18fd650d356036a3770386e6c7f/ruff-0.12.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5a0113bd6eafd545146440225fe60b4e9489f59eb5f5f107acd715ba5f0b3d2f", size = 13139490, upload-time = "2025-08-28T13:58:51.593Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b9/050a3278ecd558f74f7ee016fbdf10591d50119df8d5f5da45a22c6afafc/ruff-0.12.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0d737b4059d66295c3ea5720e6efc152623bb83fde5444209b69cd33a53e2000", size = 11958928, upload-time = "2025-08-28T13:58:53.943Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bc/93be37347db854806904a43b0493af8d6873472dfb4b4b8cbb27786eb651/ruff-0.12.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:916fc5defee32dbc1fc1650b576a8fed68f5e8256e2180d4d9855aea43d6aab2", size = 11764513, upload-time = "2025-08-28T13:58:55.976Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a1/1471751e2015a81fd8e166cd311456c11df74c7e8769d4aabfbc7584c7ac/ruff-0.12.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c984f07d7adb42d3ded5be894fb4007f30f82c87559438b4879fe7aa08c62b39", size = 12745154, upload-time = "2025-08-28T13:58:58.16Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/2542b14890d0f4872dd81b7b2a6aed3ac1786fae1ce9b17e11e6df9e31e3/ruff-0.12.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e07fbb89f2e9249f219d88331c833860489b49cdf4b032b8e4432e9b13e8a4b9", size = 13227653, upload-time = "2025-08-28T13:59:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/2fbfc61047dbfd009c58a28369a693a1484ad15441723be1cd7fe69bb679/ruff-0.12.11-py3-none-win32.whl", hash = "sha256:c792e8f597c9c756e9bcd4d87cf407a00b60af77078c96f7b6366ea2ce9ba9d3", size = 11944270, upload-time = "2025-08-28T13:59:02.347Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/34276984705bfe069cd383101c45077ee029c3fe3b28225bf67aa35f0647/ruff-0.12.11-py3-none-win_amd64.whl", hash = "sha256:a3283325960307915b6deb3576b96919ee89432ebd9c48771ca12ee8afe4a0fd", size = 13046600, upload-time = "2025-08-28T13:59:04.751Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a8/001d4a7c2b37623a3fd7463208267fb906df40ff31db496157549cfd6e72/ruff-0.12.11-py3-none-win_arm64.whl", hash = "sha256:bae4d6e6a2676f8fb0f98b74594a048bae1b944aab17e9f5d504062303c6dbea", size = 12135290, upload-time = "2025-08-28T13:59:06.933Z" },
 ]
 
 [[package]]
@@ -1097,11 +1097,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.1"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR aligns the shared code between the k8s and the machine charm, by bringing in the newest updates :)

## Drive-bys

- fix adding prometheus scrape from other charms
- tracing integration test passes locally - CI only needs an increased timeout

---

```
⌀ aegis at ⚡zeus in ~/Repositories/Canonical
∮ diff opentelemetry-collector-k8s-operator/src/config_builder.py opentelemetry-collector-operator/src/config_builder.py
⌀ aegis at ⚡zeus in ~/Repositories/Canonical
∮ diff opentelemetry-collector-k8s-operator/src/config_manager.py opentelemetry-collector-operator/src/config_manager.py
⌀ aegis at ⚡zeus in ~/Repositories/Canonical
∮ diff opentelemetry-collector-k8s-operator/src/integrations.py opentelemetry-collector-operator/src/integrations.py
```