### PR TITLE
feat: Allow multiple tracing backends to send traces

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -135,12 +135,10 @@ requires:
       Obtain a certificate from a CA.
       The charm sends a CSR over this relation and receives a signed certificate back.
       That is the cert that would be presented to incoming TLS connections.
-  # TODO: remove limit once https://github.com/canonical/tempo-coordinator-k8s-operator/issues/168 is resolved
   send-traces:
     interface: tracing
-    limit: 1
     optional: true
-    description: Send traces to a charmed Tempo instance.
+    description: Send traces to one or more charmed Tempo instances.
   service-mesh:
     limit: 1
     interface: service_mesh

--- a/src/charm.py
+++ b/src/charm.py
@@ -279,9 +279,8 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
                 ),
                 sampling_rate_error=cast(bool, self.config.get("tracing_sampling_rate_error")),
             )
-        tracing_otlp_http_endpoint = integrations.send_traces(self)
-        if tracing_otlp_http_endpoint:
-            config_manager.add_traces_forwarding(tracing_otlp_http_endpoint)
+        for idx, endpoint in enumerate(integrations.send_traces(self)):
+            config_manager.add_traces_forwarding(endpoint, identifier=str(idx))
         integrations.send_charm_traces(self)
 
         # Dashboards setup

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -485,21 +485,22 @@ class ConfigManager:
             pipelines=[f"traces/{self._unit_name}"],
         )
 
-    def add_traces_forwarding(self, endpoint: str) -> None:
+    def add_traces_forwarding(self, endpoint: str, identifier: str) -> None:
         """Configure trace forwarding to a Tempo endpoint.
 
         Sets up an OTLP HTTP exporter to forward traces to the specified endpoint.
+        Each call must use a unique identifier so that multiple Tempo backends can
+        be wired into the traces pipeline simultaneously.
 
         Args:
             endpoint: The URL of the Tempo endpoint to forward traces to.
-
-        Note:
-            Currently, only one endpoint is supported due to limitations in the
-            Tempo charm. The exporter will be added to the 'traces' pipeline.
+            identifier: A unique string used to disambiguate the exporter name
+                (e.g. the relation ID). The exporter will be named
+                ``otlphttp/send-traces-{identifier}``.
         """
         self.config.add_component(
             Component.exporter,
-            "otlphttp/send-traces",
+            f"otlphttp/send-traces-{identifier}",
             {
                 "endpoint": endpoint,
                 **self.sending_queue_config,

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -343,11 +343,12 @@ def send_profiles(charm: CharmBase) -> List[ProfilingEndpoint]:
     ]
 
 
-def send_traces(charm: CharmBase) -> Optional[str]:
+def send_traces(charm: CharmBase) -> List[str]:
     """Integrate with Tempo via the send-traces relation endpoint.
 
     Returns:
-        The tracing OTLP HTTP endpoint if the Provider is ready, None otherwise
+        A list of OTLP HTTP endpoints for every ready ``send-traces`` relation.
+        Returns an empty list when no relation is ready.
     """
     # Enable pushing traces to a backend (i.e. Tempo) with TracingEndpointRequirer, i.e. configure the exporters
     tracing_requirer = TracingEndpointRequirer(
@@ -361,9 +362,12 @@ def send_traces(charm: CharmBase) -> Optional[str]:
     # NOTE: the name must be 'tracing' because the COS Agent library hardcodes it
     # https://github.com/canonical/grafana-agent-operator/blob/7363627f4e83b03ef179506a95b5fb411523b041/lib/charms/grafana_agent/v0/cos_agent.py#L1062
     charm.__setattr__("tracing", tracing_requirer)
-    if not tracing_requirer.is_ready():
-        return None
-    return tracing_requirer.get_endpoint("otlp_http")
+    return [
+        endpoint
+        for rel in charm.model.relations["send-traces"]
+        if tracing_requirer.is_ready(rel)
+        if (endpoint := tracing_requirer.get_endpoint("otlp_http", rel)) is not None
+    ]
 
 
 def send_charm_traces(charm: CharmBase) -> Optional[str]:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Shared helpers for integration tests."""
+
+import jubilant
+
+
+def deploy_seaweedfs(juju: jubilant.Juju, app: str, s3_requirer_app: str) -> None:
+    """Deploy seaweedfs-k8s and integrate it with the given S3-requiring app.
+
+    Args:
+        juju: The jubilant Juju instance.
+        app: The name to give the deployed seaweedfs-k8s application.
+        s3_requirer_app: The name of the app that requires the S3 relation.
+    """
+    juju.deploy("seaweedfs-k8s", app, channel="edge")
+    juju.wait(lambda status: jubilant.all_active(status, app), delay=5, timeout=600)
+    juju.integrate(f"{s3_requirer_app}:s3", f"{app}:s3-credentials")

--- a/tests/integration/test_forwarding_otlp_telemetry.py
+++ b/tests/integration/test_forwarding_otlp_telemetry.py
@@ -35,7 +35,7 @@ def test_otlp_setup(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, 
 
     # AND a `flog` which generates fake logs and sends them to the `requirer`
     juju.deploy("flog-k8s", "flog", channel="latest/edge", trust=True)
-    juju.integrate("flog", "requirer")
+    juju.integrate("flog:log-forwarder", "requirer")
 
     # AND a Grafana which sends its traces to the `requirer`
     juju.deploy("grafana-k8s", "grafana", channel="dev/edge", trust=True)

--- a/tests/integration/test_forwarding_otlp_telemetry.py
+++ b/tests/integration/test_forwarding_otlp_telemetry.py
@@ -35,7 +35,7 @@ def test_otlp_setup(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, 
 
     # AND a `flog` which generates fake logs and sends them to the `requirer`
     juju.deploy("flog-k8s", "flog", channel="latest/edge", trust=True)
-    juju.integrate("flog:log-forwarder", "requirer")
+    juju.integrate("flog:log-proxy", "requirer")
 
     # AND a Grafana which sends its traces to the `requirer`
     juju.deploy("grafana-k8s", "grafana", channel="dev/edge", trust=True)

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -26,6 +26,41 @@ async def check_traces_from_app(tempo_ip: str, app: str):
     assert traces
 
 
+def _setup_minio_bucket(
+    juju: jubilant.Juju,
+    minio_app: str,
+    s3_app: str,
+    bucket: str,
+    minio_user: str,
+    minio_pass: str,
+):
+    """Deploy minio + s3-integrator for a Tempo backend and create the bucket."""
+    juju.deploy(
+        charm="minio",
+        app=minio_app,
+        trust=True,
+        config={"access-key": minio_user, "secret-key": minio_pass},
+    )
+    juju.deploy(charm="s3-integrator", app=s3_app, channel="edge")
+    juju.wait(lambda status: jubilant.all_active(status, minio_app), delay=5)
+    minio_address = juju.status().apps[minio_app].units[f"{minio_app}/0"].address
+    minio_client: Minio = Minio(
+        f"{minio_address}:9000",
+        access_key=minio_user,
+        secret_key=minio_pass,
+        secure=False,
+    )
+    if not minio_client.bucket_exists(bucket):
+        minio_client.make_bucket(bucket)
+    juju.config(s3_app, {"endpoint": f"{minio_address}:9000", "bucket": bucket})
+    juju.run(
+        unit=f"{s3_app}/0",
+        action="sync-s3-credentials",
+        params={"access-key": minio_user, "secret-key": minio_pass},
+    )
+    return minio_address
+
+
 async def test_traces_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: traces ingestion and forwarding."""
     minio_user = "accesskey"
@@ -42,29 +77,13 @@ async def test_traces_pipeline(juju: jubilant.Juju, charm: str, charm_resources:
     juju.deploy(charm="grafana-k8s", app="grafana", channel="2/edge", trust=True)
     juju.deploy(charm="tempo-coordinator-k8s", app="tempo", channel="2/edge", trust=True)
     juju.deploy(charm="tempo-worker-k8s", app="tempo-worker", channel="2/edge", trust=True)
-    # Set up minio and s3-integrator
-    juju.deploy(
-        charm="minio",
-        app="minio-tempo",
-        trust=True,
-        config={"access-key": minio_user, "secret-key": minio_pass},
-    )
-    juju.deploy(charm="s3-integrator", app="s3-tempo", channel="edge")
-    juju.wait(lambda status: jubilant.all_active(status, "minio-tempo"), delay=5)
-    minio_address = juju.status().apps["minio-tempo"].units["minio-tempo/0"].address
-    minio_client: Minio = Minio(
-        f"{minio_address}:9000",
-        access_key=minio_user,
-        secret_key=minio_pass,
-        secure=False,
-    )
-    if not minio_client.bucket_exists(minio_bucket):
-        minio_client.make_bucket(minio_bucket)
-    juju.config("s3-tempo", {"endpoint": f"{minio_address}:9000", "bucket": minio_bucket})
-    juju.run(
-        unit="s3-tempo/0",
-        action="sync-s3-credentials",
-        params={"access-key": minio_user, "secret-key": minio_pass},
+    _setup_minio_bucket(
+        juju,
+        minio_app="minio-tempo",
+        s3_app="s3-tempo",
+        bucket=minio_bucket,
+        minio_user=minio_user,
+        minio_pass=minio_pass,
     )
     juju.integrate("tempo:s3", "s3-tempo")
     juju.integrate("tempo:tempo-cluster", "tempo-worker")
@@ -92,6 +111,44 @@ async def test_traces_pipeline(juju: jubilant.Juju, charm: str, charm_resources:
     await check_traces_from_app(tempo_ip=tempo_ip, app="grafana")
 
 
+async def test_traces_multiple_backends(
+    juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
+):
+    """Scenario: traces are forwarded to two Tempo backends simultaneously."""
+    minio_user = "accesskey"
+    minio_pass = "secretkey"
+
+    # GIVEN a second Tempo stack is deployed
+    juju.deploy(charm="tempo-coordinator-k8s", app="tempo2", channel="2/edge", trust=True)
+    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker2", channel="2/edge", trust=True)
+    _setup_minio_bucket(
+        juju,
+        minio_app="minio-tempo2",
+        s3_app="s3-tempo2",
+        bucket="tempo2",
+        minio_user=minio_user,
+        minio_pass=minio_pass,
+    )
+    juju.integrate("tempo2:s3", "s3-tempo2")
+    juju.integrate("tempo2:tempo-cluster", "tempo-worker2")
+    juju.wait(lambda status: jubilant.all_active(status, "tempo2"), delay=10, timeout=900)
+
+    # WHEN both Tempo backends are related to otelcol via send-traces
+    # (otelcol:send-traces is already related to tempo from the previous test)
+    juju.integrate("otelcol:send-traces", "tempo2:tracing")
+    juju.wait(jubilant.all_active, delay=10, timeout=900)
+
+    # THEN traces produced by grafana arrive in both Tempo backends
+    tempo_ip = juju.status().apps["tempo"].units["tempo/0"].address
+    tempo2_ip = juju.status().apps["tempo2"].units["tempo2/0"].address
+    await check_traces_from_app(tempo_ip=tempo_ip, app="grafana")
+    await check_traces_from_app(tempo_ip=tempo2_ip, app="grafana")
+
+    # WHEN one send-traces relation is removed
+    juju.remove_relation("otelcol:send-traces", "tempo2:tracing")
+    juju.wait(jubilant.all_active, delay=10, timeout=600)
+
+
 # https://github.com/canonical/cos-coordinated-workers/pull/8
 # Before removing the 'skip', check the 'uv.lock' in Tempo Coordinator
 # to make sure it's actually using the fixed library
@@ -116,3 +173,4 @@ async def test_traces_with_tls(juju: jubilant.Juju):
     # THEN traces arrive in tempo
     tempo_ip = juju.status().apps["tempo"].units["tempo/0"].address
     await check_traces_from_app(tempo_ip=tempo_ip, app="coconut")
+

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -4,13 +4,14 @@
 """Feature: Ingested traces are pushed to Tempo."""
 
 import json
-from minio import Minio
 from typing import Dict
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_exception_type
 from requests import request
 import pytest
 
 import jubilant
+
+from helpers import deploy_seaweedfs
 
 
 @retry(
@@ -26,47 +27,8 @@ async def check_traces_from_app(tempo_ip: str, app: str):
     assert traces
 
 
-def _setup_minio_bucket(
-    juju: jubilant.Juju,
-    minio_app: str,
-    s3_app: str,
-    bucket: str,
-    minio_user: str,
-    minio_pass: str,
-):
-    """Deploy minio + s3-integrator for a Tempo backend and create the bucket."""
-    juju.deploy(
-        charm="minio",
-        app=minio_app,
-        trust=True,
-        config={"access-key": minio_user, "secret-key": minio_pass},
-    )
-    juju.deploy(charm="s3-integrator", app=s3_app, channel="edge")
-    juju.wait(lambda status: jubilant.all_active(status, minio_app), delay=5)
-    minio_address = juju.status().apps[minio_app].units[f"{minio_app}/0"].address
-    minio_client: Minio = Minio(
-        f"{minio_address}:9000",
-        access_key=minio_user,
-        secret_key=minio_pass,
-        secure=False,
-    )
-    if not minio_client.bucket_exists(bucket):
-        minio_client.make_bucket(bucket)
-    juju.config(s3_app, {"endpoint": f"{minio_address}:9000", "bucket": bucket})
-    juju.run(
-        unit=f"{s3_app}/0",
-        action="sync-s3-credentials",
-        params={"access-key": minio_user, "secret-key": minio_pass},
-    )
-    return minio_address
-
-
 async def test_traces_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: traces ingestion and forwarding."""
-    minio_user = "accesskey"
-    minio_pass = "secretkey"
-    minio_bucket = "tempo"
-
     # GIVEN a model with grafana, otel-collector, and tempo charms
     juju.deploy(
         charm=charm,
@@ -77,15 +39,7 @@ async def test_traces_pipeline(juju: jubilant.Juju, charm: str, charm_resources:
     juju.deploy(charm="grafana-k8s", app="grafana", channel="2/edge", trust=True)
     juju.deploy(charm="tempo-coordinator-k8s", app="tempo", channel="2/edge", trust=True)
     juju.deploy(charm="tempo-worker-k8s", app="tempo-worker", channel="2/edge", trust=True)
-    _setup_minio_bucket(
-        juju,
-        minio_app="minio-tempo",
-        s3_app="s3-tempo",
-        bucket=minio_bucket,
-        minio_user=minio_user,
-        minio_pass=minio_pass,
-    )
-    juju.integrate("tempo:s3", "s3-tempo")
+    deploy_seaweedfs(juju, app="seaweedfs-tempo", s3_requirer_app="tempo")
     juju.integrate("tempo:tempo-cluster", "tempo-worker")
     # WHEN we add relations to send charm traces to tempo
     juju.integrate("otelcol:send-charm-traces", "tempo:tracing")
@@ -115,21 +69,10 @@ async def test_traces_multiple_backends(
     juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
 ):
     """Scenario: traces are forwarded to two Tempo backends simultaneously."""
-    minio_user = "accesskey"
-    minio_pass = "secretkey"
-
     # GIVEN a second Tempo stack is deployed
     juju.deploy(charm="tempo-coordinator-k8s", app="tempo2", channel="2/edge", trust=True)
     juju.deploy(charm="tempo-worker-k8s", app="tempo-worker2", channel="2/edge", trust=True)
-    _setup_minio_bucket(
-        juju,
-        minio_app="minio-tempo2",
-        s3_app="s3-tempo2",
-        bucket="tempo2",
-        minio_user=minio_user,
-        minio_pass=minio_pass,
-    )
-    juju.integrate("tempo2:s3", "s3-tempo2")
+    deploy_seaweedfs(juju, app="seaweedfs-tempo2", s3_requirer_app="tempo2")
     juju.integrate("tempo2:tempo-cluster", "tempo-worker2")
     juju.wait(lambda status: jubilant.all_active(status, "tempo2"), delay=10, timeout=900)
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -139,7 +139,7 @@ def test_add_traces_forwarding():
         insecure_skip_verify=True,
     )
 
-    # WHEN a traces exporter is added to the config
+    # WHEN a single traces exporter is added to the config
     expected_traces_forwarding_cfg = {
         "endpoint": "http://192.168.1.244:4318",
         "retry_on_failure": {
@@ -149,13 +149,49 @@ def test_add_traces_forwarding():
     }
     config_manager.add_traces_forwarding(
         endpoint="http://192.168.1.244:4318",
+        identifier="0",
     )
-    # THEN it exists in the traces exporter config
+    # THEN it exists in the traces exporter config under a uniquely named key
     config = dict(
-        sorted(config_manager.config._config["exporters"]["otlphttp/send-traces"].items())
+        sorted(config_manager.config._config["exporters"]["otlphttp/send-traces-0"].items())
     )
     expected_config = dict(sorted(expected_traces_forwarding_cfg.items()))
     assert config == expected_config
+
+
+def test_add_traces_forwarding_multiple_endpoints():
+    # GIVEN an empty config
+    config_manager = ConfigManager(
+        unit_name="otelcol/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        insecure_skip_verify=True,
+    )
+
+    # WHEN two traces exporters are added to the config (one per Tempo backend)
+    config_manager.add_traces_forwarding(
+        endpoint="http://tempo1.example.com:4318",
+        identifier="0",
+    )
+    config_manager.add_traces_forwarding(
+        endpoint="http://tempo2.example.com:4318",
+        identifier="1",
+    )
+
+    exporters = config_manager.config._config["exporters"]
+
+    # THEN two distinct exporters exist
+    assert "otlphttp/send-traces-0" in exporters
+    assert "otlphttp/send-traces-1" in exporters
+    assert exporters["otlphttp/send-traces-0"]["endpoint"] == "http://tempo1.example.com:4318"
+    assert exporters["otlphttp/send-traces-1"]["endpoint"] == "http://tempo2.example.com:4318"
+
+    # AND both exporters are wired into the traces pipeline
+    pipeline_exporters = config_manager.config._config["service"]["pipelines"][
+        "traces/otelcol/0"
+    ]["exporters"]
+    assert "otlphttp/send-traces-0" in pipeline_exporters
+    assert "otlphttp/send-traces-1" in pipeline_exporters
 
 
 def test_add_remote_write():

--- a/tests/unit/test_relational_config.py
+++ b/tests/unit/test_relational_config.py
@@ -203,8 +203,61 @@ def test_traces_exporters(ctx, otelcol_container):
     state_out: State = ctx.run(ctx.on.update_status(), state_in)
     # THEN the config file exists and the pebble service is running
     cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
-    # AND the exporters for tracing exists in the config
-    expected_exporters = {"otlphttp/send-traces"}
-    assert expected_exporters.issubset(set(cfg["exporters"].keys()))
+    # AND exactly one otlphttp/send-traces-* exporter exists in the config
+    send_traces_exporters = [k for k in cfg["exporters"] if k.startswith("otlphttp/send-traces-")]
+    assert len(send_traces_exporters) == 1
+    # AND the pipelines are valid
+    check_valid_pipelines(cfg)
+
+
+def test_traces_exporters_multiple_backends(ctx, otelcol_container):
+    """Scenario: Fan-out tracing architecture to multiple Tempo backends."""
+    # GIVEN two simultaneous send-traces relations (one per Tempo instance)
+    receivers_tempo1 = json.dumps(
+        [
+            {
+                "protocol": {"name": "otlp_http", "type": "http"},
+                "url": "http://tempo1.svc.cluster.local:4318",
+            },
+        ]
+    )
+    receivers_tempo2 = json.dumps(
+        [
+            {
+                "protocol": {"name": "otlp_http", "type": "http"},
+                "url": "http://tempo2.svc.cluster.local:4318",
+            },
+        ]
+    )
+    local_app_data = {"receivers": json.dumps(["otlp_http"])}
+    tempo1_relation = Relation(
+        endpoint="send-traces",
+        interface="tracing",
+        remote_app_data={"receivers": receivers_tempo1},
+        local_app_data=local_app_data,
+    )
+    tempo2_relation = Relation(
+        endpoint="send-traces",
+        interface="tracing",
+        remote_app_data={"receivers": receivers_tempo2},
+        local_app_data=local_app_data,
+    )
+    state_in = State(
+        relations=[tempo1_relation, tempo2_relation],
+        containers=otelcol_container,
+    )
+    # WHEN any event executes the reconciler
+    state_out: State = ctx.run(ctx.on.update_status(), state_in)
+    # THEN the config file exists and the pebble service is running
+    cfg = get_otelcol_file(state_out, ctx, CONFIG_PATH)
+    # AND two distinct otlphttp/send-traces-* exporters exist — one per backend
+    send_traces_exporters = [k for k in cfg["exporters"] if k.startswith("otlphttp/send-traces-")]
+    assert len(send_traces_exporters) == 2
+    # AND both exporters are wired into the traces pipeline
+    pipeline_exporters = cfg["service"]["pipelines"]["traces/opentelemetry-collector-k8s/0"][
+        "exporters"
+    ]
+    for exporter_name in send_traces_exporters:
+        assert exporter_name in pipeline_exporters
     # AND the pipelines are valid
     check_valid_pipelines(cfg)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The `send-traces` endpoint had an unnecessary `limit: 1`. It isn't because of any reasonable restrictions: opentelemetry-collector can send traces to more than one backend.

## Solution
<!-- A summary of the solution addressing the above issue -->
Drop `limit: 1` and make sure all the backends get the traces.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
We did not touch the `send-charm-traces` endpoint because it's responsible for sending otel-collector's own charm traces. `ops[tracing]` does not allow for more than 1 destination for the charm traces so I think in these cases, we would need to send them to another collector that will propagate them to two destinations.

Although we will consider retiring the interface in future, given the near LTS, we want to make sure there's enough support for multiple tracing backends in the current charms.

Contributes to solving https://github.com/canonical/tempo-operators/issues/36 .

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
The integration tests should cover the testing part.

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
