### PR TITLE
fix: ensure posargs are correctly applied when running tests using tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ allowlist_externals =
 commands =
   /usr/bin/env sh -c 'stat cos-tool-amd64 > /dev/null 2>&1 || curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64 && chmod 755 cos-tool-amd64'
   uv run {[vars]uv_flags} coverage run --source={[vars]src_path},{[vars]lib_path} -m pytest \
-      {[vars]tst_path}/unit {posargs}
+      {posargs:{[vars]tst_path}/unit}
   uv run {[vars]uv_flags} coverage report
 
 [testenv:integration]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Currently, when you run `tox -e integration -- tests/integration/test_otlp.py`, the desired behaviour is that **only** that one test is executed. However, instead, this command results in the running of all integration tests files.
The same thing happens with unit tests, where we run `tox -e unit -- tests/unit/test_otlp.py` and all the unit tests file end up getting executed.

## Solution
<!-- A summary of the solution addressing the above issue -->
This change moves the positional args, which results in ONLY the file specified being run.
### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Run `tox -e integration -- tests/integration/test_otlp.py`. Only the `test_otlp` test file should run.
Run `tox -e unit -- tests/unit/test_otlp.py`. Only the `test_otlp` test file should run.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
