### PR TITLE
feat: Use the cos-lib reconciler

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,7 @@ from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
 from cosl import JujuTopology, MandatoryRelationPairs
 from cosl.reconciler import all_events, observe_events
 from lightkube.models.core_v1 import ResourceRequirements
-from ops import BlockedStatus, CharmBase, Container, StatusBase, main
+from ops import BlockedStatus, CharmBase, Container, StatusBase, ActionEvent, main
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import APIError, CheckDict, ExecDict, HttpDict, Layer
 
@@ -96,6 +96,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             self.unit.status = MaintenanceStatus("Waiting for otelcol to start")
             return
 
+        observe_events(self, [ActionEvent], self._reconcile)
         observe_events(self, all_events, self._reconcile)
 
     def _reconcile(self):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We added a reconciler, and later found out that there is [a better way to do it](https://github.com/canonical/cos-lib/blob/main/src/cosl/reconciler.py). This is needed for this tandem PR:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/173

## Solution
<!-- A summary of the solution addressing the above issue -->
Implement the `cosl` reconciler in the charm's constructor.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
