### PR TITLE
fix: No metric normalization in prometheus components

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -105,12 +105,7 @@ requires:
   metrics-endpoint:
     interface: prometheus_scrape
     optional: true
-    description: |
-      To scrape other charms' metrics endpoints.
-
-      The prometheus receiver config has ``trim_metric_suffixes`` set to
-      ``true`` to restore the original metric names used in OpenTelemetry
-      instrumentation. This maintains parity with grafana-agent.
+    description: To scrape other charms' metrics endpoints.
   send-remote-write:
     interface: prometheus_remote_write
     optional: true

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -109,7 +109,13 @@ requires:
   send-remote-write:
     interface: prometheus_remote_write
     optional: true
-    description: To forward collected metrics to a Prometheus backend.
+    description: |
+      To forward collected metrics to a Prometheus backend.
+
+      The remote write exporter config has ``add_metric_suffixes`` set to
+      ``false`` to not add suffixes to metric names based on the type of the
+      metric (e.g. _total for counters). This is to maintain parity with
+      grafana-agent, and will eventually be deprecated.
   send-loki-logs:
     interface: loki_push_api
     optional: true

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -105,17 +105,21 @@ requires:
   metrics-endpoint:
     interface: prometheus_scrape
     optional: true
-    description: To scrape other charms' metrics endpoints.
+    description: |
+      To scrape other charms' metrics endpoints.
+
+      The prometheus receiver config has ``trim_metric_suffixes`` set to
+      ``true`` to restore the original metric names used in OpenTelemetry
+      instrumentation. This maintains parity with grafana-agent.
   send-remote-write:
     interface: prometheus_remote_write
     optional: true
     description: |
       To forward collected metrics to a Prometheus backend.
 
-      The remote write exporter config has ``add_metric_suffixes`` set to
-      ``false`` to not add suffixes to metric names based on the type of the
-      metric (e.g. _total for counters). This is to maintain parity with
-      grafana-agent, and will eventually be deprecated.
+      The prometheus receiver config has ``trim_metric_suffixes`` set to
+      ``true`` to restore the original metric names used in OpenTelemetry
+      instrumentation. This maintains parity with grafana-agent.
   send-loki-logs:
     interface: loki_push_api
     optional: true

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -350,7 +350,10 @@ class ConfigManager:
         self.config.add_component(
             Component.receiver,
             f"prometheus/metrics-endpoint/{self._unit_name}",
-            config={"config": {"scrape_configs": jobs}},
+            config={
+                "config": {"scrape_configs": jobs},
+                "trim_metric_suffixes": True,
+            },
             pipelines=[f"metrics/{self._unit_name}"],
         )
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -350,10 +350,7 @@ class ConfigManager:
         self.config.add_component(
             Component.receiver,
             f"prometheus/metrics-endpoint/{self._unit_name}",
-            config={
-                "config": {"scrape_configs": jobs},
-                "trim_metric_suffixes": True,
-            },
+            config={"config": {"scrape_configs": jobs}},
             pipelines=[f"metrics/{self._unit_name}"],
         )
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -364,6 +364,7 @@ class ConfigManager:
                 {
                     "endpoint": endpoint["url"],
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
+                    "add_metric_suffixes": False,
                     **self.prometheus_remotewrite_wal_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -170,6 +170,7 @@ def test_add_remote_write():
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {
         "endpoint": "http://192.168.1.244/cos-prometheus-0/api/v1/write",
+        "add_metric_suffixes": False,
         "tls": {
             "insecure_skip_verify": True,
         },

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -40,8 +40,7 @@ def test_add_prometheus_scrape():
                     "tls_config": {"insecure_skip_verify": True},
                 },
             ],
-        },
-        "trim_metric_suffixes": True,
+        }
     }
     config_manager.add_prometheus_scrape_jobs(first_job)
     # THEN it exists in the prometheus receiver config

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -40,7 +40,8 @@ def test_add_prometheus_scrape():
                     "tls_config": {"insecure_skip_verify": True},
                 },
             ],
-        }
+        },
+        "trim_metric_suffixes": True,
     }
     config_manager.add_prometheus_scrape_jobs(first_job)
     # THEN it exists in the prometheus receiver config


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Resolves partially https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/232

Relates to:
- https://github.com/canonical/opentelemetry-collector-operator/pull/247

## Solution
<!-- A summary of the solution addressing the above issue -->
- [ ] We need to backport this into track/2

We want to be able to maintain parity with Grafana-agent, which did not normalize metrics to a new Otel standard. This is [a simple config in the Prometheus Remote Write exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b41f28058ad1559acb63a7261793b4e6968b0109/exporter/prometheusremotewriteexporter/config.schema.yaml#L37-L39) to disable this and [one in the Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/4a3eb63725150d9e47e357d526f94c9aeedb4941/receiver/prometheusreceiver/config.schema.yaml#L24).

> [!WARNING]
> We need to be aware that we are deviating from the upstream's direction. Our prometheus receivers and remote write exporters will always maintain parity with grafana-agent and by steering our users towards send|receive-otlp integrations, we can get away from this tech debt.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
DP says that they have some contracts with 10y support for Grafana-agent.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

- [ ] Convert into itest?
<img width="697" height="273" alt="image" src="https://github.com/user-attachments/assets/0f5c5cd7-41b8-4bd1-a959-28564e653c40" />

### K8s charm remote writes
Choose a metric from this PR:
- https://github.com/canonical/postgresql-k8s-operator/pull/1285/changes

and ensure that the `_total` suffix does not exist with PRW relation.

Checking the otelcol-vm pipeline:
```
sudo snap logs -f opentelemetry-collector | grep pg_stat_database
pg_stat_database_tup_fetched{datid=1,datname=template1,juju_application=postgresql,juju_model=psql,juju_model_uuid=a2aa5afd-228a-4ea7-8d64-24fbf7209932,juju_unit=postgresql/0,server=/tmp:5432} 0
```
Checking the otelcol-k8s pipeline:
```
jssh --container otelcol otelcol/0 "pebble logs -f" | grep "juju_application=postgresql"
pg_stat_database_tup_fetched{datid=14429,datname=postgres,juju_application=postgresql,juju_model=psql,juju_model_uuid=a2aa5afd-228a-4ea7-8d64-24fbf7209932,juju_unit=postgresql/0,server=/tmp:5432} 15996
```
where we see that the suffix was there originally, and after refreshing the charm, it no longer exists:
<img width="1069" height="352" alt="image" src="https://github.com/user-attachments/assets/d41947ce-4fd1-4587-861f-2fbdafbd71f4" />

### VM charm remote writes
When we also relate the VM charm to Mimir via remote-write, the total suffix is not appended to the metric.
<img width="768" height="360" alt="image" src="https://github.com/user-attachments/assets/515ba5a7-7ff9-47a6-9a98-e1ee436cd4bf" />

### Bundles
LXD model:
```yaml
default-base: ubuntu@22.04/stable
saas:
  otlp:
    url: k8s:admin/mimir-standalone.otelcol
  prw:
    url: k8s:admin/mimir-standalone.prw
applications:
  otelcol:
    charm: local:opentelemetry-collector-0
    options:
      debug_exporter_for_metrics: true
    trust: true
  postgresql:
    charm: postgresql
    channel: 14/stable
    revision: 1045
    num_units: 2
    to:
    - "0"
    - "1"
    constraints: arch=amd64
    storage:
      pgdata: rootfs,1,1024M
machines:
  "0":
    constraints: arch=amd64
  "1":
    constraints: arch=amd64
relations:
- - otelcol:cos-agent
  - postgresql:cos-agent
- - otelcol:send-remote-write
  - prw:receive-remote-write
```
K8s model:
```yaml
bundle: kubernetes
saas:
  remote-acfd61fe6afd4cb08258be74133952d9: {}
applications:
  grafana:
    charm: grafana-k8s
    channel: 2/stable
    revision: 180
    resources:
      grafana-image: 77
      litestream-image: 46
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  mimir:
    charm: mimir-coordinator-k8s
    channel: 2/stable
    revision: 77
    resources:
      nginx-image: 15
      nginx-prometheus-exporter-image: 4
    scale: 1
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=mimir,anti-pod.topology-key=kubernetes.io/hostname
    trust: true
  mimir-backend:
    charm: mimir-worker-k8s
    channel: 2/stable
    revision: 58
    resources:
      mimir-image: 16
    scale: 1
    options:
      role-backend: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=mimir-backend,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  mimir-read:
    charm: mimir-worker-k8s
    channel: 2/stable
    revision: 58
    resources:
      mimir-image: 16
    scale: 1
    options:
      role-read: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=mimir-read,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  mimir-s3-integrator:
    charm: s3-integrator
    channel: 2/edge
    revision: 536
    scale: 1
    options:
      bucket: mimir
      credentials: secret:dpe6udftanu30oil8iu0
      endpoint: http://10.1.0.178:8333
    constraints: arch=amd64
    trust: true
  mimir-write:
    charm: mimir-worker-k8s
    channel: 2/stable
    revision: 58
    resources:
      mimir-image: 16
    scale: 1
    options:
      role-write: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=mimir-write,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  otelcol:
    charm: local:opentelemetry-collector-k8s-1
    resources:
      opentelemetry-collector-image: 9
    scale: 1
    options:
      debug_exporter_for_metrics: true
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/stable
    revision: 281
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 162
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - mimir:s3
  - mimir-s3-integrator:s3-credentials
- - mimir:mimir-cluster
  - mimir-backend:mimir-cluster
- - mimir:mimir-cluster
  - mimir-write:mimir-cluster
- - mimir:ingress
  - traefik:ingress
- - mimir:mimir-cluster
  - mimir-read:mimir-cluster
- - otelcol:send-remote-write
  - mimir:receive-remote-write
- - mimir:grafana-source
  - grafana:grafana-source
- - traefik:traefik-route
  - grafana:ingress
- - traefik:traefik-route
  - otelcol:ingress
- - mimir:receive-remote-write
  - remote-acfd61fe6afd4cb08258be74133952d9:send-remote-write
--- # overlay.yaml
applications:
  mimir:
    offers:
      prw:
        endpoints:
        - receive-remote-write
        acl:
          admin: admin
  otelcol:
    offers:
      otelcol:
        endpoints:
        - receive-otlp
        acl:
          admin: admin
```

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
Any queries|dashboards that were created prior to adopting the otelcol charm and expecting the e.g., `_total` suffix (among other suffixes) need to be updated because we have disabled this in the `send-remote-write` integration.