### PR TITLE
fix: remove overview dashboard uid and update title

### DIFF
--- a/src/grafana_dashboards/overview-dashboard.json
+++ b/src/grafana_dashboards/overview-dashboard.json
@@ -2036,8 +2036,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "OpenTelemetry Collector",
-  "uid": "3031fb6fc42cebfa9502c30aee9969cb2c0af01e",
+  "title": "OpenTelemetry Collector K8s",
   "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Issue and Solution
<!-- What issue is this PR trying to solve? -->
This PR removes the hardcoded UID for the overview dashboard and updates the title. As a result, when there are multiple charms (for example: a K8s and a VM Otelcol charm) sending this dashboard to Grafana, the dashboards are not deduplicated.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
