### PR TITLE
feat: Better rules tests

### DIFF
--- a/tests/unit/test_otlp.py
+++ b/tests/unit/test_otlp.py
@@ -5,7 +5,7 @@
 
 import dataclasses
 import json
-from contextlib import ExitStack
+from typing import Mapping
 from unittest.mock import patch
 
 import pytest
@@ -194,26 +194,105 @@ def test_cyclic_relations(ctx, otelcol_container, relations, is_cyclic):
     assert result == is_cyclic
 
 
-@pytest.mark.parametrize("forward_rules", [True, False])
-def test_received_otlp_rules_forwarded_to_remote_write(
-    ctx, otelcol_container, all_rules, forward_rules
-):
-    """Regression test for https://github.com/canonical/opentelemetry-collector-operator/issues/297.
+def _alerts_from_send_otlp(local_app_data: Mapping[str, str]) -> set:
+    """Extract alert names from a `send-otlp` outgoing databag.
 
-    Alert rules received over `receive-otlp` must be staged to disk by `stage_received_otlp_rules`
-    so that `send_remote_write` forwards them to Prometheus. The OTLP interface only exposes
-    received rules via relation data and does not persist them, so without staging them the rules
-    would never reach Prometheus.
+    The OTLP requirer publishes rules under the (LZMA-compressed) ``rules`` field, split into
+    ``promql`` and ``logql`` top-level keys.
     """
-    # GIVEN a receive-otlp relation carrying (compressed) alert rules AND a send-remote-write relation
-    databag = {
-        "rules": json.dumps(LZMABase64.compress(json.dumps(all_rules))),
-        "metadata": json.dumps(OTELCOL_METADATA),
-    }
-    receiver = Relation("receive-otlp", remote_app_data=databag)
-    remote_write = Relation("send-remote-write", remote_app_name="prometheus")
+    rules = local_app_data.get("rules")
+    if not rules:
+        return set()
+    decompressed = _decompress(rules)
+    alerts: set = set()
+    for tier in ("promql", "logql"):
+        for group in decompressed.get(tier, {}).get("groups", []):
+            for rule in group.get("rules", []):
+                if "alert" in rule:
+                    alerts.add(rule["alert"])
+    return alerts
+
+
+def _alerts_from_alert_rules_field(local_app_data: Mapping[str, str]) -> set:
+    """Extract alert names from a databag using the ``alert_rules`` JSON field.
+
+    Used by both `send-remote-write` (promql) and `send-loki-logs` (logql).
+    """
+    raw = local_app_data.get("alert_rules", '{"groups": []}')
+    alerts: set = set()
+    for group in json.loads(raw).get("groups", []):
+        for rule in group.get("rules", []):
+            if "alert" in rule:
+                alerts.add(rule["alert"])
+    return alerts
+
+
+@pytest.mark.parametrize("forward_rules", [True, False])
+@pytest.mark.parametrize(
+    "downstream_endpoint, downstream_remote_app, downstream_remote_app_data, expected_alerts, extract_alerts",
+    [
+        pytest.param(
+            "send-otlp",
+            "downstream-otelcol",
+            {"endpoints": "[]"},
+            {"Workload Missing", "HighLogVolume"},
+            _alerts_from_send_otlp,
+            id="otlp-to-otlp",
+        ),
+        pytest.param(
+            "send-remote-write",
+            "prometheus",
+            None,
+            {"Workload Missing"},
+            _alerts_from_alert_rules_field,
+            id="otlp-to-remote-write",
+        ),
+        pytest.param(
+            "send-loki-logs",
+            "loki",
+            None,
+            {"HighLogVolume"},
+            _alerts_from_alert_rules_field,
+            id="otlp-to-loki",
+        ),
+    ],
+)
+def test_received_otlp_rules_forwarded_downstream(
+    ctx,
+    otelcol_container,
+    all_rules,
+    forward_rules,
+    downstream_endpoint,
+    downstream_remote_app,
+    downstream_remote_app_data,
+    expected_alerts,
+    extract_alerts,
+):
+    """Rules via `receive-otlp` must reach every downstream.
+
+    Alert rules received over `receive-otlp` must reach every downstream iff
+    `forward_alert_rules` is enabled. Each downstream uses a different databag
+    layout, so the matrix exercises all forwarding paths:
+
+        * `send-otlp`: LZMA-compressed dict under `rules`, split by `promql`/`logql`.
+        * `send-remote-write`: JSON dict under `alert_rules` (promql only).
+        * `send-loki-logs`: JSON dict under `alert_rules` (logql only).
+    """
+    # GIVEN a receive-otlp relation carrying compressed alert rules
+    # * a single downstream forwarding relation
+    receiver = Relation(
+        "receive-otlp",
+        remote_app_data={
+            "rules": json.dumps(LZMABase64.compress(json.dumps(all_rules))),
+            "metadata": json.dumps(OTELCOL_METADATA),
+        },
+    )
+    downstream_kwargs = {"remote_app_name": downstream_remote_app}
+    if downstream_remote_app_data is not None:
+        downstream_kwargs["remote_app_data"] = downstream_remote_app_data
+    downstream = Relation(downstream_endpoint, **downstream_kwargs)
     state = State(
-        relations=[receiver, remote_write],
+        relations=[receiver, downstream],
         leader=True,
         containers=otelcol_container,
         model=MODEL,
@@ -223,80 +302,144 @@ def test_received_otlp_rules_forwarded_to_remote_write(
     # WHEN any event executes the reconciler
     state_out = ctx.run(ctx.on.update_status(), state=state)
 
-    # THEN the received alert rule is forwarded to Prometheus iff forwarding is enabled
-    rw_out = state_out.get_relation(remote_write.id)
-    alert_rules = json.loads(rw_out.local_app_data.get("alert_rules", '{"groups": []}'))
-    forwarded_alerts = {
-        rule.get("alert")
-        for group in alert_rules.get("groups", [])
-        for rule in group.get("rules", [])
-        if "alert" in rule
-    }
-    # "Workload Missing" is the promql alert defined in the `all_rules` fixture (received over otlp)
+    # THEN the received alert rules reach the downstream databag iff forwarding is enabled
+    out_relation = state_out.get_relation(downstream.id)
+    forwarded = extract_alerts(out_relation.local_app_data)
     if forward_rules:
-        assert "Workload Missing" in forwarded_alerts
+        missing = expected_alerts - forwarded
+        assert not missing, (
+            f"expected {expected_alerts} in {downstream_endpoint} databag but missing {missing}; "
+            f"forwarded={forwarded}"
+        )
     else:
-        assert "Workload Missing" not in forwarded_alerts
+        leaked = expected_alerts & forwarded
+        assert not leaked, (
+            f"forwarding disabled but received-OTLP alerts leaked into {downstream_endpoint}: {leaked}"
+        )
 
 
-def test_reconcile_stages_otlp_rules_in_correct_order(ctx, otelcol_container, all_rules):
-    """Guard the temporal ordering contract that makes OTLP rule forwarding work.
+@pytest.mark.parametrize("forward_rules", [True, False])
+@pytest.mark.parametrize(
+    "source_endpoint, source_remote_app_name, source_remote_app_data, expected_alerts",
+    [
+        pytest.param(
+            "receive-otlp",
+            "upstream-otelcol",
+            None,  # filled in at runtime from the `all_rules` fixture
+            {"Workload Missing", "HighLogVolume"},
+            id="receive-otlp-to-send-otlp",
+        ),
+        pytest.param(
+            "metrics-endpoint",
+            "zinc",
+            {
+                "alert_rules": json.dumps(
+                    {
+                        "groups": [
+                            {
+                                "name": "scrape_endpoint_group",
+                                "rules": [
+                                    {
+                                        "alert": "ScrapeEndpointAlert",
+                                        "expr": "up == 0",
+                                        "for": "0m",
+                                        "labels": {"severity": "critical"},
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ),
+                "scrape_metadata": json.dumps(
+                    {
+                        "model": MODEL_NAME,
+                        "model_uuid": MODEL_UUID,
+                        "application": "zinc",
+                        "charm_name": "zinc-k8s",
+                        "unit": "zinc/0",
+                    }
+                ),
+                "scrape_jobs": json.dumps(
+                    [{"job_name": "zinc", "static_configs": [{"targets": ["1.2.3.4:8080"]}]}]
+                ),
+            },
+            {"ScrapeEndpointAlert"},
+            # `send_otlp` currently only forwards rules from bundled SRC dirs and `OtlpProvider`
+            # (i.e. `receive-otlp`). It does not pick up rules from `metrics-endpoint` or
+            # `receive-loki-logs` upstreams, so they never reach downstream OTLP collectors.
+            # This `xfail` documents the desired behavior; once `send_otlp` is taught to include
+            # those sources, drop `marks=` to flip this back to a passing assertion.
+            # `strict=False` because the `forward_rules=False` row trivially passes today
+            # (nothing flows in or out), so it would XPASS and noise up the run.
+            marks=pytest.mark.xfail(
+                reason=(
+                    "send_otlp does not forward rules received over metrics-endpoint or "
+                    "receive-loki-logs; tracked separately."
+                ),
+                strict=False,
+            ),
+            id="metrics-endpoint-to-send-otlp",
+        ),
+    ],
+)
+def test_incoming_rules_forwarded_to_send_otlp(
+    ctx,
+    otelcol_container,
+    all_rules,
+    forward_rules,
+    source_endpoint,
+    source_remote_app_name,
+    source_remote_app_data,
+    expected_alerts,
+):
+    """Alert rules received over any incoming relation must reach `send-otlp` iff forwarding is enabled.
 
-    Staging the received OTLP rules to disk (`stage_received_otlp_rules`) only forwards them to
-    Prometheus/Loki if it runs:
-      * AFTER `cleanup` (which wipes the rule directories), and
-      * BEFORE the integrations that read those directories: `receive_loki_logs`/`scrape_metrics`
-        (which copy the bundled rules in) and `send_loki_logs`/`send_remote_write` (which forward).
+    Symmetric counterpart to `test_received_otlp_rules_forwarded_downstream`: that test fans out
+    from `receive-otlp` to every downstream forwarding endpoint; this one fans in from every
+    rule-bearing incoming endpoint to a single `send-otlp` downstream. Each source uses a
+    different databag layout:
 
-    This ordering lives in `charm._reconcile` and is otherwise only enforced by a comment, so a
-    future reorder would silently regress https://github.com/canonical/opentelemetry-collector-operator/issues/297.
-    This test spies on the reconcile call order to fail fast if that contract is broken.
+        * `receive-otlp`: LZMA-compressed dict under `rules`, split by `promql`/`logql`.
+        * `metrics-endpoint`: JSON dict under `alert_rules` plus `scrape_metadata`/`scrape_jobs`.
     """
-    # `charm.py` does `import integrations`, so spy on that same module object
-    import integrations
-
-    call_order: list[str] = []
-    spied = [
-        "cleanup",
-        "stage_received_otlp_rules",
-        "receive_loki_logs",
-        "send_loki_logs",
-        "scrape_metrics",
-        "send_remote_write",
-    ]
-    real = {name: getattr(integrations, name) for name in spied}
-
-    def make_spy(name):
-        def spy(*args, **kwargs):
-            call_order.append(name)
-            return real[name](*args, **kwargs)
-
-        return spy
-
-    # GIVEN a receive-otlp relation carrying alert rules, with forwarding enabled
-    databag = {
-        "rules": json.dumps(LZMABase64.compress(json.dumps(all_rules))),
-        "metadata": json.dumps(OTELCOL_METADATA),
-    }
+    # GIVEN one rule-bearing incoming relation AND a single `send-otlp` downstream relation
+    if source_endpoint == "receive-otlp":
+        source_remote_app_data = {
+            "rules": json.dumps(LZMABase64.compress(json.dumps(all_rules))),
+            "metadata": json.dumps(OTELCOL_METADATA),
+        }
+    source = Relation(
+        source_endpoint,
+        remote_app_name=source_remote_app_name,
+        remote_app_data=source_remote_app_data,
+    )
+    downstream = Relation(
+        "send-otlp", remote_app_name="downstream-otelcol", remote_app_data={"endpoints": "[]"}
+    )
     state = State(
-        relations=[Relation("receive-otlp", remote_app_data=databag)],
+        relations=[source, downstream],
         leader=True,
         containers=otelcol_container,
         model=MODEL,
-        config={"forward_alert_rules": True},
+        config={"forward_alert_rules": forward_rules},
     )
 
     # WHEN any event executes the reconciler
-    with ExitStack() as stack:
-        for name in spied:
-            stack.enter_context(patch.object(integrations, name, make_spy(name)))
-        ctx.run(ctx.on.update_status(), state=state)
+    state_out = ctx.run(ctx.on.update_status(), state=state)
 
-    # THEN staging runs after the cleanup and before every integration that reads the rule dirs
-    assert call_order.index("cleanup") < call_order.index("stage_received_otlp_rules")
-    for reader in ("receive_loki_logs", "send_loki_logs", "scrape_metrics", "send_remote_write"):
-        assert call_order.index("stage_received_otlp_rules") < call_order.index(reader), (
-            f"stage_received_otlp_rules must run before {reader}"
+    # THEN the source's alert rules reach the `send-otlp` databag iff forwarding is enabled
+    out_relation = state_out.get_relation(downstream.id)
+    forwarded = _alerts_from_send_otlp(out_relation.local_app_data)
+    if forward_rules:
+        missing = expected_alerts - forwarded
+        assert not missing, (
+            f"expected {expected_alerts} from {source_endpoint} in send-otlp databag but missing "
+            f"{missing}; forwarded={forwarded}"
+        )
+    else:
+        leaked = expected_alerts & forwarded
+        assert not leaked, (
+            f"forwarding disabled but {source_endpoint} alerts leaked into send-otlp: {leaked}"
         )
 
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We could create one parameterized test that asserts the same alert appears in each downstream's databag. Cleaner than the current single-endpoint test, recovers OTLP→OTLP coverage, and adds Loki, remote-write and metrics-endpoint coverage.

## Solution
<!-- A summary of the solution addressing the above issue -->


### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
