### PR TITLE
fix(track/2): No metric normalization in prometheus components

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -101,7 +101,12 @@ requires:
   send-remote-write:
     interface: prometheus_remote_write
     optional: true
-    description: To forward collected metrics to a Prometheus backend.
+    description: |
+      To forward collected metrics to a Prometheus backend.
+
+      The prometheus receiver config has ``trim_metric_suffixes`` set to
+      ``true`` to restore the original metric names used in OpenTelemetry
+      instrumentation. This maintains parity with grafana-agent.
   send-loki-logs:
     interface: loki_push_api
     optional: true

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -362,6 +362,7 @@ class ConfigManager:
                 {
                     "endpoint": endpoint["url"],
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
+                    "add_metric_suffixes": False,
                     **self.prometheus_remotewrite_wal_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -148,6 +148,7 @@ def test_add_remote_write():
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {
         "endpoint": "http://192.168.1.244/cos-prometheus-0/api/v1/write",
+        "add_metric_suffixes": False,
         "tls": {
             "insecure_skip_verify": True,
         },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Same as:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/238

but backport into track/2.

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
Any queries|dashboards that were created prior to adopting the otelcol charm and expecting the e.g., `_total` suffix (among other suffixes) need to be updated because we have disabled this in the `send-remote-write` integration.