### PR TITLE
feat: Custom component ID

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -675,9 +675,7 @@ class ConfigManager:
 
             for config_type, config in config_block.items():
                 if config_type not in Component:
-                    logger.warning(
-                        "wrong component type '%s' in external config, skipping", config_type
-                    )
+                    logger.warning("wrong component type '%s' in external config, skipping", config_type)
                     continue
 
                 for name, cnf in config.items():
@@ -686,11 +684,6 @@ class ConfigManager:
                         Component(config_type),
                         comp_name,
                         cnf,
-                        pipelines=[
-                            f"{getattr(p, 'value', p)}/{self._unit_name}"
-                            for p in configs["pipelines"]
-                        ],
+                        pipelines=[f"{getattr(p, 'value', p)}/{self._unit_name}" for p in configs["pipelines"]],
                     )
-                    logger.debug(
-                        "component type: '%s', name: '%s' added to config", config_type, comp_name
-                    )
+                    logger.debug("component type: '%s', name: '%s' added to config", config_type, comp_name)

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -4,11 +4,11 @@ import logging
 from typing import Any, Dict, List, Literal, Optional, Set
 
 import yaml
+from charmlibs.interfaces.otlp import OtlpEndpoint
 
 from config_builder import Component, ConfigBuilder, Port
-from constants import FILE_STORAGE_DIRECTORY
+from constants import CUSTOM_COMPONENT_ID, FILE_STORAGE_DIRECTORY
 from integrations import ProfilingEndpoint
-from charmlibs.interfaces.otlp import OtlpEndpoint
 
 logger = logging.getLogger(__name__)
 
@@ -589,7 +589,7 @@ class ConfigManager:
         for processor_name, processor_config in yaml.safe_load(processors_raw).items():
             self.config.add_component(
                 Component.processor,
-                f"{processor_name}/{self._unit_name}/_custom",
+                f"{processor_name}/{self._unit_name}/{CUSTOM_COMPONENT_ID}",
                 processor_config,
                 pipelines=[
                     f"metrics/{self._unit_name}",
@@ -675,7 +675,9 @@ class ConfigManager:
 
             for config_type, config in config_block.items():
                 if config_type not in Component:
-                    logger.warning("wrong component type '%s' in external config, skipping", config_type)
+                    logger.warning(
+                        "wrong component type '%s' in external config, skipping", config_type
+                    )
                     continue
 
                 for name, cnf in config.items():
@@ -684,6 +686,11 @@ class ConfigManager:
                         Component(config_type),
                         comp_name,
                         cnf,
-                        pipelines=[f"{getattr(p, 'value', p)}/{self._unit_name}" for p in configs["pipelines"]],
+                        pipelines=[
+                            f"{getattr(p, 'value', p)}/{self._unit_name}"
+                            for p in configs["pipelines"]
+                        ],
                     )
-                    logger.debug("component type: '%s', name: '%s' added to config", config_type, comp_name)
+                    logger.debug(
+                        "component type: '%s', name: '%s' added to config", config_type, comp_name
+                    )

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,6 +2,8 @@
 
 from typing import Final
 
+SERVICE_NAME: Final[str] = "otelcol"
+CUSTOM_COMPONENT_ID: Final[str] = "_custom"
 RECV_CA_CERT_FOLDER_PATH: Final[str] = "/usr/local/share/ca-certificates/juju_receive-ca-cert"
 SERVER_CA_CERT_PATH: Final[str] = (
     "/usr/local/share/ca-certificates/juju_receive-ca-cert/cos-ca.crt"
@@ -9,7 +11,6 @@ SERVER_CA_CERT_PATH: Final[str] = (
 SERVER_CERT_PATH: Final[str] = "/etc/otelcol/otelcol-server-cert.crt"
 SERVER_CERT_PRIVATE_KEY_PATH: Final[str] = "/etc/otelcol/otelcol-private-key.key"
 CONFIG_PATH: Final[str] = "/etc/otelcol/config.yaml"
-SERVICE_NAME: Final[str] = "otelcol"
 METRICS_RULES_SRC_PATH: Final[str] = "src/prometheus_alert_rules"
 METRICS_RULES_DEST_PATH: Final[str] = "prometheus_alert_rules"
 LOKI_RULES_SRC_PATH: Final[str] = "src/loki_alert_rules"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
To maintain parity with the VM charm gaining this feature:
- https://github.com/canonical/opentelemetry-collector-operator/pull/251

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Use the constant to identify custom (user-defined) components in the config.
2. Formatting clean-up