### PR TITLE
chore(track 2): implement new prom remote write lib requirements

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -149,6 +149,10 @@ requires:
     optional: true
     description: Send charm traces to a charmed Tempo instance.
 
+peers:
+  peers:
+    interface: otelcol_replicas
+
 config:
   options:
     processors:

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -233,6 +233,7 @@ def send_remote_write(charm: CharmBase) -> List[Dict[str, str]]:
         extra_alert_labels=key_value_pair_string_to_dict(
             cast(str, charm.model.config.get("extra_alert_labels", ""))
         ),
+        peer_relation_name="peers",
     )
     charm.__setattr__("remote_write", remote_write)
     # TODO: add alerts from remote write

--- a/uv.lock
+++ b/uv.lock
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.3.1"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
@@ -216,9 +216,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/d5/a9ea4a4c29a374d6d356bbdc2a78348de5dc7aa2d869b932bbd559367d2b/cosl-1.3.1.tar.gz", hash = "sha256:aa836828350398beb5bbd4fe85cb582e796a7b8b5d9a214a5bc6fd855cde11af", size = 45361, upload-time = "2025-10-08T09:58:04.504Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/c41b6308ce2a6a1523fe1d5cebb831ad779e55008f8d8c0c724fccc4b407/cosl-1.4.0.tar.gz", hash = "sha256:eb6ebf682f76eec24e3c9759fb6fe5185660fcf7bb3dd8adc42e5a74816c8615", size = 46191, upload-time = "2025-11-25T17:16:01.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/54/a72b67cae15af226882dd6c7da011c26ae3c9c5843c36511d0dd1753c298/cosl-1.3.1-py3-none-any.whl", hash = "sha256:8ab9b23b367f041ec0f4eae63d4b1960712431a2b3bf6fb6fdec473efea30f77", size = 36387, upload-time = "2025-10-08T09:58:03.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9b/716ceb6021530b9cdbbfd681b7f296b660cdc763c365283e82581a71c299/cosl-1.4.0-py3-none-any.whl", hash = "sha256:410042805b17876c19d405ff5bf5c2461a84a7bff389ce3ad928f44e8c09b882", size = 36649, upload-time = "2025-11-25T17:16:00.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Tracking issue with further context: https://github.com/canonical/cos-lib/issues/167
This is based on a similar PR #148 except this one is for backporting the change into track 2.
## Solution
<!-- A summary of the solution addressing the above issue -->
1. Bumps `cosl` so new generic alert rules (with new descriptions) are used.
2. Fetches charm libs so new changes from Prometheus remote write lib are present (lib patch 11).
3. Passes the name of this charm's peer relation when instantiating `PromtheusRemoteWriteConsumer`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Pack this charm and relate it to Prometheus.
2. Scale up this charm to 2.
3. On the Prom alerts page, you should now see 2 HostMetricsMissing rules, one per each unit of Otelcol.
<img width="2520" height="1186" alt="image" src="https://github.com/user-attachments/assets/40d78eac-6ce8-4409-95e1-dd18060e641a" />
4. If we do `pebble stop otelcol` in one of the units (e.g. otelcol/0), we expect to see only one `HostMetricsMissing` alert to fire. 
<img width="2531" height="925" alt="image" src="https://github.com/user-attachments/assets/4352c1da-ccd4-49f3-9b42-07a58a09d007" />

However, the AggregatorMetricsMissing alert should not be firing because only one of two units is down.


5. And when we do `pebble stop otelcol` in the other unit also, we should see that alert firing for both units. In addition, since ALL units of Otelcol are now down, the rule named AggregatorMetricsMissing needs to fire too.
<img width="2528" height="362" alt="image" src="https://github.com/user-attachments/assets/d8e28447-6f6f-491f-ad34-bd8594a0d774" />

## Upgrade Notes
<!-- To upgrade from an older revision of the charm, ... -->
