### PR TITLE
chore: xFail traefik ingress itests

### DIFF
--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -6,10 +6,12 @@
 import json
 import logging
 import time
+from datetime import date
 from typing import Dict
 from urllib.request import Request, urlopen
 
 import jubilant
+import pytest
 import sh
 import yaml
 
@@ -102,6 +104,8 @@ def push_otlp_logs_through_ingress(juju: jubilant.Juju, ingress_app: str):
     assert IDENTIFIER in logs_pipeline
 
 
+# https://warthogs.atlassian.net/browse/OBC-2053
+@pytest.mark.xfail(date.today() < date(2026, 6, 8), reason="expected to fail until 2026-06-08", strict=True)
 def test_health_through_traefik_ingress(
     juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
 ):
@@ -119,6 +123,8 @@ def test_health_through_traefik_ingress(
     health_check_reachable_via_ingress(juju, "traefik")
 
 
+# https://warthogs.atlassian.net/browse/OBC-2053
+@pytest.mark.xfail(date.today() < date(2026, 6, 8), reason="expected to fail until 2026-06-08", strict=True)
 def test_push_logs_through_traefik_ingress(
     juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
 ):
@@ -144,6 +150,8 @@ def test_push_logs_through_traefik_ingress(
     push_logs_through_ingress(juju, "traefik")
 
 
+# https://warthogs.atlassian.net/browse/OBC-2053
+@pytest.mark.xfail(date.today() < date(2026, 6, 8), reason="expected to fail until 2026-06-08", strict=True)
 def test_push_otlp_logs_through_traefik_ingress(juju: jubilant.Juju):
     """Scenario: receive OTLP logs via the otlp_http receiver through ingress."""
     # GIVEN a model with otel-collector and traefik

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -123,8 +123,6 @@ def test_health_through_traefik_ingress(
     health_check_reachable_via_ingress(juju, "traefik")
 
 
-# https://warthogs.atlassian.net/browse/OBC-2053
-@pytest.mark.xfail(date.today() < date(2026, 6, 8), reason="expected to fail until 2026-06-08", strict=True)
 def test_push_logs_through_traefik_ingress(
     juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
 ):
@@ -150,8 +148,6 @@ def test_push_logs_through_traefik_ingress(
     push_logs_through_ingress(juju, "traefik")
 
 
-# https://warthogs.atlassian.net/browse/OBC-2053
-@pytest.mark.xfail(date.today() < date(2026, 6, 8), reason="expected to fail until 2026-06-08", strict=True)
 def test_push_otlp_logs_through_traefik_ingress(juju: jubilant.Juju):
     """Scenario: receive OTLP logs via the otlp_http receiver through ingress."""
     # GIVEN a model with otel-collector and traefik

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -104,8 +104,6 @@ def push_otlp_logs_through_ingress(juju: jubilant.Juju, ingress_app: str):
     assert IDENTIFIER in logs_pipeline
 
 
-# https://warthogs.atlassian.net/browse/OBC-2053
-@pytest.mark.xfail(date.today() < date(2026, 6, 8), reason="expected to fail until 2026-06-08", strict=True)
 def test_health_through_traefik_ingress(
     juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
 ):

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -6,12 +6,12 @@
 import json
 import logging
 import time
-from datetime import date
+# from datetime import date
 from typing import Dict
 from urllib.request import Request, urlopen
 
 import jubilant
-import pytest
+# import pytest
 import sh
 import yaml
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We need to update the way we test Traefik's ingress because the runner has network restrictions for using it's IP directly.

In the future, we should:
> Use the cluster-internal Traefik service DNS rather than using the external MetalLB IP at all

Blocking this PR:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/253

because ingress fails. We have [a Jira issue](https://warthogs.atlassian.net/browse/OBC-2053) for this issue and CI will fail again in 1 month.

## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This is likely failing in track/2 as well

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
