### PR TITLE
feat: add Juju topology to exporter alert annotations

### DIFF
--- a/src/prometheus_alert_rules/otelcol_exporter.rules
+++ b/src/prometheus_alert_rules/otelcol_exporter.rules
@@ -7,7 +7,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some log points failed to send by exporter
+          summary: Some log points failed to send by exporter (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: failed-metrics
         expr: sum(rate(otelcol_exporter_send_failed_metric_points{}[5m])) > 0
@@ -15,7 +15,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some metric points failed to send by exporter
+          summary: Some metric points failed to send by exporter (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: failed-traces
         expr: sum(rate(otelcol_exporter_send_failed_spans{}[5m])) > 0
@@ -23,7 +23,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some spans failed to send by exporter
+          summary: Some spans failed to send by exporter (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: queue-near-capacity
         expr: otelcol_exporter_queue_size / otelcol_exporter_queue_capacity > 0.8
@@ -31,7 +31,7 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: Exporter sending queue is over 80% full
+          summary: Exporter sending queue is over 80% full (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
           description: >
             The exporter's sending queue has stayed above 80% capacity, meaning the destination
             can't keep up with incoming telemetry. If the queue reaches capacity, data will be
@@ -47,7 +47,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Exporter sending queue is full and dropping telemetry
+          summary: Exporter sending queue is full and dropping telemetry (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
           description: >
             The exporter's sending queue is at capacity and rejecting new telemetry at enqueue,
             causing data loss. Check that the exporter's endpoint is operational, reduce the

--- a/src/prometheus_alert_rules/otelcol_exporter.rules
+++ b/src/prometheus_alert_rules/otelcol_exporter.rules
@@ -7,7 +7,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some log points failed to send by exporter (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
+          summary: Some log points failed to send by exporter (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: failed-metrics
         expr: sum(rate(otelcol_exporter_send_failed_metric_points{}[5m])) > 0
@@ -15,7 +15,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some metric points failed to send by exporter (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
+          summary: Some metric points failed to send by exporter (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: failed-traces
         expr: sum(rate(otelcol_exporter_send_failed_spans{}[5m])) > 0
@@ -23,7 +23,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some spans failed to send by exporter (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
+          summary: Some spans failed to send by exporter (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: queue-near-capacity
         expr: otelcol_exporter_queue_size / otelcol_exporter_queue_capacity > 0.8
@@ -31,7 +31,7 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: Exporter sending queue is over 80% full (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
+          summary: Exporter sending queue is over 80% full (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: >
             The exporter's sending queue has stayed above 80% capacity, meaning the destination
             can't keep up with incoming telemetry. If the queue reaches capacity, data will be
@@ -47,7 +47,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Exporter sending queue is full and dropping telemetry (application {{ $labels.juju_application }} in model {{ $labels.juju_model }})
+          summary: Exporter sending queue is full and dropping telemetry (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: >
             The exporter's sending queue is at capacity and rejecting new telemetry at enqueue,
             causing data loss. Check that the exporter's endpoint is operational, reduce the

--- a/src/prometheus_alert_rules/otelcol_hardware.rules
+++ b/src/prometheus_alert_rules/otelcol_hardware.rules
@@ -7,5 +7,5 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: High max CPU usage
+          summary: High max CPU usage (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Collector needs to scale up

--- a/src/prometheus_alert_rules/otelcol_receiver.rules
+++ b/src/prometheus_alert_rules/otelcol_receiver.rules
@@ -7,7 +7,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some log points have been refused by receiver
+          summary: Some log points have been refused by receiver (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Maybe collector has received non standard log points or it reached some limits
       - alert: receiver-refused-metrics
         expr: sum(rate(otelcol_receiver_refused_metric_points_total{}[5m])) > 0
@@ -15,5 +15,5 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some metric points have been refused by receiver
+          summary: Some metric points have been refused by receiver (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Maybe collector has received non standard metric points or it reached some limits


### PR DESCRIPTION
## Issue
Closes #279 .

Exporter alerts doesn't identifies the affected unit.

## Solution
Append the firing series' Juju topology to the summary annotation of each exporter alert rule.

### Checklist
- [ ] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
When one of the collector's exporter alerts fires, the notification doesn't say which collector it came from. In a model with several opentelemetry-collector-k8s applications (or the same app across models), an alert like "Some log points failed to send by exporter" is ambiguous — an operator can't tell the affected charm/model from the summary alone. Other COS charms (e.g. alertmanager-k8s) already embed Juju topology in their alert annotations; the otel-collector exporter rules did not.


## Testing Instructions
Unit tests validate that all .rules files are syntactically valid and are picked up by the charm's alert rule discovery.
### Manual Testing
I set the threshold to 0 on the queue capacity alert so that it's always firing I can see the application name and the model name correctly 
<img width="1484" height="502" alt="image" src="https://github.com/user-attachments/assets/cfb248d9-82e7-41bb-be5c-a227e29dab4c" />



## Upgrade Notes
None. This only changes alert annotation text; no config, relation, or metric changes. On upgrade, existing exporter alerts will simply start including the application/model in their summary.
