### PR TITLE
fix: insecure_skip_verify precedence for prometheus jobs

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -124,7 +124,8 @@ class ConfigManager:
             global_scrape_interval: set a global scrape interval for all prometheus receivers on build
             global_scrape_timeout: set a global scrape timeout for all prometheus receivers on build
             receiver_tls: whether to inject TLS config in all receivers on build
-            insecure_skip_verify: value for `insecure_skip_verify` in all exporters
+            insecure_skip_verify: default value for `insecure_skip_verify` in all exporters
+                and prometheus scrape jobs (per-exporter and per-job settings take precedence)
             queue_size: size of the sending queue for exporters
             max_elapsed_time_min: maximum elapsed time for retrying failed requests in minutes
         """
@@ -336,7 +337,8 @@ class ConfigManager:
 
         Note:
             The scrape jobs will be added to the Prometheus receiver configuration
-            with TLS verification settings inherited from the ConfigManager instance.
+            with TLS verification settings inherited from the ConfigManager instance
+            if they are not specified at the job level.
         """
         if not jobs:
             return
@@ -344,7 +346,7 @@ class ConfigManager:
             scrape_job.setdefault("tls_config", {})
             # Otelcol acts as a client and scrapes the metrics-generating server, so we enable
             # toggling of skipping the validation of the server certificate
-            scrape_job["tls_config"].update({"insecure_skip_verify": self._insecure_skip_verify})
+            scrape_job["tls_config"].setdefault("insecure_skip_verify", self._insecure_skip_verify)
 
         self.config.add_component(
             Component.receiver,

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -72,6 +72,50 @@ def test_add_prometheus_scrape():
     assert job_names == ["second_job", "third_job"]
 
 
+@pytest.mark.parametrize(
+    "global_skip_verify, job_tls_config, expected",
+    [
+        (True, {"insecure_skip_verify": True}, True),
+        (True, {"insecure_skip_verify": False}, False),
+        (True, None, True),
+        (True, {}, True),
+        (False, {"insecure_skip_verify": True}, True),
+        (False, {"insecure_skip_verify": False}, False),
+        (False, None, False),
+        (False, {}, False),
+    ],
+)
+def test_add_prometheus_scrape_insecure_skip_verify_precedence(
+    global_skip_verify, job_tls_config, expected
+):
+    """Per-job insecure_skip_verify takes priority over the global setting."""
+    # GIVEN a config manager with global insecure_skip_verify
+    config_manager = ConfigManager(
+        unit_name="otelcol/0",
+        global_scrape_interval="15s",
+        global_scrape_timeout="",
+        insecure_skip_verify=global_skip_verify,
+    )
+
+    # AND a prometheus job with a possible tls_config value
+    job = {
+        "metrics_path": "/metrics",
+        "static_configs": [{"targets": ["*:9001"]}],
+        "job_name": "test_job",
+    }
+    if job_tls_config is not None:
+        job["tls_config"] = job_tls_config
+
+    # WHEN the job is added
+    config_manager.add_prometheus_scrape_jobs([job])
+
+    # THEN the resulting insecure_skip_verify matches expected
+    scrape = config_manager.config._config["receivers"][
+        "prometheus/metrics-endpoint/otelcol/0"
+    ]["config"]["scrape_configs"][0]
+    assert scrape["tls_config"]["insecure_skip_verify"] is expected
+
+
 def test_add_log_ingestion():
     # GIVEN an empty config
     config_manager = ConfigManager(


### PR DESCRIPTION
## Issue

Fixes #265 

## Solution

If there is a a value already defined at the job level, we do not modify it.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

## Context

This change is inline with [the way exporters are handled](https://github.com/canonical/opentelemetry-collector-k8s-operator/blob/ca1f760b6aff4a408a64737c7a1bbc45cb8a5719/src/config_builder.py#L303).

## Testing Instructions

Corresponding unit tests are added:
```
tox -e unit -- -k test_add_prometheus_scrape_insecure_skip_verify_precedence
```

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
