### PR TITLE
fix: overview dashboard dropdowns

### DIFF
--- a/src/grafana_dashboards/overview-dashboard.json
+++ b/src/grafana_dashboards/overview-dashboard.json
@@ -1589,7 +1589,7 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "charm: opentelemetry-collector"
+    "charm: opentelemetry-collector-k8s"
   ],
   "templating": {
     "list": [


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR implements the same fix as in this machine charm PR: https://github.com/canonical/opentelemetry-collector-operator/pull/220

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Renames the "Datasource" dropdown to be "Prometheus datasource".
2. Fixes the templating for "prometheusds".
3. Both Loki and Prometheus datasources are prepopulated where a source exists.
<img width="2135" height="1260" alt="image" src="https://github.com/user-attachments/assets/2126d0b9-2bb6-45cc-acf3-f235a3ee0c97" />

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
