### PR TITLE
fix: Disable the sending queue in otelcol's debugexporter.

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -641,7 +641,13 @@ class ConfigManager:
             self.config.add_component(
                 Component.exporter,
                 "debug/juju-config-enabled",
-                {"verbosity": "normal", "use_internal_logger": False},
+                {
+                    "verbosity": "normal",
+                    "use_internal_logger": False,
+                    # We disable the sending_queue for now, but this is fixed upstream in rocks
+                    # >0.138.0. Remove this config once we bumped our otelcol rock.
+                    "sending_queue": {"enabled": False},
+                },
                 pipelines=[
                     f"{pipeline}/{self._unit_name}"
                     for pipeline, enabled in pipelines.items()


### PR DESCRIPTION
- [ ] Backport this into track/2

## Issue
<!-- What issue is this PR trying to solve? -->
This issue is resolved upstream in:
- https://github.com/open-telemetry/opentelemetry-collector/issues/14138

However, we cannot bump our [rock version](https://github.com/canonical/opentelemetry-collector-k8s-operator/blob/be8a92e9b7e5f750e5da9ebc39f0854d9c79f43e/charmcraft.yaml#L60) past `0.138.0` since they removed `lokiexporter` in later versions which we rely on.

## Solution
<!-- A summary of the solution addressing the above issue -->
Manually port the upstream fix into our `config_builder` charm code. This is can be removed once we are able to bump the snap version:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/201

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
