### PR TITLE
feat: TF checks

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,3 +14,10 @@ resource "juju_application" "opentelemetry_collector" {
     revision = var.revision
   }
 }
+
+check "storage_directives" {
+  assert {
+    condition     = length(var.storage_directives) > 0
+    error_message = "storage_directives is unset, so it will use the default 1G volume. Set a size before deploying to production; resizing a persistent volume after deployment requires manual steps. See https://documentation.ubuntu.com/observability/latest/how-to/configure-and-tune/customize-storage-options/"
+  }
+}

--- a/terraform/tests/storage_directives.tftest.hcl
+++ b/terraform/tests/storage_directives.tftest.hcl
@@ -1,0 +1,18 @@
+mock_provider "juju" {}
+
+variables {
+  channel    = "dev/edge"
+  model_uuid = "00000000-0000-0000-0000-000000000000"
+}
+
+run "warns_when_storage_directives_unset" {
+  command = plan
+
+  expect_failures = [check.storage_directives]
+}
+
+run "no_warning_when_storage_directives_set" {
+  command = plan
+
+  variables { storage_directives = { "data" = "1G" } }
+}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Otelcol can be deployed standalone without COS. We should still warn users to set storage directives in these cases.

## Solution
<!-- A summary of the solution addressing the above issue -->
In tandem with:
- https://github.com/canonical/observability-stack/pull/424

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Use atelier to setup otelcol from this branch `feat/tf-checks`:
```
atelier module add https://github.com/canonical/opentelemetry-collector-k8s-operator.git --ref feat/tf-checks
```
and plan:
```shell
Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: Check block assertion failed
│ 
│   on .terraform/modules/terraform/terraform/main.tf line 20, in check "storage_directives":
│   20:     condition     = length(var.storage_directives) > 0
│     ├────────────────
│     │ var.storage_directives is empty map of string
│ 
│ storage_directives is unset, so it will use the default 1G volume. Set a size before deploying to production; resizing a persistent volume after deployment requires manual steps. See
│ https://documentation.ubuntu.com/observability/latest/how-to/configure-and-tune/customize-storage-options/
╵
```

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
