### PR TITLE
DO NOT MERGE: Track/0.130 performance

### DIFF
--- a/src/prometheus_alert_rules/otelcol_exporter.rules
+++ b/src/prometheus_alert_rules/otelcol_exporter.rules
@@ -7,7 +7,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some log points failed to send by exporter
+          summary: Some log points failed to send by exporter (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: failed-metrics
         expr: sum(rate(otelcol_exporter_send_failed_metric_points{}[5m])) > 0
@@ -15,7 +15,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some metric points failed to send by exporter
+          summary: Some metric points failed to send by exporter (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: failed-traces
         expr: sum(rate(otelcol_exporter_send_failed_spans{}[5m])) > 0
@@ -23,7 +23,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some spans failed to send by exporter
+          summary: Some spans failed to send by exporter (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Destination may have a problem or payload is incorrect
       - alert: queue-near-capacity
         expr: otelcol_exporter_queue_size / otelcol_exporter_queue_capacity > 0.8
@@ -31,7 +31,7 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: Exporter sending queue is over 80% full
+          summary: Exporter sending queue is over 80% full (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: >
             The exporter's sending queue has stayed above 80% capacity, meaning the destination
             can't keep up with incoming telemetry. If the queue reaches capacity, data will be
@@ -47,7 +47,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Exporter sending queue is full and dropping telemetry
+          summary: Exporter sending queue is full and dropping telemetry (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: >
             The exporter's sending queue is at capacity and rejecting new telemetry at enqueue,
             causing data loss. Check that the exporter's endpoint is operational, reduce the

--- a/src/prometheus_alert_rules/otelcol_hardware.rules
+++ b/src/prometheus_alert_rules/otelcol_hardware.rules
@@ -7,5 +7,5 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: High max CPU usage
+          summary: High max CPU usage (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Collector needs to scale up

--- a/src/prometheus_alert_rules/otelcol_receiver.rules
+++ b/src/prometheus_alert_rules/otelcol_receiver.rules
@@ -7,7 +7,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some log points have been refused by receiver
+          summary: Some log points have been refused by receiver (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Maybe collector has received non standard log points or it reached some limits
       - alert: receiver-refused-metrics
         expr: sum(rate(otelcol_receiver_refused_metric_points_total{}[5m])) > 0
@@ -15,5 +15,5 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Some metric points have been refused by receiver
+          summary: Some metric points have been refused by receiver (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model }})
           description: Maybe collector has received non standard metric points or it reached some limits

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,6 +26,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"opentelemetry-collector"` | no |
+| <a name="input_base"></a> [base](#input\_base) | The operating system on which to deploy. E.g. ubuntu@26.04. Check Charmhub for per-charm base support. | `string` | `"ubuntu@26.04"` | no |
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
 | <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -17,10 +17,6 @@ This is a Terraform module facilitating the deployment of opentelemetry-collecto
 |------|---------|
 | <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0 |
 
-## Modules
-
-No modules.
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ resource "juju_application" "opentelemetry_collector" {
   units              = var.units
 
   charm {
+    base     = var.base
     name     = "opentelemetry-collector-k8s"
     channel  = var.channel
     revision = var.revision

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -25,6 +25,7 @@ output "requires" {
     send_otlp                   = "send-otlp",
     send_remote_write           = "send-remote-write",
     send_traces                 = "send-traces",
+    send_charm_traces           = "send-charm-traces",
     service_mesh                = "service-mesh",
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "opentelemetry-collector"
 }
 
+variable "base" {
+  description = "The operating system on which to deploy. E.g. ubuntu@26.04. Check Charmhub for per-charm base support."
+  default     = "ubuntu@26.04"
+  type        = string
+}
+
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,8 +15,8 @@ variable "channel" {
   type        = string
 
   validation {
-    condition     = startswith(var.channel, "dev/")
-    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+    condition     = startswith(var.channel, "0.130/")
+    error_message = "The track of the channel must be '0.130/'. e.g. '0.130/edge'."
   }
 }
 

--- a/tests/stress/bench_reconcile.py
+++ b/tests/stress/bench_reconcile.py
@@ -1,0 +1,381 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Stress-test / micro-benchmark for the otelcol charm reconciliation.
+
+This measures the *charm code* execution time (i.e. `_reconcile()`) as a function
+of the number of related charms. It uses the ops.testing (Scenario) framework, so
+it runs the real reconciliation logic WITHOUT needing a Kubernetes cluster.
+
+Container I/O (push/pull/replan) is handled in-memory by Scenario, so the numbers
+reflect the pure Python/charm cost: relation parsing, LZMA (de)compression,
+alert-rule staging, YAML generation and hashing.
+
+Run with:
+    uv run python tests/stress/bench_reconcile.py                    # quick table
+    uv run python tests/stress/bench_reconcile.py --profile --n 300  # cProfile at N=300
+    uv run python tests/stress/bench_reconcile.py --breakdown --n 300  # per-function breakdown
+    uv run python tests/stress/bench_reconcile.py --sizes 1,50,100,200,300,500
+"""
+
+import argparse
+import cProfile
+import contextlib
+import json
+import pstats
+import time
+from pathlib import Path
+from shutil import copytree
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+from cosl import LZMABase64
+from cosl.rules import JujuTopology
+from charmlibs.interfaces.otlp._rules import RuleStore, _RulesModel
+from ops import ActiveStatus
+from ops.testing import Container, Context, Exec, Relation, State
+
+from src.charm import OpenTelemetryCollectorK8sCharm
+
+CHARM_ROOT = Path(__file__).parent.parent.parent
+
+
+@contextlib.contextmanager
+def k8s_patches():
+    """Replicate the autouse `k8s_resource_multipatch` fixture from conftest.py."""
+    with patch.multiple(
+        "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch",
+        _namespace="test-namespace",
+        _patch=lambda *_a, **_kw: True,
+        is_ready=lambda *_a, **_kw: True,
+        get_status=lambda _: ActiveStatus(),
+    ):
+        with patch("lightkube.core.client.GenericSyncClient", new=MagicMock()):
+            yield
+
+
+def _make_ctx(tmp_path: Path) -> Context:
+    """Replicate the `ctx` fixture from tests/unit/conftest.py."""
+    for src_dir in ["grafana_dashboards", "loki_alert_rules", "prometheus_alert_rules"]:
+        copytree(CHARM_ROOT / "src" / src_dir, tmp_path / "src" / src_dir, dirs_exist_ok=True)
+    return Context(OpenTelemetryCollectorK8sCharm, charm_root=tmp_path)
+
+
+# Load the real bundled dashboard once so every emulated client sends a realistic
+# (~77KB) payload, giving LZMA (de)compression representative work.
+_REAL_DASHBOARD = json.loads(
+    (CHARM_ROOT / "src" / "grafana_dashboards" / "overview-dashboard.json").read_text()
+)
+
+
+def _dashboard_payload(idx: int) -> str:
+    """Build a realistic (compressed) dashboard databag for one client.
+
+    Uses the actual bundled overview dashboard (src/grafana_dashboards/overview-dashboard.json)
+    so the LZMA compression/decompression and JSON parsing costs match production.
+    The title is made unique per client to avoid the dedup-by-title collapse in
+    `_get_dashboards`, so all N dashboards are actually processed.
+    """
+    dashboard = dict(_REAL_DASHBOARD)
+    dashboard["title"] = f"{dashboard.get('title', 'Overview')} - client {idx}"
+    return json.dumps(
+        {
+            "templates": {
+                f"file:dashboard-{idx}": {
+                    "charm": f"client-charm-{idx}",
+                    "content": LZMABase64.compress(json.dumps(dashboard)),
+                }
+            }
+        }
+    )
+
+
+def _otlp_rules_databag(idx: int) -> dict:
+    """Build the full ``receive-otlp`` remote app databag for one client.
+
+    This mirrors exactly how a remote OtlpRequirer serializes its app data
+    (see charmlibs.interfaces.otlp._otlp._OtlpRequirerAppData):
+      - ``rules``: the whole ``_RulesModel`` dumped to JSON and LZMA-compressed as
+        a single blob (NOT a plain JSON of separately-compressed fields).
+      - ``metadata``: the requirer's Juju topology as a JSON dict, used to label
+        rule expressions.
+
+    The PromQL rules are the real bundled ones from ``src/prometheus_alert_rules``.
+    ``src/loki_alert_rules`` ships empty (only a .gitkeep), so we add a small,
+    representative LogQL rule to exercise the LogQL path too. The topology is made
+    unique per client so the N payloads are all distinct, like real deployments.
+    """
+    topology = JujuTopology(
+        model="stress-model",
+        model_uuid="f4d59020-c8e7-4053-8044-a2c1e5591c7f",
+        application=f"client-{idx}",
+        unit=f"client-{idx}/0",
+        charm_name=f"client-charm-{idx}",
+    )
+    store = RuleStore(topology)
+    store.add_promql_path(CHARM_ROOT / "src" / "prometheus_alert_rules", recursive=True)
+    store.add_logql_path(CHARM_ROOT / "src" / "loki_alert_rules", recursive=True)
+    # src/loki_alert_rules is empty in the repo; add a representative LogQL rule so
+    # the LogQL path is exercised the way it would be with real log alerts.
+    store.add_logql(
+        {
+            "groups": [
+                {
+                    "name": f"log_alerts_{idx}",
+                    "rules": [
+                        {
+                            "alert": "HighLogVolume",
+                            "expr": 'count_over_time({job=~".+"}[30s]) > 100',
+                            "labels": {"severity": "high"},
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    rules_model = _RulesModel(logql=store.logql.as_dict(), promql=store.promql.as_dict())
+    # ops' Relation.load() runs json.loads() on each databag value before handing
+    # it to pydantic, so every value must itself be a JSON string. The rules blob
+    # (LZMA+base64) is therefore wrapped with json.dumps so it round-trips back to
+    # the blob string, which the model's field validator then LZMA-decompresses.
+    return {
+        "rules": json.dumps(LZMABase64.compress(rules_model.model_dump_json())),
+        "metadata": json.dumps(topology.as_dict()),
+    }
+
+
+def build_state(n_clients: int) -> State:
+    """Build a State emulating `n_clients` clients pushing via OTLP + dashboards.
+
+    Each client relates over:
+      - receive-otlp  (telemetry + alert rules)
+      - grafana-dashboards-consumer (dashboards)
+    Plus outgoing relations so the aggregator actually forwards data.
+    """
+    relations = []
+    for i in range(n_clients):
+        relations.append(
+            Relation(
+                "receive-otlp",
+                id=1000 + i,
+                remote_app_data=_otlp_rules_databag(i),
+            )
+        )
+        relations.append(
+            Relation(
+                "grafana-dashboards-consumer",
+                id=5000 + i,
+                remote_app_data={"dashboards": _dashboard_payload(i)},
+            )
+        )
+
+    # Outgoing (backends) so pipelines have exporters
+    relations.append(Relation("send-remote-write", remote_app_data={}))
+    relations.append(Relation("send-loki-logs", remote_app_data={}))
+    relations.append(Relation("grafana-dashboards-provider"))
+
+    execs = {
+        Exec(["update-ca-certificates", "--fresh"], return_code=0, stdout=""),
+        Exec(["/usr/bin/otelcol", "--version"], return_code=0, stdout="otelcol version 0.130.1"),
+    }
+    return State(
+        relations=relations,
+        leader=True,
+        containers=[Container("otelcol", can_connect=True, execs=execs)],
+    )
+
+
+def time_reconcile(n_clients: int, repeats: int = 3) -> float:
+    """Return the median wall-clock time (seconds) of one reconciliation."""
+    samples = []
+    for _ in range(repeats):
+        with TemporaryDirectory() as td:
+            ctx = _make_ctx(Path(td))
+            state = build_state(n_clients)
+            with k8s_patches():
+                start = time.perf_counter()
+                ctx.run(ctx.on.update_status(), state=state)
+                samples.append(time.perf_counter() - start)
+    samples.sort()
+    return samples[len(samples) // 2]
+
+
+@contextlib.contextmanager
+def _no_cos_tool():
+    """Neutralize cos-tool subprocess calls to isolate the charm's own per-client cost.
+
+    cos-tool is invoked a *fixed* number of times (independent of client count) to
+    inject label matchers into alert rules. It dominates the wall clock but does not
+    scale with the number of clients, so patching it out reveals the true O(n) cost.
+    """
+    def _fake_exec(self, *args, **kwargs):
+        # Return the stdin unchanged (skip the real cos-tool subprocess).
+        if len(args) >= 2:
+            return args[1] or ""
+        return kwargs.get("stdin") or ""
+
+    with patch("cosl.cos_tool.CosTool._exec", _fake_exec):
+        yield
+
+
+def run_table(sizes, isolate=False):
+    label = "  (cos-tool patched out)" if isolate else ""
+    print(f"{'clients':>8} | {'relations':>9} | {'median (s)':>10} | {'per-client (ms)':>15}{label}")
+    print("-" * 60)
+    for n in sizes:
+        if isolate:
+            with _no_cos_tool():
+                t = time_reconcile(n)
+        else:
+            t = time_reconcile(n)
+        per_client = (t / n * 1000) if n else 0
+        print(f"{n:>8} | {n * 2:>9} | {t:>10.3f} | {per_client:>15.2f}")
+
+
+def run_profile(n_clients: int, isolate: bool = False):
+    with TemporaryDirectory() as td:
+        ctx = _make_ctx(Path(td))
+        state = build_state(n_clients)
+        profiler = cProfile.Profile()
+        cm = _no_cos_tool() if isolate else contextlib.nullcontext()
+        with k8s_patches(), cm:
+            profiler.enable()
+            ctx.run(ctx.on.update_status(), state=state)
+            profiler.disable()
+    stats = pstats.Stats(profiler)
+    stats.sort_stats("cumulative")
+    suffix = " (cos-tool patched out)" if isolate else ""
+    print(f"\n=== cProfile @ {n_clients} clients{suffix} (top 30 by cumulative time) ===")
+    stats.print_stats(30)
+
+
+# --- Per-charm-function breakdown --------------------------------------------
+#
+# Instead of made-up categories, we attribute the time to the REAL functions that
+# `_reconcile()` calls directly. cProfile records, for each edge
+# (caller -> callee), the cumtime of that edge (the callee's time plus everything
+# it calls below it). Since the functions in `_reconcile()` run sequentially and
+# do not call one another, those cumtimes do NOT overlap and add up to the total
+# of `_reconcile()`. The names come from the profile; nothing is hardcoded.
+
+
+def _find_reconcile_key(stats):
+    for key in stats.stats:
+        filename, _lineno, funcname = key
+        if funcname == "_reconcile" and filename.endswith("charm.py"):
+            return key
+    raise RuntimeError("could not find _reconcile in the profile")
+
+
+def _short_name(func_key) -> str:
+    """Readable short name: 'src/file.py:line(function)', or the builtin as-is."""
+    filename, lineno, funcname = func_key
+    if not filename or filename.startswith("~") or filename.startswith("{"):
+        return funcname  # builtin
+    # Trim the path starting at 'src/', or to the last couple of segments.
+    parts = filename.split("/")
+    if "src" in parts:
+        short = "/".join(parts[parts.index("src"):])
+    elif "site-packages" in parts:
+        short = "/".join(parts[parts.index("site-packages") + 1:])
+    else:
+        short = "/".join(parts[-2:])
+    return f"{short}:{lineno}({funcname})"
+
+
+def run_breakdown(n_clients: int, isolate: bool = False, top: int = 30):
+    with TemporaryDirectory() as td:
+        ctx = _make_ctx(Path(td))
+        state = build_state(n_clients)
+        profiler = cProfile.Profile()
+        cm = _no_cos_tool() if isolate else contextlib.nullcontext()
+        with k8s_patches(), cm:
+            profiler.enable()
+            ctx.run(ctx.on.update_status(), state=state)
+            profiler.disable()
+
+    stats = pstats.Stats(profiler)
+    reconcile_key = _find_reconcile_key(stats)
+    reconcile_cumtime = stats.stats[reconcile_key][3]
+
+    # For each function, check whether _reconcile called it directly and extract
+    # the cumtime of that specific edge.
+    # stats.stats[callee] = (cc, nc, tottime, cumtime, callers)
+    # callers[caller_key] = (cc, nc, tottime, cumtime)  <- edge cumtime
+    rows = []
+    attributed = 0.0
+    for callee_key, (_cc, _nc, _tt, _ct, callers) in stats.stats.items():
+        edge = callers.get(reconcile_key)
+        if edge is None:
+            continue
+        edge_cumtime = edge[3]
+        rows.append((_short_name(callee_key), edge_cumtime))
+        attributed += edge_cumtime
+
+    rows.sort(key=lambda x: x[1], reverse=True)
+    # Unattributed = inline code inside _reconcile (loops, assignments) plus its
+    # own tottime; we surface it as "(inline in _reconcile)".
+    inline = reconcile_cumtime - attributed
+    if inline > 0:
+        rows.append(("(inline in _reconcile: loops/assignments/own tottime)", inline))
+
+    suffix = " (cos-tool patched out)" if isolate else ""
+    print(f"\n=== _reconcile() breakdown by function @ {n_clients} clients{suffix} ===")
+    print("(cumtime of each direct call from _reconcile; they do not overlap)\n")
+    print(f"{'cumtime (s)':>12} | {'% recon':>8} | function")
+    print("-" * 90)
+    for name, t in rows[:top]:
+        pct = (t / reconcile_cumtime * 100) if reconcile_cumtime else 0
+        print(f"{t:>12.3f} | {pct:>7.1f}% | {name}")
+    print("-" * 90)
+    print(f"{reconcile_cumtime:>12.3f} | {100.0:>7.1f}% | _reconcile TOTAL")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Micro-benchmark of the otelcol charm's _reconcile().",
+    )
+    parser.add_argument(
+        "--sizes",
+        default="1,50,100,200,300",
+        help="comma-separated list of client counts (table mode)",
+    )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="run cProfile instead of the timing table",
+    )
+    parser.add_argument(
+        "--breakdown",
+        action="store_true",
+        help="break down _reconcile() time by the charm functions it calls",
+    )
+    parser.add_argument(
+        "--n",
+        type=int,
+        default=300,
+        help="client count to use with --profile/--breakdown (default: 300)",
+    )
+    parser.add_argument(
+        "--isolate",
+        action="store_true",
+        help="patch out cos-tool to isolate the charm's O(n) cost",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=30,
+        help="number of functions to list in --breakdown (default: 30)",
+    )
+    args = parser.parse_args()
+
+    if args.breakdown:
+        run_breakdown(args.n, isolate=args.isolate, top=args.top)
+    elif args.profile:
+        run_profile(args.n, isolate=args.isolate)
+    else:
+        sizes = [int(x) for x in args.sizes.split(",")]
+        run_table(sizes, isolate=args.isolate)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# `_reconcile()` execution flow and per-stage time consumption

Based on the run with **300 clients** and **real cos-tool**:

```shell
$ PYTHONPATH="$PWD/lib:$PWD/src:$PWD" uv run --extra=dev  python3 tests/stress/bench_reconcile.py  --breakdown --n 300 --top 6

=== _reconcile() breakdown by function @ 300 clients ===
(cumtime of each direct call from _reconcile; they do not overlap)

 cumtime (s) |  % recon | function
------------------------------------------------------------------------------------------
     703.594 |    49.6% | src/integrations.py:566(send_otlp)
     489.975 |    34.6% | src/integrations.py:523(stage_received_otlp_rules)
     198.047 |    14.0% | src/integrations.py:257(send_remote_write)
      24.448 |     1.7% | src/integrations.py:158(send_loki_logs)
       1.603 |     0.1% | src/integrations.py:456(forward_dashboards)
       0.021 |     0.0% | src/integrations.py:489(receive_otlp)
------------------------------------------------------------------------------------------
    1417.719 |   100.0% | _reconcile TOTAL

```

**Total ≈ 1417.7 s ≈ 23.6 minutes** for a single reconciliation with 300 clients.

---

## 1. Execution order (sequential, inside `_reconcile()`)

`_reconcile()` runs all stages **one after another, in a single thread**. There is no
parallelism: the total time is the sum of every stage. This is the actual order (per
`src/charm.py`), annotated with the measured time:

```mermaid
flowchart TD
    A["cleanup()  (~0s)<br/>charm.py:175 · deletes rules/dashboards dirs"] --> B

    B["setup mesh / ingress / TLS / address  (~0s)<br/>charm.py:178-207"] --> C

    subgraph OTLP["OTLP block — 84.2% of the time"]
      C["receive_otlp()  0.02s (0.0%)<br/>charm.py:241 · publishes endpoints"] --> D
      D["stage_received_otlp_rules()  490.0s (34.6%)<br/>charm.py:244 · reads rules from 300 relations,<br/>cos-tool per expression, writes to disk"] --> E
      E["send_otlp()  703.6s (49.6%)<br/>charm.py:245 · combines bundled + 300 rule stores,<br/>cos-tool per expression, compresses, publishes"]
    end

    E --> F

    subgraph LOGS["Logs block — 1.7%"]
      F["receive_loki_logs()  ~0s<br/>charm.py:249"] --> G
      G["send_loki_logs()  24.4s (1.7%)<br/>charm.py:250 · processes Loki rules with cos-tool"]
    end

    G --> H

    subgraph METRICS["Metrics block — 14.0%"]
      H["add_self_scrape / scrape_metrics()  ~0s<br/>charm.py:257-269"] --> I
      I["send_remote_write()  198.0s (14.0%)<br/>charm.py:277 · processes PromQL rules with cos-tool"]
    end

    I --> J["external-config / profiling / tracing  (~0s)<br/>charm.py:280-312"] --> K

    subgraph DASH["Dashboards — 0.1%"]
      K["forward_dashboards()  1.6s (0.1%)<br/>charm.py:315 · LZMA of 300 dashboards (leader only)"]
    end

    K --> L["cloud integrator / config.build() / push / replan  (~1s)<br/>charm.py:317-365"] --> M["ActiveStatus"]
```

---

## 2. Where the time is spent

```
send_otlp                 ############################################  49.6%  (703.6s)
stage_received_otlp_rules ###############################             34.6%  (490.0s)
send_remote_write         ############                                14.0%  (198.0s)
send_loki_logs            #                                            1.7%  ( 24.4s)
forward_dashboards        ·                                            0.1%  (  1.6s)
receive_otlp                                                           0.0%  (  0.0s)
```

**98.2% of the time (≈ 1392s) sits in three functions that process alert rules**:
`send_otlp` + `stage_received_otlp_rules` + `send_remote_write`. They all share the same root
cause: they invoke the external **`cos-tool`** binary **once per alert expression** (to inject
topology label matchers and validate).

---

## 3. Why the same rules are processed 3 times

The most important insight of the flow is that **each alert expression goes through cos-tool
several times within the same reconciliation**, across three distinct and sequential stages:

| Stage | What it does with the rules | Time |
|-------|-----------------------------|------|
| `stage_received_otlp_rules()` | Reads the rules received from the 300 OTLP relations and **writes them to disk** (rules are processed with cos-tool when accessing `provider.rules`) | 490.0s |
| `send_otlp()` | **Re-combines** the bundled rules + those from the 300 rule stores and re-processes them with cos-tool before publishing to the `send-otlp` relation | 703.6s |
| `send_remote_write()` | **Reads them again** from disk and processes them with cos-tool to publish toward Prometheus | 198.0s |
| `send_loki_logs()` | Same, for the LogQL rules toward Loki | 24.4s |

In other words, it is not that there is a single expensive step: **the same set of rules is
walked and cos-tool is invoked over it in 3-4 independent stages**, multiplying the cost.

`send_otlp` is the most expensive (49.6%) because it combines the bundled rules **with** those
from the 300 relations (`rules.combine()`), producing the largest set, and then processes the
whole thing.

---

## 4. Conclusions about the flow

1. **100% sequential execution**: the total (~23.6 min) is the direct sum of the stages. There is
   no way for them to "overlap"; each function waits for the previous one.

2. **The flow is dominated by alert rule handling** (98.2%), concentrated in the OTLP block
   (`stage_received_otlp_rules` + `send_otlp` = 84.2%). Dashboards, tracing, profiling, scrape
   metrics, config build and push are statistical noise by comparison.

3. **Redundant work**: the same rules are processed with cos-tool in 3-4 stages. Caching the
   cos-tool result by hash of (expression + topology) would attack all four stages at once, since
   they share the same expressions.

4. **Clear optimization priority**: any improvement in how cos-tool is invoked (caching, batching,
   or not reprocessing rules that did not change) directly impacts 98% of the time. Optimizing
   dashboards (0.1%) or any other stage is irrelevant next to this.

---

*Numbers from the `--breakdown --n 300` run with real cos-tool. Each function's `cumtime` is the
time of that direct call from `_reconcile()` including everything it calls below it; since the
calls are sequential and do not overlap, they add up to the total of `_reconcile()`.*
