### PR TITLE
feat: add queue to all exporters

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -157,6 +157,27 @@ class ConfigManager:
         }
 
     @property
+    def remote_write_queue_config(self) -> Dict[str, Any]:
+        """Return the queue and retry configuration for prometheusremotewrite exporters.
+
+        The prometheusremotewrite exporter does not support the standard ``sending_queue``
+        configuration block. Instead it exposes ``remote_write_queue`` for queue control
+        and inherits ``retry_on_failure`` from the exporterhelper.
+
+        See Also:
+            https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md
+        """
+        return {
+            "remote_write_queue": {
+                "enabled": True,
+                "queue_size": self._queue_size,
+            },
+            "retry_on_failure": {
+                "max_elapsed_time": f"{self._max_elapsed_time_min}m",
+            },
+        }
+
+    @property
     def prometheus_remotewrite_wal_config(self) -> Dict[str, Any]:
         """Return the default WAL configuration for Prometheus remote write.
 
@@ -282,6 +303,7 @@ class ConfigManager:
                         "insecure": endpoint.insecure,
                         "insecure_skip_verify": self._insecure_skip_verify,
                     },
+                    **self.sending_queue_config,
                 },
                 pipelines=[f"profiles/{self._unit_name}"],
             )
@@ -365,6 +387,7 @@ class ConfigManager:
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
                     "add_metric_suffixes": False,
                     **self.prometheus_remotewrite_wal_config,
+                    **self.remote_write_queue_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],
             )
@@ -396,7 +419,11 @@ class ConfigManager:
             self.config.add_component(
                 Component.exporter,
                 f"{exporter_type}/rel-{rel_id}/{self._unit_name}",
-                {"endpoint": otlp_endpoint.endpoint, "tls": tls_config},
+                {
+                    "endpoint": otlp_endpoint.endpoint,
+                    "tls": tls_config,
+                    **self.sending_queue_config,
+                },
                 pipelines=[f"{_type}/{self._unit_name}" for _type in otlp_endpoint.telemetries],
             )
 
@@ -550,6 +577,7 @@ class ConfigManager:
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
                     **exporter_auth_config,
                     **self.prometheus_remotewrite_wal_config,
+                    **self.remote_write_queue_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],
             )

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -210,6 +210,10 @@ def test_add_remote_write():
         "tls": {
             "insecure_skip_verify": True,
         },
+        "retry_on_failure": {
+            "max_elapsed_time": "5m",
+        },
+        "remote_write_queue": {"enabled": True, "queue_size": 1000},
     }
     config_manager.add_remote_write(
         endpoints=[{"url": "http://192.168.1.244/cos-prometheus-0/api/v1/write"}],
@@ -343,14 +347,20 @@ def test_add_otlp_forwarding():
         f"otlp/rel-0/{unit_name}": {
             "endpoint": "1.2.3.4:grpc-port",
             "tls": {"insecure": False, "insecure_skip_verify": True},
+            "retry_on_failure": {"max_elapsed_time": "5m"},
+            "sending_queue": {"enabled": True, "queue_size": 1000, "storage": "file_storage"},
         },
         f"otlphttp/rel-1/{unit_name}": {
             "endpoint": "http://host-1:http-port",
             "tls": {"insecure": True, "insecure_skip_verify": True},
+            "retry_on_failure": {"max_elapsed_time": "5m"},
+            "sending_queue": {"enabled": True, "queue_size": 1000, "storage": "file_storage"},
         },
         f"otlp/rel-2/{unit_name}": {
             "endpoint": "host-2:grpc-port",
             "tls": {"insecure": True, "insecure_skip_verify": True},
+            "retry_on_failure": {"max_elapsed_time": "5m"},
+            "sending_queue": {"enabled": True, "queue_size": 1000, "storage": "file_storage"},
         },
     }
     # AND the exporters are added to the appropriate pipelines


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
In tandem with https://github.com/canonical/opentelemetry-collector-operator/pull/343.

## Solution
<!-- A summary of the solution addressing the above issue -->
Adds a new proprty to ConfigManager called `remote_write_queue_config`. This is because the Remote Write Exporter uses a different config for configuring the queue. Read more [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md).

This PR also ensures that the sending queue option configured by the user applies to all exporters.
### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy the following bundle
```yaml
bundle: kubernetes
applications:
  flog:
    charm: flog-k8s
    channel: latest/edge
    revision: 13
    base: ubuntu@20.04/stable
    resources:
      workload-image: 4
    scale: 1
    constraints: arch=amd64
    trust: true
  loki:
    charm: loki-coordinator-k8s
    channel: dev/edge
    revision: 79
    base: ubuntu@26.04/stable
    resources:
      nginx-image: 8
      nginx-prometheus-exporter-image: 4
    scale: 1
    constraints: arch=amd64
    trust: true
  loki-backend:
    charm: local:loki-worker-k8s-3
    base: ubuntu@26.04/stable
    resources:
      loki-image: 8
    scale: 1
    options:
      role-backend: true
    constraints: arch=amd64
    storage:
      loki-persisted: kubernetes,1,1024M
    trust: true
  loki-read:
    charm: loki-worker-k8s
    channel: dev/edge
    revision: 85
    resources:
      loki-image: 7
    scale: 1
    options:
      role-read: true
    constraints: arch=amd64
    storage:
      loki-persisted: kubernetes,1,1024M
    trust: true
  loki-write:
    charm: loki-worker-k8s
    channel: dev/edge
    revision: 93
    base: ubuntu@26.04/stable
    resources:
      loki-image: 8
    scale: 1
    options:
      role-write: true
    constraints: arch=amd64
    storage:
      loki-persisted: kubernetes,1,1024M
    trust: true
  otelcol:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 211
    resources:
      opentelemetry-collector-image: 9
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  otelcol2:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 211
    base: ubuntu@26.04/stable
    resources:
      opentelemetry-collector-image: 11
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  prom:
    charm: prometheus-k8s
    channel: dev/edge
    revision: 296
    resources:
      prometheus-image: 154
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  s3:
    charm: s3-integrator
    channel: 2/edge
    revision: 550
    scale: 1
    options:
      bucket: loki
      credentials: secret:mborcqcac7emg8safr60
      endpoint: http://10.181.160.41:8080
    constraints: arch=amd64
    trust: true
relations:
- - loki:s3
  - s3:s3-credentials
- - loki:loki-cluster
  - loki-write:loki-cluster
- - loki:loki-cluster
  - loki-read:loki-cluster
- - loki:loki-cluster
  - loki-backend:loki-cluster
- - flog:log-forwarder
  - loki:logging
- - otelcol:send-otlp
  - otelcol2:receive-otlp
- - otelcol:send-loki-logs
  - loki:logging
- - otelcol:send-remote-write
  - prom:receive-remote-write

```
1. Look at the config file for Otelcol.
2. Notice that even though you have three exporters, the default sending queue and retry logic will only apply to the Loki exporter
```yaml
connectors: {}
exporters:
  loki/send-loki-logs/0:
    default_labels_enabled:
      exporter: false
      job: true
    endpoint: http://loki-0.loki-endpoints.test.svc.cluster.local:8080/loki/api/v1/push
    retry_on_failure:
      max_elapsed_time: 5m
    sending_queue:
      enabled: true
      queue_size: 1000
      storage: file_storage
    tls:
      insecure_skip_verify: false
  otlp/rel-24/otelcol/0:
    endpoint: otelcol2-0.otelcol2-endpoints.test.svc.cluster.local:4317
    tls:
      insecure: true
      insecure_skip_verify: false
  prometheusremotewrite/send-remote-write/0:
    add_metric_suffixes: false
    endpoint: http://prom-0.prom-endpoints.test.svc.cluster.local:9090/api/v1/write
    tls:
      insecure_skip_verify: false

```
3. Now, pack this charm and refresh Otelcol.
4.  Now, the same resiliency config should apply to ALL exporters.
```yaml
connectors: {}
exporters:
  loki/send-loki-logs/0:
    default_labels_enabled:
      exporter: false
      job: true
    endpoint: http://loki-0.loki-endpoints.test.svc.cluster.local:8080/loki/api/v1/push
    retry_on_failure:
      max_elapsed_time: 5m
    sending_queue:
      enabled: true
      queue_size: 1000
      storage: file_storage
    tls:
      insecure_skip_verify: false
  otlp/rel-30/otelcol/0:
    endpoint: otelcol2-0.otelcol2-endpoints.test.svc.cluster.local:4317
    retry_on_failure:
      max_elapsed_time: 5m
    sending_queue:
      enabled: true
      queue_size: 1000
      storage: file_storage
    tls:
      insecure: true
      insecure_skip_verify: false
  prometheusremotewrite/send-remote-write/0:
    add_metric_suffixes: false
    endpoint: http://prom-0.prom-endpoints.test.svc.cluster.local:9090/api/v1/write
    remote_write_queue:
      enabled: true
      queue_size: 1000
    retry_on_failure:
      max_elapsed_time: 5m
    tls:
      insecure_skip_verify: false

```
## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
