### PR TITLE
fix: adds a preset pytest flag for itests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,6 +18,25 @@ import jubilant
 
 logger = logging.getLogger(__name__)
 
+VALID_PRESETS = ("microk8s", "ck8s")
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--preset",
+        action="store",
+        default="microk8s",  # defaults to microk8s as CI runs on microk8s at the moment.
+        choices=VALID_PRESETS,
+        help="Substrate preset for substrate-specific test configuration. "
+        f"Valid values: {', '.join(VALID_PRESETS)}",
+    )
+
+
+@pytest.fixture(scope="session")
+def preset(request) -> str:
+    """Return the substrate preset (default: microk8s)."""
+    return request.config.getoption("--preset")
+
 store = defaultdict(str)
 
 

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -171,23 +171,36 @@ def test_remove_traefik_ingress(juju: jubilant.Juju):
     )
 
 
-def test_integrate_istio_ingress(juju: jubilant.Juju):
+def test_integrate_istio_ingress(juju: jubilant.Juju, preset: str):
     # GIVEN otelcol is not ingressed
     # WHEN Istio applications are deployed
     juju.deploy("istio-ingress-k8s", channel="dev/edge", trust=True)
     juju.deploy("istio-k8s", channel="dev/edge", trust=True)
 
-    # For devs using Canonical Kubernetes, set `juju config istio-k8s platform=""`
-    # https://canonical-service-mesh-documentation.readthedocs-hosted.com/latest/how-to/use-charmed-istio-with-canonical-kubernetes/
+    if preset == "ck8s":
+        # https://canonical-service-mesh-documentation.readthedocs-hosted.com/latest/how-to/use-charmed-istio-with-canonical-kubernetes/
+        juju.config("istio-k8s", {"platform": ""})
 
     # AND integrated with otelcol
     juju.integrate("otelcol:istio-ingress", "istio-ingress-k8s:istio-ingress-route")
-    juju.wait(
-        lambda status: jubilant.all_active(
-            status, "istio-k8s", "istio-ingress-k8s", "otelcol-push"
-        ),
-        timeout=300,
-    )
+    try:
+        juju.wait(
+            lambda status: jubilant.all_active(
+                status, "istio-k8s", "istio-ingress-k8s", "otelcol-push"
+            ),
+            timeout=300,
+        )
+    except TimeoutError:
+        status = juju.status()
+        for unit in status.apps["istio-k8s"].units.values():
+            if "platform mismatch" in unit.workload_status.message.lower():
+                raise AssertionError(
+                    f"istio-k8s unit reports: '{unit.workload_status.message}'. "
+                    "If running on Canonical Kubernetes, re-run with the following pytest flag: "
+                    "--preset ck8s"
+                ) from None
+        raise
+
     juju.wait(
         lambda status: jubilant.all_blocked(status, "otelcol"),
         timeout=300,


### PR DESCRIPTION
## Issue
The `istio-k8s` charm used for service-mesh and ingress integrations, has a substrate specific configuration. This makes running the same test for different substrates locally painful.

## Solution
This PR addresses this by adding `--preset` flag to pytest. The preset defaults to microk8s at the moment since thats the CI default.

We arent auto-detecting because 

- its an unwanted moving part and added maintenance burden and 
- more importantly especially for service-mesh security features this setting needs to be intentional. CK8s with cilium can, without proper configuration, bypass service mesh entirely for example giving a false positive.
- Explicit is better than implicit magic 

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Testing Instructions
Run the ingress test for example on CK8s using

```sh
tox -e integration -- -k test_ingress.py --preset ck8s
```


## Upgrade Notes
-
