### PR TITLE
feature: Add syslog exporter support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -178,6 +178,45 @@ config:
         Toggle forwarding of alert rules.
       type: boolean
       default: true
+    syslog_endpoint:
+      description: |
+        Single syslog server endpoint to forward logs to, in "host:port" format.
+        If not set, syslog forwarding is disabled.
+
+        For multiple endpoints, use 'syslog_endpoints' instead.
+        Note: If 'syslog_endpoints' is set, this option is ignored.
+
+        Example: "rsyslog.example.com:514"
+      type: string
+    syslog_endpoints:
+      description: |
+        Multiple syslog server endpoints to forward logs to, as a comma-separated list.
+        Each endpoint should be in "host:port" format.
+        All endpoints will use the same protocol and network settings (from syslog_protocol and syslog_network).
+
+        This option takes precedence over 'syslog_endpoint' if both are set.
+        If not set, falls back to 'syslog_endpoint' for single-endpoint configuration.
+
+        Examples:
+          - "rsyslog1.example.com:514,rsyslog2.example.com:514"
+          - "dev-rsyslog:514,staging-rsyslog:514,prod-rsyslog:514"
+      type: string
+    syslog_protocol:
+      description: |
+        Syslog message format to use when forwarding logs.
+        - "rfc5424": Modern syslog format with structured data support (recommended)
+        - "rfc3164": Legacy BSD syslog format
+
+        Reference: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/syslogexporter
+      type: string
+      default: "rfc5424"
+    syslog_network:
+      description: |
+        Network protocol to use for syslog transmission.
+        - "tcp": Reliable, connection-oriented (recommended for security logs)
+        - "udp": Faster but may lose packets
+      type: string
+      default: "tcp"
     tls_insecure_skip_verify:
       description: |
         Flag to skip the validation of certificates from servers we connect to with TLS.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -194,6 +194,8 @@ config:
               protocol: rfc5424
               network: tcp
               tls_enabled: true
+              tls_secret: secret:abc123  # optional, for mutual TLS
+              tls_skip_verify: false     # optional, default: false
 
         Single endpoint example:
           syslog_endpoints: |
@@ -204,6 +206,8 @@ config:
           - protocol (optional): Message format - "rfc5424" (modern, recommended) or "rfc3164" (legacy BSD)
           - network (optional): Transport protocol - "tcp" (reliable) or "udp" (faster but may lose packets)
           - tls_enabled (optional): Enable TLS encryption (true/false)
+          - tls_secret (optional): Juju secret URI containing client certificates for mutual TLS (e.g., "secret:abc123")
+          - tls_skip_verify (optional): Skip server certificate validation (true/false, default: false)
 
         Reference: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/syslogexporter
       type: string

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -178,45 +178,35 @@ config:
         Toggle forwarding of alert rules.
       type: boolean
       default: true
-    syslog_endpoint:
-      description: |
-        Single syslog server endpoint to forward logs to, in "host:port" format.
-        If not set, syslog forwarding is disabled.
-
-        For multiple endpoints, use 'syslog_endpoints' instead.
-        Note: If 'syslog_endpoints' is set, this option is ignored.
-
-        Example: "rsyslog.example.com:514"
-      type: string
     syslog_endpoints:
       description: |
-        Multiple syslog server endpoints to forward logs to, as a comma-separated list.
-        Each endpoint should be in "host:port" format.
-        All endpoints will use the same protocol and network settings (from syslog_protocol and syslog_network).
+        Syslog server endpoints to forward logs to, in YAML format.
+        Each endpoint can have different protocol, network, and TLS settings.
+        If not set, syslog forwarding is disabled.
 
-        This option takes precedence over 'syslog_endpoint' if both are set.
-        If not set, falls back to 'syslog_endpoint' for single-endpoint configuration.
+        Format (YAML list):
+          syslog_endpoints: |
+            - endpoint: rsyslog1.example.com:514
+              protocol: rfc5424  # optional, default: rfc5424
+              network: tcp       # optional, default: tcp
+              tls_enabled: false # optional, default: false
+            - endpoint: rsyslog2.example.com:6514
+              protocol: rfc5424
+              network: tcp
+              tls_enabled: true
 
-        Examples:
-          - "rsyslog1.example.com:514,rsyslog2.example.com:514"
-          - "dev-rsyslog:514,staging-rsyslog:514,prod-rsyslog:514"
-      type: string
-    syslog_protocol:
-      description: |
-        Syslog message format to use when forwarding logs.
-        - "rfc5424": Modern syslog format with structured data support (recommended)
-        - "rfc3164": Legacy BSD syslog format
+        Single endpoint example:
+          syslog_endpoints: |
+            - endpoint: rsyslog.example.com:514
+
+        Field descriptions:
+          - endpoint (required): Syslog server in "host:port" format
+          - protocol (optional): Message format - "rfc5424" (modern, recommended) or "rfc3164" (legacy BSD)
+          - network (optional): Transport protocol - "tcp" (reliable) or "udp" (faster but may lose packets)
+          - tls_enabled (optional): Enable TLS encryption (true/false)
 
         Reference: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/syslogexporter
       type: string
-      default: "rfc5424"
-    syslog_network:
-      description: |
-        Network protocol to use for syslog transmission.
-        - "tcp": Reliable, connection-oriented (recommended for security logs)
-        - "udp": Faster but may lose packets
-      type: string
-      default: "tcp"
     tls_insecure_skip_verify:
       description: |
         Flag to skip the validation of certificates from servers we connect to with TLS.

--- a/src/charm.py
+++ b/src/charm.py
@@ -374,7 +374,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
                     SERVICE_NAME: {
                         "override": "replace",
                         "summary": "opentelemetry-collector-k8s service",
-                        "command": " ".join(("/otelcol", *otelcol_args)),
+                        "command": " ".join(("/usr/bin/otelcol", *otelcol_args)),
                         "startup": "enabled",
                         "environment": {
                             "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),

--- a/src/charm.py
+++ b/src/charm.py
@@ -379,13 +379,6 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
 
         # If the config file or any cert has changed, a change in this environment variable
         # will trigger a restart
-        try:
-            container.exec(["chmod", "+x", "/otelcol"]).wait()
-        except APIError as e:
-            logger.error(f"Failed to set executable permission on /otelcol: {e}")
-            self.unit.status = BlockedStatus("Failed to set permissions on /otelcol")
-            return
-
         pebble_extra_env = {
             "_reload": ",".join(
                 [

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -298,9 +298,15 @@ class ConfigBuilder:
         """Add `tls::insecure_skip_verify` to every exporter's config.
 
         If the key already exists, the value is not updated.
+
+        Note: Excludes 'debug' and 'syslog' exporters.
+        - debug: Doesn't support TLS
+        - syslog: TLS is controlled via syslog_tls_enabled config option
         """
         for exporter in self._config.get("exporters", {}):
-            if exporter.split("/")[0] == "debug":
+            exporter_type = exporter.split("/")[0]
+            # Skip exporters that handle TLS separately or don't support it
+            if exporter_type in ("debug", "syslog"):
                 continue
             self._config["exporters"][exporter].setdefault("tls", {}).setdefault(
                 "insecure_skip_verify", insecure_skip_verify

--- a/src/constants.py
+++ b/src/constants.py
@@ -7,6 +7,7 @@ SERVER_CERT_PATH: Final[str] = (
     "/usr/local/share/ca-certificates/juju_tls-certificates/otelcol-server.crt"
 )
 SERVER_CERT_PRIVATE_KEY_PATH: Final[str] = "/etc/otelcol/private.key"
+SYSLOG_CERT_BASE_PATH: Final[str] = "/etc/otelcol/syslog/certs"
 CONFIG_PATH: Final[str] = "/etc/otelcol/config.yaml"
 SERVICE_NAME: Final[str] = "otelcol"
 METRICS_RULES_SRC_PATH: Final[str] = "src/prometheus_alert_rules"


### PR DESCRIPTION
## Summary

Adds syslog exporter functionality to the OpenTelemetry Collector K8s charm, enabling log forwarding to syslog/rsyslog endpoints. 

This feature allows charmed Kubernetes applications to send logs to SecOps infrastructure (Wazuh SIEM instances) via the standard syslog protocol.

## Changes

### New Configuration Option

Added `syslog_endpoints` config option supporting YAML-formatted endpoint list:

```yaml
syslog_endpoints: |
  - endpoint: rsyslog.example.com:514
    protocol: rfc5424    # optional, default: rfc5424
    network: tcp         # optional, default: tcp
    tls_enabled: false   # optional, default: false
  - endpoint: wazuh.secops.example.com:6514
    protocol: rfc5424
    network: tcp
    tls_enabled: true
    tls_secret: secret:abc123  # optional, for mutual TLS
    tls_skip_verify: false     # optional, default: false
```

### Features

- **Multiple endpoints**: Forward logs to multiple syslog servers simultaneously
- **Protocol support**: RFC5424 (modern) and RFC3164 (legacy BSD) formats
- **Transport options**: TCP (reliable) or UDP (lightweight)
- **TLS support**: Three modes:
  - Plaintext (tls_enabled: false)
  - Encryption-only (tls_enabled: true)
  - Mutual TLS with client certificates (tls_enabled: true + tls_secret)
- **Juju secret integration**: Client certificates retrieved securely from Juju secrets
- **OTLP field mapping**: Automatic transform processor maps standard OTLP fields to syslog exporte
r attributes
- **Standalone deployment**: Syslog-only deployments work without requiring Loki relation

## Testing

### Unit Tests

```bash
tox -e unit -- tests/unit/test_config_manager.py -v -k syslog
```

### Integration Testing

Comprehensive integration testing was performed against a real environment with the following components:
- OTEL Collector charm with custom rock (v0.143.0 + syslog exporter)
- WordPress-k8s charm as log source
- SecOps Wazuh-Dev instance (TLS-enabled syslog receiver)
- Local socat listeners (plaintext TCP/UDP receivers)

### Test Results Summary

| Test | Category | Result | Notes |
|------|----------|--------|-------|
| **A.1** | Config reload on endpoint change | ✅ PASSED | Log flow redirected within 40s, no pod restart |
| **A.2** | Blocked state on invalid config | ✅ PASSED | Clear error messages for all invalid configs |
| **A.3** | Multi-endpoint configuration | ✅ PASSED | Logs sent to 3 receivers simultaneously (TCP/TLS/UDP) |
| **B.1** | Log format & attribute mapping | ✅ PASSED | OTLP→syslog mapping verified, no data loss |
| **B.2** | Throughput & queue capacity | ⚠️ INCONCLUSIVE | Limited by test harness (~38 EPS max) |
| **C.1** | Buffer/queue during backend outage | ✅ PASSED | Zero log loss, in-order delivery after recovery |
| **C.2** | OTEL unavailability & recovery | ✅ PASSED | 2% log loss during pod destruction, normal flow after recovery |

**Overall: 6/7 tests passed, 1 inconclusive**

### Key Findings

- **Configuration Management**: Hot-reload works within 40 seconds, validation catches all tested invalid configurations
- **Data Integrity**: All OTLP attributes correctly mapped to RFC5424/RFC3164 syslog fields
- **Resilience**: Persistent queue prevents log loss during receiver outages; recovery under 30 seconds
- **Multi-endpoint**: Successfully forwards to multiple receivers with different protocols simultaneously

### Known Limitations

1. **Timestamp encoding**: Minor issue with fractional seconds containing non-ASCII character (0xEC) - does not affect functionality
2. **Throughput ceiling**: Maximum sustainable EPS not determined due to test harness limitations

## Checklist

- [x] Code follows project style guidelines
- [x] Unit tests added for new functionality
- [x] Documentation updated (config option descriptions in charmcraft.yaml)
- [x] No debug code or unnecessary comments
- [x] Tested with real syslog endpoints

## Related

- Upstream syslog exporter: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/syslogexporter
- Transform processor: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor