### PR TITLE
feat!: Forward internal telemetry

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -229,6 +229,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             queue_size=cast(int, self.config.get("queue_size")),
             max_elapsed_time_min=cast(int, self.config.get("max_elapsed_time_min")),
             unit_name=self.unit.name,
+            internal_host=socket.getfqdn(),
         )
 
         # TODO: if/when we support multiple feature gates, make this a list and find out how to

--- a/src/charm.py
+++ b/src/charm.py
@@ -221,6 +221,14 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
                 return
 
         # Create the config manager
+        topology = JujuTopology.from_charm(self)
+        topology_labels = {
+            "juju_charm": topology.charm_name,
+            "juju_model": topology.model,
+            "juju_model_uuid": topology.model_uuid,
+            "juju_application": topology.application,
+            "juju_unit": topology.unit,
+        }
         config_manager = ConfigManager(
             global_scrape_interval=global_configs["global_scrape_interval"],
             global_scrape_timeout=global_configs["global_scrape_timeout"],
@@ -230,6 +238,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             max_elapsed_time_min=cast(int, self.config.get("max_elapsed_time_min")),
             unit_name=self.unit.name,
             internal_host=socket.getfqdn(),
+            topology_labels=topology_labels,
         )
 
         # TODO: if/when we support multiple feature gates, make this a list and find out how to
@@ -254,16 +263,11 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         config_manager.add_log_forwarding(loki_endpoints, insecure_skip_verify)
 
         # Metrics setup
-        topology = JujuTopology.from_charm(self)
         config_manager.add_self_scrape(
             identifier=topology.identifier,
             labels={
                 "instance": f"{topology.identifier}_{topology.unit}",
-                "juju_charm": topology.charm_name,
-                "juju_model": topology.model,
-                "juju_model_uuid": topology.model_uuid,
-                "juju_application": topology.application,
-                "juju_unit": topology.unit,
+                **topology_labels,
             },
         )
         # For now, the only incoming and outgoing metrics relations are remote-write/scrape

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -7,7 +7,7 @@ from enum import Enum, unique
 
 import yaml
 
-from constants import SERVER_CERT_PATH, SERVER_CERT_PRIVATE_KEY_PATH
+from constants import SERVER_CA_CERT_PATH, SERVER_CERT_PATH, SERVER_CERT_PRIVATE_KEY_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -172,11 +172,41 @@ class ConfigBuilder:
         # FIXME https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11780
         # Add TLS config to extensions
         self.add_extension("health_check", {"endpoint": f"0.0.0.0:{Port.health.value}"})
+        # Feed the collector's OWN internal logs back into its always-on OTLP receiver (defined
+        # above and wired to the `logs/<unit>` pipeline). From there they are exported alongside
+        # every other received/forwarded log, e.g. to Loki via the `send-loki-logs` exporter, and
+        # get the same topology labels applied by the pipeline's processors. If no log exporter is
+        # attached (no `send-loki-logs` relation), the pipeline falls back to the nop exporter and
+        # the internal logs are simply dropped -- no config error.
+        # We target `localhost` (the receiver binds `0.0.0.0`) over HTTP/protobuf. When receiver
+        # TLS is enabled, `_add_tls_to_all_receivers` puts a server cert on the OTLP receiver, so
+        # the loopback exporter must speak HTTPS and trust the CA.
+        # https://opentelemetry.io/docs/collector/internal-telemetry/#configure-internal-logs
+        internal_logs_otlp_exporter: Dict[str, Any] = {
+            "protocol": "http/protobuf",
+            "endpoint": (
+                f"https://localhost:{Port.otlp_http.value}"
+                if self._receiver_tls
+                else f"http://localhost:{Port.otlp_http.value}"
+            ),
+        }
+        if self._receiver_tls:
+            internal_logs_otlp_exporter["certificate"] = SERVER_CA_CERT_PATH
         self.add_telemetry(
             "logs",
             {
                 "level": "INFO",
                 "disable_stacktrace": True,
+                # Tag internal logs so they are distinguishable from ingested/forwarded logs
+                # in Grafana.
+                "initial_fields": {"job": "otelcol-internal"},
+                "processors": [
+                    {
+                        "batch": {
+                            "exporter": {"otlp": internal_logs_otlp_exporter},
+                        }
+                    }
+                ],
             },
         )
         self.add_telemetry("metrics", {"level": "normal"})

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -158,7 +158,8 @@ class ConfigBuilder:
         The collector self-ingests its own internal logs into the `logs/<unit>` pipeline. Any
         exporter on THAT pipeline can recurse: its "Exporting failed" log is itself an internal
         log that re-enters the pipeline and is re-exported. To break the cycle we drop the logs
-        emitted by exactly those exporter components, matched on `otelcol.component.id`.
+        emitted by exactly those exporter components for the LOGS signal, matched on
+        `otelcol.component.id` AND `otelcol.signal`.
 
         We enumerate the logs-pipeline exporters dynamically (at build time, after all components
         and the fallback nop exporter have been added) so the filter automatically covers EVERY
@@ -168,6 +169,21 @@ class ConfigBuilder:
 
         The auto-injected `nop`/`debug` exporters are excluded: they have no remote endpoint, so
         they cannot fail-and-recurse.
+
+        Why also match `otelcol.signal == "logs"`: a single OTLP exporter can be attached to MORE
+        than one pipeline (e.g. `send-otlp` with `telemetries: [logs, metrics]` produces one
+        `otlphttp/rel-N` component on both `logs/<unit>` and `metrics/<unit>`). That component
+        emits failure logs for BOTH signals with the SAME `otelcol.component.id`. Only its
+        `signal: logs` failures can recurse (they flow through the logs pipeline it feeds); its
+        `signal: metrics` failures pass through once and are the useful cross-signal logs we want
+        to keep. Matching id alone would over-drop the latter, so we AND in the signal.
+
+        IMPORTANT: the collector attaches `otelcol.component.id` (and `otelcol.signal`) to the
+        log's INSTRUMENTATION SCOPE, not to the log-record attributes (verified against the
+        OTLP-decoded internal logs: they appear under `InstrumentationScope attributes`, while the
+        log record's own `Attributes` only carry `code.*`/`error`/`interval`). So the OTTL
+        conditions must use the `instrumentation_scope.attributes[...]` context; `attributes[...]`
+        (log-record) never matches and would filter nothing.
         """
         filter_name = f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}"
         if filter_name not in self._config["processors"]:
@@ -178,10 +194,14 @@ class ConfigBuilder:
             for exporter_id in logs_pipeline.get("exporters", [])
             if exporter_id.split("/")[0] not in NON_LOOPING_EXPORTER_PREFIXES
         ]
-        # OTTL conditions are OR-ed: drop the record if it was emitted by ANY exporter attached to
-        # the logs pipeline (the source of the recursive "Exporting failed"/retry/queue logs).
+        # OTTL conditions are OR-ed across the list: drop the record if it was emitted by ANY
+        # logs-pipeline exporter FOR THE LOGS SIGNAL (the only failures that can recurse). Both
+        # `otelcol.component.id` and `otelcol.signal` live on the instrumentation scope (see
+        # docstring); the id+signal AND avoids over-dropping a shared exporter's metrics/traces
+        # failure logs.
         self._config["processors"][filter_name]["logs"]["log_record"] = [
-            f'attributes["otelcol.component.id"] == "{exporter_id}"'
+            f'instrumentation_scope.attributes["otelcol.component.id"] == "{exporter_id}" '
+            f'and instrumentation_scope.attributes["otelcol.signal"] == "logs"'
             for exporter_id in log_exporter_ids
         ]
 
@@ -251,8 +271,6 @@ class ConfigBuilder:
             {
                 "level": "INFO",
                 "disable_stacktrace": True,
-                # Tag internal logs so they are distinguishable from ingested/forwarded logs
-                # in Grafana.
                 "initial_fields": {"job": "otelcol-internal"},
                 "processors": [
                     {

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -9,6 +9,7 @@ import yaml
 
 from constants import (
     INTERNAL_LOGS_FILTER_ID,
+    INTERNAL_TELEMETRY_SERVICE_NAME,
     NON_LOOPING_EXPORTER_PREFIXES,
     SERVER_CERT_PATH,
     SERVER_CERT_PRIVATE_KEY_PATH,
@@ -251,12 +252,19 @@ class ConfigBuilder:
                 else f"http://localhost:{Port.otlp_http.value}"
             ),
         }
+        # Tag ALL of the collector's own telemetry (logs/metrics/traces) with a dedicated
+        # `service.name`. This is the OTel-standard way to identify a service, and the Loki
+        # exporter derives its `job` label from `service.namespace/service.name`, so this
+        # deterministically lands the self-ingested internal logs under `job=otelcol-internal`.
+        # It is exporter-agnostic: any backend (OTLP, remote-write, etc.) sees the same identifier.
+        self._config["service"]["telemetry"]["resource"] = {
+            "service.name": INTERNAL_TELEMETRY_SERVICE_NAME
+        }
         self.add_telemetry(
             "logs",
             {
                 "level": "INFO",
                 "disable_stacktrace": True,
-                "initial_fields": {"job": "otelcol-internal"},
                 "processors": [
                     {
                         "batch": {

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -9,8 +9,7 @@ import yaml
 
 from constants import (
     INTERNAL_LOGS_FILTER_ID,
-    LOOPABLE_LOG_EXPORTER_ID_PREFIXES,
-    SERVER_CA_CERT_PATH,
+    NON_LOOPING_EXPORTER_PREFIXES,
     SERVER_CERT_PATH,
     SERVER_CERT_PRIVATE_KEY_PATH,
 )
@@ -98,6 +97,7 @@ class ConfigBuilder:
         global_scrape_timeout: str,
         receiver_tls: bool = False,
         exporter_skip_verify: bool = False,
+        internal_host: str = "localhost",
     ):
         """Generate an empty OpenTelemetry collector config.
 
@@ -107,6 +107,9 @@ class ConfigBuilder:
             global_scrape_timeout: value for `scrape_timeout` in all prometheus receivers
             receiver_tls: whether to inject TLS config in all receivers on build
             exporter_skip_verify: value for `insecure_skip_verify` in all exporters
+            internal_host: the host the OTLP receiver's server cert is valid for (the unit FQDN).
+                Used as the loopback self-ingest endpoint when receiver TLS is enabled, so the
+                exporter connects to a name present in the cert's SANs.
         """
         self._config = {
             "extensions": {},
@@ -123,6 +126,7 @@ class ConfigBuilder:
         self._unit_name = unit_name
         self._receiver_tls = receiver_tls
         self._exporter_skip_verify = exporter_skip_verify
+        self._internal_host = internal_host
         self._scrape_interval = global_scrape_interval
         self._scrape_timeout = global_scrape_timeout
 
@@ -138,6 +142,7 @@ class ConfigBuilder:
             str: A YAML string representing the complete configuration.
         """
         self._add_missing_nop_exporters()
+        self._populate_loop_breaker_filter()
         if self._receiver_tls:
             self._add_tls_to_all_receivers()
         self._set_prometheus_receiver_global_timeout_and_interval(
@@ -146,6 +151,39 @@ class ConfigBuilder:
         )
         self._add_exporter_insecure_skip_verify(self._exporter_skip_verify)
         return yaml.safe_dump(self._config)
+
+    def _populate_loop_breaker_filter(self):
+        """Populate the internal-telemetry loop-breaker filter's drop conditions.
+
+        The collector self-ingests its own internal logs into the `logs/<unit>` pipeline. Any
+        exporter on THAT pipeline can recurse: its "Exporting failed" log is itself an internal
+        log that re-enters the pipeline and is re-exported. To break the cycle we drop the logs
+        emitted by exactly those exporter components, matched on `otelcol.component.id`.
+
+        We enumerate the logs-pipeline exporters dynamically (at build time, after all components
+        and the fallback nop exporter have been added) so the filter automatically covers EVERY
+        log exporter -- send-loki-logs, cloud-integrator, send-otlp logs, and any future one --
+        with no static list to maintain. Exporters on the metrics/traces pipelines are never
+        included, so their failure logs still reach Loki.
+
+        The auto-injected `nop`/`debug` exporters are excluded: they have no remote endpoint, so
+        they cannot fail-and-recurse.
+        """
+        filter_name = f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}"
+        if filter_name not in self._config["processors"]:
+            return
+        logs_pipeline = self._config["service"]["pipelines"].get(f"logs/{self._unit_name}", {})
+        log_exporter_ids = [
+            exporter_id
+            for exporter_id in logs_pipeline.get("exporters", [])
+            if exporter_id.split("/")[0] not in NON_LOOPING_EXPORTER_PREFIXES
+        ]
+        # OTTL conditions are OR-ed: drop the record if it was emitted by ANY exporter attached to
+        # the logs pipeline (the source of the recursive "Exporting failed"/retry/queue logs).
+        self._config["processors"][filter_name]["logs"]["log_record"] = [
+            f'attributes["otelcol.component.id"] == "{exporter_id}"'
+            for exporter_id in log_exporter_ids
+        ]
 
     @property
     def hash(self):
@@ -180,66 +218,34 @@ class ConfigBuilder:
         self.add_extension("health_check", {"endpoint": f"0.0.0.0:{Port.health.value}"})
         # Loop-breaker for self-ingested internal telemetry.
         #
-        # We feed the collector's OWN internal logs back into the `logs/<unit>` pipeline (see the
-        # telemetry config below), so they can be exported (e.g. to Loki) with topology labels.
-        # This creates a recursion risk: when the LOG exporter's endpoint is down, it emits an
-        # "Exporting failed" log; that log is itself internal telemetry, so it re-enters the
-        # pipeline, is re-exported, fails again, and so on -- an unbounded feedback loop.
-        # https://github.com/canonical/opentelemetry-collector-operator/pull/138
+        # We feed the collector's OWN internal logs back into the `logs/<unit>` pipeline, so they
+        # can be exported (e.g. to Loki) with topology labels. This creates a recursion risk: any
+        # exporter ATTACHED TO THE LOGS PIPELINE emits an "Exporting failed" log when its endpoint
+        # is down; that log is itself internal telemetry, so it re-enters the same pipeline, is
+        # re-exported, fails again; an unbounded feedback loop.
         #
-        # ONLY the log exporter(s) the internal logs actually loop THROUGH can recurse. A failure
-        # log from a NON-log exporter (Mimir/remote-write, Tempo, OTLP-metrics/traces, ...) flows
-        # through the log path exactly once and leaves -- it cannot form a cycle while that log
-        # path is healthy. Those exporter-failure logs are also the MOST useful logs to see in
-        # Grafana. So we drop ONLY the failure logs emitted by the looping log exporter(s),
-        # identified by their `otelcol.component.id` prefix, and let all other exporters' failure
-        # logs through. Keyed on origin/id -- not on a message string.
-        #
-        # INVARIANT: every log exporter added to `logs/<unit>` (now or in the future) must have
-        # its id prefix listed in LOOPABLE_LOG_EXPORTER_ID_PREFIXES so it is covered here. The
-        # filter is added unconditionally on the base config, so it always sits upstream of every
-        # exporter on the logs pipeline.
-        loopable_exporter_conditions = [
-            f'IsMatch(attributes["otelcol.component.id"], "^{prefix}")'
-            for prefix in LOOPABLE_LOG_EXPORTER_ID_PREFIXES
-        ]
+        # We add the filter here (unconditionally, on the base config) so it always sits UPSTREAM
+        # of every log exporter. Its drop conditions are left EMPTY here and are populated at build
+        # time by `_populate_loop_breaker_filter`, once the full set of exporters on the logs
+        # pipeline is known.
         self.add_component(
             Component.processor,
             f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}",
             {
-                # `ignore` keeps the pipeline resilient: OTTL evaluation errors (e.g. a log record
-                # with no `otelcol.component.id` attribute) are logged but do NOT drop valid data.
-                # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#error-modes
                 "error_mode": "ignore",
-                "logs": {
-                    # OTTL conditions are OR-ed: drop the record if it was emitted by ANY of the
-                    # log exporters the internal logs loop through (the source of the recursive
-                    # "Exporting failed"/retry/queue logs on THAT path).
-                    "log_record": loopable_exporter_conditions,
-                },
+                # Populated at build time from the logs-pipeline exporters (see build()).
+                "logs": {"log_record": []},
             },
             pipelines=[f"logs/{self._unit_name}"],
         )
-        # Feed the collector's OWN internal logs back into its always-on OTLP receiver (defined
-        # above and wired to the `logs/<unit>` pipeline). From there they are exported alongside
-        # every other received/forwarded log, e.g. to Loki via the `send-loki-logs` exporter, and
-        # get the same topology labels applied by the pipeline's processors. If no log exporter is
-        # attached (no `send-loki-logs` relation), the pipeline falls back to the nop exporter and
-        # the internal logs are simply dropped -- no config error.
-        # We target `localhost` (the receiver binds `0.0.0.0`) over HTTP/protobuf. When receiver
-        # TLS is enabled, `_add_tls_to_all_receivers` puts a server cert on the OTLP receiver, so
-        # the loopback exporter must speak HTTPS and trust the CA.
-        # https://opentelemetry.io/docs/collector/internal-telemetry/#configure-internal-logs
         internal_logs_otlp_exporter: Dict[str, Any] = {
             "protocol": "http/protobuf",
             "endpoint": (
-                f"https://localhost:{Port.otlp_http.value}"
+                f"https://{self._internal_host}:{Port.otlp_http.value}"
                 if self._receiver_tls
                 else f"http://localhost:{Port.otlp_http.value}"
             ),
         }
-        if self._receiver_tls:
-            internal_logs_otlp_exporter["certificate"] = SERVER_CA_CERT_PATH
         self.add_telemetry(
             "logs",
             {

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -167,14 +167,6 @@ class ConfigBuilder:
 
         The auto-injected `nop`/`debug` exporters are excluded: they have no remote endpoint, so
         they cannot fail-and-recurse.
-
-        Why also match `otelcol.signal == "logs"`: a single OTLP exporter can be attached to MORE
-        than one pipeline (e.g. `send-otlp` with `telemetries: [logs, metrics]` produces one
-        `otlphttp/rel-N` component on both `logs/<unit>` and `metrics/<unit>`). That component
-        emits failure logs for BOTH signals with the SAME `otelcol.component.id`. Only its
-        `signal: logs` failures can recurse (they flow through the logs pipeline it feeds); its
-        `signal: metrics` failures pass through once and are the useful cross-signal logs we want
-        to keep. Matching id alone would over-drop the latter, so we AND in the signal.
         """
         filter_name = f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}"
         if filter_name not in self._config["processors"]:
@@ -222,18 +214,23 @@ class ConfigBuilder:
         # FIXME https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11780
         # Add TLS config to extensions
         self.add_extension("health_check", {"endpoint": f"0.0.0.0:{Port.health.value}"})
-        # Loop-breaker for self-ingested internal telemetry.
-        #
-        # We feed the collector's OWN internal logs back into the `logs/<unit>` pipeline, so they
-        # can be exported (e.g. to Loki) with topology labels. This creates a recursion risk: any
-        # exporter ATTACHED TO THE LOGS PIPELINE emits an "Exporting failed" log when its endpoint
-        # is down; that log is itself internal telemetry, so it re-enters the same pipeline, is
-        # re-exported, fails again; an unbounded feedback loop.
-        #
-        # We add the filter here (unconditionally, on the base config) so it always sits UPSTREAM
-        # of every log exporter. Its drop conditions are left EMPTY here and are populated at build
-        # time by `_populate_loop_breaker_filter`, once the full set of exporters on the logs
-        # pipeline is known.
+        self._add_internal_telemetry_loop_breaker()
+        self.add_telemetry("metrics", {"level": "normal"})
+
+    def _add_internal_telemetry_loop_breaker(self):
+        """Configure the loop-breaker and self-ingestion of the collector's internal telemetry.
+
+        We feed the collector's OWN internal logs back into the `logs/<unit>` pipeline, so they
+        can be exported (e.g. to Loki) with topology labels. This creates a recursion risk: any
+        exporter ATTACHED TO THE LOGS PIPELINE emits an "Exporting failed" log when its endpoint
+        is down; that log is itself internal telemetry, so it re-enters the same pipeline, is
+        re-exported, fails again; an unbounded feedback loop.
+
+        We add the filter here (unconditionally, on the base config) so it always sits UPSTREAM
+        of every log exporter. Its drop conditions are left EMPTY here and are populated at build
+        time by `_populate_loop_breaker_filter`, once the full set of exporters on the logs
+        pipeline is known.
+        """
         self.add_component(
             Component.processor,
             f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}",
@@ -280,7 +277,6 @@ class ConfigBuilder:
                 ],
             },
         )
-        self.add_telemetry("metrics", {"level": "normal"})
 
     def add_component(
         self,

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -265,35 +265,22 @@ class ConfigBuilder:
             ),
         }
         # Tag ALL of the collector's own telemetry (logs/metrics/traces) with a dedicated
-        # `service.name`. This is the OTel-standard way to identify a service, and the Loki
-        # exporter derives its `job` label from `service.namespace/service.name`, so this
-        # deterministically lands the self-ingested internal logs under `job=otelcol-internal`.
-        # It is exporter-agnostic: any backend (OTLP, remote-write, etc.) sees the same identifier.
-        #
-        # `loki.format: logfmt` renders the full record (body + attributes) into the Loki line, so
-        # attributes like `error`, `interval` and `target_labels` (the scraped target's topology,
-        # e.g. `juju_unit=loki-read/0`) survive. `add_log_forwarding`'s `insert` of `loki.format:
-        # raw` won't overwrite this, so scraped charm logs stay `raw`.
+        # `service.name`. The Loki exporter derives its `job` label from
+        # `service.namespace/service.name`, so this lands the self-ingested internal logs under
+        # `job=otelcol-internal`.
         resource: Dict[str, Any] = {
             "service.name": INTERNAL_TELEMETRY_SERVICE_NAME,
             "loki.format": "logfmt",
         }
-        # Attach this collector's own Juju topology so internal logs from multiple otelcol
-        # apps/units are distinguishable in Loki (otherwise every app's internal logs collapse
-        # into the single `job=otelcol-internal` stream and can't be told apart).
         if self._topology_labels:
             resource.update(self._topology_labels)
             # Pin `service.instance.id` to the Juju unit so the Loki `instance` label is stable and
             # correlatable with Juju. Otherwise the collector defaults it to a random per-process
-            # UUID that changes on every restart, minting a new Loki stream each time (needless
-            # cardinality churn that is also impossible to map back to a unit).
+            # UUID that changes on every restart; cardinality churn.
             if "juju_unit" in self._topology_labels:
                 resource["service.instance.id"] = self._topology_labels["juju_unit"]
             # Promote ONLY the bounded topology keys to Loki labels via the exporter's
-            # `loki.resource.labels` hint. Cardinality is then bounded by the number of otelcol
-            # units. Crucially we do NOT promote the collector's own high-cardinality log
-            # attributes (`error`, `target_labels`, `scrape_timestamp`, `otelcol.component.id`,
-            # ...); those stay in the `logfmt` body, so there is no cardinality explosion.
+            # `loki.resource.labels` hint.
             resource["loki.resource.labels"] = ", ".join(sorted(self._topology_labels))
         self._config["service"]["telemetry"]["resource"] = resource
         self.add_telemetry(

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -7,7 +7,13 @@ from enum import Enum, unique
 
 import yaml
 
-from constants import SERVER_CA_CERT_PATH, SERVER_CERT_PATH, SERVER_CERT_PRIVATE_KEY_PATH
+from constants import (
+    INTERNAL_LOGS_FILTER_ID,
+    LOOPABLE_LOG_EXPORTER_ID_PREFIXES,
+    SERVER_CA_CERT_PATH,
+    SERVER_CERT_PATH,
+    SERVER_CERT_PRIVATE_KEY_PATH,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +178,48 @@ class ConfigBuilder:
         # FIXME https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11780
         # Add TLS config to extensions
         self.add_extension("health_check", {"endpoint": f"0.0.0.0:{Port.health.value}"})
+        # Loop-breaker for self-ingested internal telemetry.
+        #
+        # We feed the collector's OWN internal logs back into the `logs/<unit>` pipeline (see the
+        # telemetry config below), so they can be exported (e.g. to Loki) with topology labels.
+        # This creates a recursion risk: when the LOG exporter's endpoint is down, it emits an
+        # "Exporting failed" log; that log is itself internal telemetry, so it re-enters the
+        # pipeline, is re-exported, fails again, and so on -- an unbounded feedback loop.
+        # https://github.com/canonical/opentelemetry-collector-operator/pull/138
+        #
+        # ONLY the log exporter(s) the internal logs actually loop THROUGH can recurse. A failure
+        # log from a NON-log exporter (Mimir/remote-write, Tempo, OTLP-metrics/traces, ...) flows
+        # through the log path exactly once and leaves -- it cannot form a cycle while that log
+        # path is healthy. Those exporter-failure logs are also the MOST useful logs to see in
+        # Grafana. So we drop ONLY the failure logs emitted by the looping log exporter(s),
+        # identified by their `otelcol.component.id` prefix, and let all other exporters' failure
+        # logs through. Keyed on origin/id -- not on a message string.
+        #
+        # INVARIANT: every log exporter added to `logs/<unit>` (now or in the future) must have
+        # its id prefix listed in LOOPABLE_LOG_EXPORTER_ID_PREFIXES so it is covered here. The
+        # filter is added unconditionally on the base config, so it always sits upstream of every
+        # exporter on the logs pipeline.
+        loopable_exporter_conditions = [
+            f'IsMatch(attributes["otelcol.component.id"], "^{prefix}")'
+            for prefix in LOOPABLE_LOG_EXPORTER_ID_PREFIXES
+        ]
+        self.add_component(
+            Component.processor,
+            f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}",
+            {
+                # `ignore` keeps the pipeline resilient: OTTL evaluation errors (e.g. a log record
+                # with no `otelcol.component.id` attribute) are logged but do NOT drop valid data.
+                # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#error-modes
+                "error_mode": "ignore",
+                "logs": {
+                    # OTTL conditions are OR-ed: drop the record if it was emitted by ANY of the
+                    # log exporters the internal logs loop through (the source of the recursive
+                    # "Exporting failed"/retry/queue logs on THAT path).
+                    "log_record": loopable_exporter_conditions,
+                },
+            },
+            pipelines=[f"logs/{self._unit_name}"],
+        )
         # Feed the collector's OWN internal logs back into its always-on OTLP receiver (defined
         # above and wired to the `logs/<unit>` pipeline). From there they are exported alongside
         # every other received/forwarded log, e.g. to Loki via the `send-loki-logs` exporter, and

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -257,8 +257,14 @@ class ConfigBuilder:
         # exporter derives its `job` label from `service.namespace/service.name`, so this
         # deterministically lands the self-ingested internal logs under `job=otelcol-internal`.
         # It is exporter-agnostic: any backend (OTLP, remote-write, etc.) sees the same identifier.
+        #
+        # `loki.format: logfmt` renders the full record (body + attributes) into the Loki line, so
+        # attributes like `error`, `interval` and `target_labels` (the scraped target's topology,
+        # e.g. `juju_unit=loki-read/0`) survive. `add_log_forwarding`'s `insert` of `loki.format:
+        # raw` won't overwrite this, so scraped charm logs stay `raw`.
         self._config["service"]["telemetry"]["resource"] = {
-            "service.name": INTERNAL_TELEMETRY_SERVICE_NAME
+            "service.name": INTERNAL_TELEMETRY_SERVICE_NAME,
+            "loki.format": "logfmt",
         }
         self.add_telemetry(
             "logs",

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -99,6 +99,7 @@ class ConfigBuilder:
         receiver_tls: bool = False,
         exporter_skip_verify: bool = False,
         internal_host: str = "localhost",
+        topology_labels: Optional[Dict[str, str]] = None,
     ):
         """Generate an empty OpenTelemetry collector config.
 
@@ -109,6 +110,8 @@ class ConfigBuilder:
             receiver_tls: whether to inject TLS config in all receivers on build
             exporter_skip_verify: value for `insecure_skip_verify` in all exporters
             internal_host: the unit FQDN the OTLP receiver's server cert is valid for
+            topology_labels: this collector's own deployment topology. Attached to the collector's
+                internal telemetry so logs from multiple otelcol apps/units are distinguishable.
         """
         self._config = {
             "extensions": {},
@@ -123,6 +126,7 @@ class ConfigBuilder:
             },
         }
         self._unit_name = unit_name
+        self._topology_labels = dict(topology_labels or {})
         self._receiver_tls = receiver_tls
         self._exporter_skip_verify = exporter_skip_verify
         self._internal_host = internal_host
@@ -155,15 +159,19 @@ class ConfigBuilder:
         """Populate the internal-telemetry loop-breaker filter's drop conditions.
 
         The collector self-ingests its own internal logs into the `logs/<unit>` pipeline. Any
-        exporter on THAT pipeline can recurse: its "Exporting failed" log is itself an internal
+        exporter on ANY logs pipeline can recurse: its "Exporting failed" log is itself an internal
         log that re-enters the pipeline and is re-exported. To break the cycle we drop the logs
         emitted by exactly those exporter components for the LOGS signal, matched on
         `otelcol.component.id` AND `otelcol.signal`.
 
-        We enumerate the logs-pipeline exporters dynamically (at build time, after all components
-        and the fallback nop exporter have been added) so the filter automatically covers EVERY log
-        exporter: send-loki-logs, cloud-integrator, send-otlp logs, and any future one. Exporters
-        on the metrics/traces pipelines are never included, so their failure logs still reach Loki.
+        We enumerate the exporters across EVERY logs pipeline dynamically (at build time, after all
+        components and the fallback nop exporter have been added), not just the charm-managed
+        `logs/<unit>` pipeline. This is important because a user-supplied config can add its own
+        logs pipeline (e.g. `logs/custom`) and/or exporters; those would otherwise fail-and-recurse
+        without being covered by the filter. As a result the filter automatically covers EVERY log
+        exporter: send-loki-logs, cloud-integrator, send-otlp logs, custom user exporters, and any
+        future one. Exporters on the metrics/traces pipelines are never included, so their failure
+        logs still reach Loki.
 
         The auto-injected `nop`/`debug` exporters are excluded: they have no remote endpoint, so
         they cannot fail-and-recurse.
@@ -171,12 +179,19 @@ class ConfigBuilder:
         filter_name = f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}"
         if filter_name not in self._config["processors"]:
             return
-        logs_pipeline = self._config["service"]["pipelines"].get(f"logs/{self._unit_name}", {})
-        log_exporter_ids = [
-            exporter_id
-            for exporter_id in logs_pipeline.get("exporters", [])
-            if exporter_id.split("/")[0] not in NON_LOOPING_EXPORTER_PREFIXES
-        ]
+        # A pipeline is a logs pipeline when its name is `logs` or `logs/<something>`; its type is
+        # the segment before the first `/`. Collect exporters across ALL such pipelines, preserving
+        # order and de-duplicating (an exporter may be shared by several logs pipelines).
+        log_exporter_ids: List[str] = []
+        for pipeline_name, pipeline in self._config["service"]["pipelines"].items():
+            if pipeline_name.split("/")[0] != "logs":
+                continue
+            for exporter_id in pipeline.get("exporters", []):
+                if (
+                    exporter_id.split("/")[0] not in NON_LOOPING_EXPORTER_PREFIXES
+                    and exporter_id not in log_exporter_ids
+                ):
+                    log_exporter_ids.append(exporter_id)
         self._config["processors"][filter_name]["logs"]["log_record"] = [
             f'instrumentation_scope.attributes["otelcol.component.id"] == "{exporter_id}" '
             f'and instrumentation_scope.attributes["otelcol.signal"] == "logs"'
@@ -259,10 +274,28 @@ class ConfigBuilder:
         # attributes like `error`, `interval` and `target_labels` (the scraped target's topology,
         # e.g. `juju_unit=loki-read/0`) survive. `add_log_forwarding`'s `insert` of `loki.format:
         # raw` won't overwrite this, so scraped charm logs stay `raw`.
-        self._config["service"]["telemetry"]["resource"] = {
+        resource: Dict[str, Any] = {
             "service.name": INTERNAL_TELEMETRY_SERVICE_NAME,
             "loki.format": "logfmt",
         }
+        # Attach this collector's own Juju topology so internal logs from multiple otelcol
+        # apps/units are distinguishable in Loki (otherwise every app's internal logs collapse
+        # into the single `job=otelcol-internal` stream and can't be told apart).
+        if self._topology_labels:
+            resource.update(self._topology_labels)
+            # Pin `service.instance.id` to the Juju unit so the Loki `instance` label is stable and
+            # correlatable with Juju. Otherwise the collector defaults it to a random per-process
+            # UUID that changes on every restart, minting a new Loki stream each time (needless
+            # cardinality churn that is also impossible to map back to a unit).
+            if "juju_unit" in self._topology_labels:
+                resource["service.instance.id"] = self._topology_labels["juju_unit"]
+            # Promote ONLY the bounded topology keys to Loki labels via the exporter's
+            # `loki.resource.labels` hint. Cardinality is then bounded by the number of otelcol
+            # units. Crucially we do NOT promote the collector's own high-cardinality log
+            # attributes (`error`, `target_labels`, `scrape_timestamp`, `otelcol.component.id`,
+            # ...); those stay in the `logfmt` body, so there is no cardinality explosion.
+            resource["loki.resource.labels"] = ", ".join(sorted(self._topology_labels))
+        self._config["service"]["telemetry"]["resource"] = resource
         self.add_telemetry(
             "logs",
             {

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -162,10 +162,9 @@ class ConfigBuilder:
         `otelcol.component.id` AND `otelcol.signal`.
 
         We enumerate the logs-pipeline exporters dynamically (at build time, after all components
-        and the fallback nop exporter have been added) so the filter automatically covers EVERY
-        log exporter -- send-loki-logs, cloud-integrator, send-otlp logs, and any future one --
-        with no static list to maintain. Exporters on the metrics/traces pipelines are never
-        included, so their failure logs still reach Loki.
+        and the fallback nop exporter have been added) so the filter automatically covers EVERY log
+        exporter: send-loki-logs, cloud-integrator, send-otlp logs, and any future one. Exporters
+        on the metrics/traces pipelines are never included, so their failure logs still reach Loki.
 
         The auto-injected `nop`/`debug` exporters are excluded: they have no remote endpoint, so
         they cannot fail-and-recurse.
@@ -177,13 +176,6 @@ class ConfigBuilder:
         `signal: logs` failures can recurse (they flow through the logs pipeline it feeds); its
         `signal: metrics` failures pass through once and are the useful cross-signal logs we want
         to keep. Matching id alone would over-drop the latter, so we AND in the signal.
-
-        IMPORTANT: the collector attaches `otelcol.component.id` (and `otelcol.signal`) to the
-        log's INSTRUMENTATION SCOPE, not to the log-record attributes (verified against the
-        OTLP-decoded internal logs: they appear under `InstrumentationScope attributes`, while the
-        log record's own `Attributes` only carry `code.*`/`error`/`interval`). So the OTTL
-        conditions must use the `instrumentation_scope.attributes[...]` context; `attributes[...]`
-        (log-record) never matches and would filter nothing.
         """
         filter_name = f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}"
         if filter_name not in self._config["processors"]:
@@ -194,11 +186,6 @@ class ConfigBuilder:
             for exporter_id in logs_pipeline.get("exporters", [])
             if exporter_id.split("/")[0] not in NON_LOOPING_EXPORTER_PREFIXES
         ]
-        # OTTL conditions are OR-ed across the list: drop the record if it was emitted by ANY
-        # logs-pipeline exporter FOR THE LOGS SIGNAL (the only failures that can recurse). Both
-        # `otelcol.component.id` and `otelcol.signal` live on the instrumentation scope (see
-        # docstring); the id+signal AND avoids over-dropping a shared exporter's metrics/traces
-        # failure logs.
         self._config["processors"][filter_name]["logs"]["log_record"] = [
             f'instrumentation_scope.attributes["otelcol.component.id"] == "{exporter_id}" '
             f'and instrumentation_scope.attributes["otelcol.signal"] == "logs"'

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -107,9 +107,7 @@ class ConfigBuilder:
             global_scrape_timeout: value for `scrape_timeout` in all prometheus receivers
             receiver_tls: whether to inject TLS config in all receivers on build
             exporter_skip_verify: value for `insecure_skip_verify` in all exporters
-            internal_host: the host the OTLP receiver's server cert is valid for (the unit FQDN).
-                Used as the loopback self-ingest endpoint when receiver TLS is enabled, so the
-                exporter connects to a name present in the cert's SANs.
+            internal_host: the unit FQDN the OTLP receiver's server cert is valid for
         """
         self._config = {
             "extensions": {},

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -115,6 +115,7 @@ class ConfigManager:
         queue_size: int = 1000,
         max_elapsed_time_min: int = 5,
         internal_host: str = "localhost",
+        topology_labels: Optional[Dict[str, str]] = None,
     ):
         """Generate a default OpenTelemetry collector ConfigManager.
 
@@ -129,6 +130,8 @@ class ConfigManager:
             queue_size: size of the sending queue for exporters
             max_elapsed_time_min: maximum elapsed time for retrying failed requests in minutes
             internal_host: the unit FQDN the OTLP receiver's server cert is valid for
+            topology_labels: this collector's own Juju topology labels, attached to its internal
+                telemetry so logs from multiple otelcol apps/units are distinguishable in Loki
         """
         self._unit_name = unit_name
         self._insecure_skip_verify = insecure_skip_verify
@@ -141,6 +144,7 @@ class ConfigManager:
             receiver_tls=receiver_tls,
             exporter_skip_verify=insecure_skip_verify,
             internal_host=internal_host,
+            topology_labels=topology_labels,
         )
         self.config.add_default_config()
         self.config.add_extension("file_storage", {"directory": FILE_STORAGE_DIRECTORY})

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -114,6 +114,7 @@ class ConfigManager:
         insecure_skip_verify: bool = False,
         queue_size: int = 1000,
         max_elapsed_time_min: int = 5,
+        internal_host: str = "localhost",
     ):
         """Generate a default OpenTelemetry collector ConfigManager.
 
@@ -127,6 +128,8 @@ class ConfigManager:
             insecure_skip_verify: value for `insecure_skip_verify` in all exporters
             queue_size: size of the sending queue for exporters
             max_elapsed_time_min: maximum elapsed time for retrying failed requests in minutes
+            internal_host: the unit FQDN the OTLP receiver's server cert is valid for; used as the
+                loopback self-ingest endpoint when receiver TLS is enabled.
         """
         self._unit_name = unit_name
         self._insecure_skip_verify = insecure_skip_verify
@@ -138,6 +141,7 @@ class ConfigManager:
             global_scrape_timeout=global_scrape_timeout,
             receiver_tls=receiver_tls,
             exporter_skip_verify=insecure_skip_verify,
+            internal_host=internal_host,
         )
         self.config.add_default_config()
         self.config.add_extension("file_storage", {"directory": FILE_STORAGE_DIRECTORY})

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -128,8 +128,7 @@ class ConfigManager:
             insecure_skip_verify: value for `insecure_skip_verify` in all exporters
             queue_size: size of the sending queue for exporters
             max_elapsed_time_min: maximum elapsed time for retrying failed requests in minutes
-            internal_host: the unit FQDN the OTLP receiver's server cert is valid for; used as the
-                loopback self-ingest endpoint when receiver TLS is enabled.
+            internal_host: the unit FQDN the OTLP receiver's server cert is valid for
         """
         self._unit_name = unit_name
         self._insecure_skip_verify = insecure_skip_verify

--- a/src/constants.py
+++ b/src/constants.py
@@ -22,3 +22,9 @@ FILE_STORAGE_DIRECTORY: Final[str] = "/otelcol"
 CERTS_DIR: Final[str] = "/etc/otelcol/certs/"
 EXTERNAL_CONFIG_SECRETS_DIR: Final[str] = "/etc/otelcol/external_config_secrets/"
 INGRESS_IP_MATCHER: Final[str] = "ClientIP(`0.0.0.0/0`)"
+INTERNAL_LOGS_FILTER_ID: Final[str] = "internal-telemetry-loop-breaker"
+# `otelcol.component.id` prefixes of the log exporters the internal error logs are filtered for
+LOOPABLE_LOG_EXPORTER_ID_PREFIXES: Final[tuple] = (
+    "loki/send-loki-logs/",  # add_log_forwarding (send-loki-logs relation)
+    "loki/cloud-config",  # add_cloud_integrator (cloud-integrator relation)
+)

--- a/src/constants.py
+++ b/src/constants.py
@@ -22,9 +22,18 @@ FILE_STORAGE_DIRECTORY: Final[str] = "/otelcol"
 CERTS_DIR: Final[str] = "/etc/otelcol/certs/"
 EXTERNAL_CONFIG_SECRETS_DIR: Final[str] = "/etc/otelcol/external_config_secrets/"
 INGRESS_IP_MATCHER: Final[str] = "ClientIP(`0.0.0.0/0`)"
+
+# Loop-breaker for self-ingested internal telemetry.
+# The collector feeds its OWN internal logs into the `logs/<unit>` pipeline, so they can be
+# exported with topology labels. Only the exporter(s) attached to the LOGS pipeline can recurse:
+# such an exporter's "Exporting failed" log is itself an internal log, so it re-enters the same
+# pipeline and is re-exported -> an unbounded loop when the endpoint is down. We drop the logs
+# emitted by exactly those log-pipeline exporter components (matched on `otelcol.component.id`,
+# enumerated dynamically at build time in ConfigBuilder._populate_loop_breaker_filter). Every OTHER
+# component's logs -- including failure logs from exporters on the metrics/traces pipelines
+# (Mimir/remote-write, Tempo, OTLP-metrics/traces) -- pass through to Loki, since they cannot form
+# a cycle while the log path is up and are the most useful logs to see in Grafana.
 INTERNAL_LOGS_FILTER_ID: Final[str] = "internal-telemetry-loop-breaker"
-# `otelcol.component.id` prefixes of the log exporters the internal error logs are filtered for
-LOOPABLE_LOG_EXPORTER_ID_PREFIXES: Final[tuple] = (
-    "loki/send-loki-logs/",  # add_log_forwarding (send-loki-logs relation)
-    "loki/cloud-config",  # add_cloud_integrator (cloud-integrator relation)
-)
+# Exporter component-id prefixes that are auto-injected by the builder (not real destinations) and
+# so must never be treated as loop-through log exporters by the loop-breaker filter.
+NON_LOOPING_EXPORTER_PREFIXES: Final[tuple] = ("nop", "debug")

--- a/src/constants.py
+++ b/src/constants.py
@@ -22,18 +22,5 @@ FILE_STORAGE_DIRECTORY: Final[str] = "/otelcol"
 CERTS_DIR: Final[str] = "/etc/otelcol/certs/"
 EXTERNAL_CONFIG_SECRETS_DIR: Final[str] = "/etc/otelcol/external_config_secrets/"
 INGRESS_IP_MATCHER: Final[str] = "ClientIP(`0.0.0.0/0`)"
-
-# Loop-breaker for self-ingested internal telemetry.
-# The collector feeds its OWN internal logs into the `logs/<unit>` pipeline, so they can be
-# exported with topology labels. Only the exporter(s) attached to the LOGS pipeline can recurse:
-# such an exporter's "Exporting failed" log is itself an internal log, so it re-enters the same
-# pipeline and is re-exported -> an unbounded loop when the endpoint is down. We drop the logs
-# emitted by exactly those log-pipeline exporter components (matched on `otelcol.component.id`,
-# enumerated dynamically at build time in ConfigBuilder._populate_loop_breaker_filter). Every OTHER
-# component's logs -- including failure logs from exporters on the metrics/traces pipelines
-# (Mimir/remote-write, Tempo, OTLP-metrics/traces) -- pass through to Loki, since they cannot form
-# a cycle while the log path is up and are the most useful logs to see in Grafana.
 INTERNAL_LOGS_FILTER_ID: Final[str] = "internal-telemetry-loop-breaker"
-# Exporter component-id prefixes that are auto-injected by the builder (not real destinations) and
-# so must never be treated as loop-through log exporters by the loop-breaker filter.
 NON_LOOPING_EXPORTER_PREFIXES: Final[tuple] = ("nop", "debug")

--- a/src/constants.py
+++ b/src/constants.py
@@ -23,4 +23,5 @@ CERTS_DIR: Final[str] = "/etc/otelcol/certs/"
 EXTERNAL_CONFIG_SECRETS_DIR: Final[str] = "/etc/otelcol/external_config_secrets/"
 INGRESS_IP_MATCHER: Final[str] = "ClientIP(`0.0.0.0/0`)"
 INTERNAL_LOGS_FILTER_ID: Final[str] = "internal-telemetry-loop-breaker"
+INTERNAL_TELEMETRY_SERVICE_NAME: Final[str] = "otelcol-internal"
 NON_LOOPING_EXPORTER_PREFIXES: Final[tuple] = ("nop", "debug")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -25,6 +25,25 @@ RETRY = retry(
 )
 
 
+@RETRY
+def assert_pebble_service_active(
+    juju: jubilant.Juju, unit: str, container: str, service: str
+) -> None:
+    """Assert a Pebble service in a workload container is running (Current == active)."""
+    out = juju.ssh(target=unit, command=f"pebble services {service}", container=container)
+    # `pebble services <name>` prints a header then one row per service:
+    #   Service  Startup  Current  Since
+    #   <name>   enabled  active   ...
+    for line in out.splitlines():
+        cols = line.split()
+        if cols and cols[0] == service:
+            assert "active" in cols, f"pebble service {service!r} is not active: {out!r}"
+            return
+    raise AssertionError(
+        f"pebble service {service!r} not found in container {container!r}: {out!r}"
+    )
+
+
 def deploy_seaweedfs(juju: jubilant.Juju, app: str, s3_requirer_app: str) -> None:
     """Deploy seaweedfs-k8s and integrate it with the given S3-requiring app.
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,7 +2,27 @@
 # See LICENSE file for licensing details.
 """Shared helpers for integration tests."""
 
+import logging
+
 import jubilant
+from tenacity import (
+    after_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+# Reusable retry decorator for polling assertions in integration tests.
+# Retries only on AssertionError (so real errors surface immediately), with exponential backoff.
+RETRY = retry(
+    retry=retry_if_exception_type(AssertionError),
+    wait=wait_exponential(multiplier=1, min=2, max=45),
+    stop=stop_after_attempt(10),
+    after=after_log(logger, logging.INFO),
+)
 
 
 def deploy_seaweedfs(juju: jubilant.Juju, app: str, s3_requirer_app: str) -> None:

--- a/tests/integration/test_forwarding_otlp_telemetry.py
+++ b/tests/integration/test_forwarding_otlp_telemetry.py
@@ -6,25 +6,10 @@
 import logging
 from typing import Dict
 
-from tenacity import (
-    after_log,
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
-
 import jubilant
-
+from helpers import RETRY
 
 logger = logging.getLogger(__name__)
-
-RETRY = retry(
-    retry=retry_if_exception_type(AssertionError),
-    wait=wait_exponential(multiplier=1, min=2, max=45),
-    stop=stop_after_attempt(10),
-    after=after_log(logger, logging.INFO),
-)
 
 
 def test_otlp_setup(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -84,16 +84,36 @@ def _assert_loop_breaker_dropped_more(juju: jubilant.Juju, baseline: float) -> N
 
 
 @RETRY
-def _assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str) -> None:
-    """Assert the collector's own internal telemetry logs (job=otelcol-internal) reach Loki."""
+def _assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str, otelcol_app: str) -> None:
+    """Assert the collector's own internal telemetry logs reach Loki with Juju topology labels.
+
+    The internal logs are tagged with this collector's own Juju topology so that, when multiple
+    otelcol apps ship to the same Loki, their `job=otelcol-internal` streams stay distinguishable.
+    We also pin `service.instance.id` to the Juju unit, so the `instance` label is the unit (stable
+    and correlatable) rather than a random per-process UUID that churns on every restart.
+    """
     result = juju.ssh(
         target=f"{loki_app}/leader",
         command="/usr/bin/logcli series --quiet '{job=\"otelcol-internal\"}'",
         container="loki",
     )
-    # {instance="59c126fd-e67f-49c6-8008-5994b6d501b1", job="otelcol-internal", level="INFO", service_name="otelcol-internal"}
+    # {instance="otelcol/0", job="otelcol-internal", juju_application="otelcol", juju_charm="...",
+    #  juju_model="...", juju_model_uuid="...", juju_unit="otelcol/0", level="INFO", ...}
     assert "otelcol-internal" in result, (
         f"No `job=otelcol-internal` stream found in Loki: {result!r}"
+    )
+    # Topology labels are present and identify the emitting app/unit ...
+    for label in (
+        f'juju_application="{otelcol_app}"',
+        f'juju_unit="{otelcol_app}/0"',
+        "juju_model=",
+        "juju_model_uuid=",
+        "juju_charm=",
+    ):
+        assert label in result, f"Expected topology label {label!r} on internal logs: {result!r}"
+    # ... and the `instance` label is the Juju unit, not a random UUID.
+    assert f'instance="{otelcol_app}/0"' in result, (
+        f"Expected `instance` label pinned to the Juju unit: {result!r}"
     )
 
 
@@ -125,7 +145,7 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     _assert_topology_labels()
 
     # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
-    _assert_internal_logs_in_loki(juju, "loki")
+    _assert_internal_logs_in_loki(juju, "loki", "otelcol")
 
 
 def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
@@ -151,7 +171,7 @@ def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: 
     assert "application" in labels
 
     # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
-    _assert_internal_logs_in_loki(juju, "loki-pebble")
+    _assert_internal_logs_in_loki(juju, "loki-pebble", "otelcol-pebble")
 
 
 def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -3,12 +3,14 @@
 
 """Feature: Ingested logs are forwarded."""
 
+import json
 import logging
 import pathlib
-from typing import Dict
+import time
+from typing import Dict, Optional
 
 import jubilant
-from helpers import RETRY
+from helpers import RETRY, assert_pebble_service_active
 
 logger = logging.getLogger(__name__)
 
@@ -18,66 +20,79 @@ logger = logging.getLogger(__name__)
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
 
 
-def _dump_internal_logs_diagnostics(juju: jubilant.Juju, otelcol_app: str, loki_app: str) -> None:
-    """Log diagnostics to disambiguate why internal logs didn't reach Loki (CI-vs-local).
+def _jsonl_has_entries(result: str) -> bool:
+    """Assert `logcli query --output=jsonl` returned at least one real log entry.
 
-    Distinguishes the two possible failure boundaries:
-      * self-ingest boundary: the collector exports its own logs to its OWN OTLP receiver
-        (http://localhost:4318). If this fails, `otelcol_receiver_accepted_log_records` for the
-        otlp receiver stays at 0 and the otelcol logs show connection/TLS errors to :4318.
-      * Loki boundary: logs are ingested locally but never forwarded (send-loki-logs failing) or
-        arrive under a different label than `job=otelcol-internal`.
+    Each line is a JSON object like `{"labels": {...}, "line": "...", "timestamp": "..."}`. We parse
+    it (rather than a bare truthiness check on stdout) and require at least one entry with a
+    non-empty `line`. The caller's stream selector (e.g. `{job="otelcol-internal"}`) is what
+    guarantees the labels on the returned entries -- `logcli` strips labels common to all returned
+    streams from the per-line `labels` field (so it is often `{}`), which is why we do NOT assert on
+    that field here. Use `logcli series` when you need to assert the label set explicitly.
     """
+    entries = [line for line in result.splitlines() if line.strip()]
+    assert entries, f"logcli returned no log entries: {result!r}"
+    for line in entries:
+        if json.loads(line).get("line", "").strip():
+            return True
+    logger.error("logcli returned entries but none had a log line: %s", result)
+    return False
 
-    def _ssh(target: str, container: str, command: str) -> str:
-        try:
-            return juju.ssh(target=target, command=command, container=container)
-        except Exception as exc:  # noqa: BLE001 - diagnostics must never mask the real failure
-            return f"<ssh failed: {exc}>"
 
-    # 1) Self-export boundary: the collector exports its OWN logs to http://localhost:4318.
-    #    If that connection fails, the otelcol log tail shows connection/TLS errors to :4318, and
-    #    the internal logs never enter the pipeline (so they can't reach Loki). `curl` is NOT in
-    #    the rock, so we rely on the Pebble log tail, which is always available.
-    otelcol_logs = _ssh(f"{otelcol_app}/leader", "otelcol", "pebble logs -n 300")
-    suspicious = "\n".join(
-        line
-        for line in otelcol_logs.splitlines()
-        if any(
-            token in line.lower()
-            for token in ("4318", "x509", "certificate", "refused", "otelcol-internal", "error")
-        )
-    )
-    # 2) Loki boundary: what labels/streams actually exist? If ingestion works but the `job` label
-    #    differs in CI, `job` will list values other than (or missing) `otelcol-internal`.
-    loki_labels = _ssh(f"{loki_app}/leader", "loki", "/usr/bin/logcli labels")
-    loki_jobs = _ssh(f"{loki_app}/leader", "loki", "/usr/bin/logcli labels job")
+def _loop_breaker_filtered_count(juju: jubilant.Juju) -> Optional[float]:
+    """Return the latest loop-breaker `filtered` counter from otelcol's Pebble logs, else None.
 
-    logger.error(
-        "INTERNAL-LOGS DIAGNOSTICS\n"
-        "=== otelcol suspicious log lines (self-export to :4318 / errors) ===\n%s\n"
-        "=== loki labels ===\n%s\n"
-        "=== loki `job` label values ===\n%s\n"
-        "=== otelcol log tail (last 300) ===\n%s",
-        suspicious or "<no suspicious lines>",
-        loki_labels,
-        loki_jobs,
-        otelcol_logs,
-    )
+    Requires `debug_exporter_for_metrics=True` so the collector's internal metrics are printed to
+    the Pebble logs.
+
+    Note: the Pebble log ring buffer persists across the collector restarts triggered by config
+    changes, so callers that compare values over time should sample late (after enough fresh logs
+    have scrolled older, pre-restart samples out of the `-n 1000` window).
+
+    Sample:
+        2026-07-16T17:52:13.115Z [otelcol] otelcol_processor_filter_logs.filtered{
+            filter=filter/internal-telemetry-loop-breaker/otelcol/0,
+            juju_application=otelcol,
+            juju_charm=opentelemetry-collector-k8s,
+            juju_model=jubilant-14697ea3,
+            juju_model_uuid=35054976-38b2-4f7c-8c50-a793733187e2,
+            juju_unit=otelcol/0,
+            otel_scope_name=github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor,
+            service.instance.id=aaa3c609-a192-4bee-9b48-641cb2e92dcf,
+            service.name=otelcol-internal,
+            service.version=0.130.1
+        } 14
+    """
+    logs = juju.ssh(target="otelcol/leader", command="pebble logs -n 1000", container="otelcol")
+    value: Optional[float] = None
+    for line in logs.splitlines():
+        if "otelcol_processor_filter_logs.filtered" in line and "loop-breaker" in line:
+            value = float(line.rsplit(" ", 1)[-1])  # keep the most recent sample
+    return value
 
 
 @RETRY
-def assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str) -> None:
-    """Assert the collector's own internal telemetry logs (job=otelcol-internal) reach Loki.
+def _filter_dropped_logs(juju: jubilant.Juju) -> bool:
+    value = _loop_breaker_filtered_count(juju)
+    if value is None:
+        logger.warning("loop-breaker filter dropped logs counter not found in Pebble logs")
+        return False
+    logger.info("loop-breaker filter dropped logs counter: %s", value)
+    return value > 0
 
-    Ref: https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/323
-    """
+
+@RETRY
+def _assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str) -> None:
+    """Assert the collector's own internal telemetry logs (job=otelcol-internal) reach Loki."""
     result = juju.ssh(
         target=f"{loki_app}/leader",
-        command="/usr/bin/logcli query --quiet --limit=1 --output=jsonl '{job=\"otelcol-internal\"}'",
+        command="/usr/bin/logcli series --quiet '{job=\"otelcol-internal\"}'",
         container="loki",
     )
-    assert result.strip(), f"No internal logs (job=otelcol-internal) found in Loki: {result!r}"
+    # {instance="59c126fd-e67f-49c6-8008-5994b6d501b1", job="otelcol-internal", level="INFO", service_name="otelcol-internal"}
+    assert "otelcol-internal" in result, (
+        f"No `job=otelcol-internal` stream found in Loki: {result!r}"
+    )
 
 
 def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
@@ -85,7 +100,7 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     # GIVEN a model with flog, otel-collector, and loki
     juju.deploy(charm, "otelcol", resources=charm_resources, trust=True)
     juju.deploy("flog-k8s", "flog", channel="latest/stable")
-    juju.deploy("loki-k8s", "loki", channel="2/edge", trust=True)
+    juju.deploy("loki-k8s", "loki", channel="dev/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface
     juju.integrate("otelcol:receive-loki-logs", "flog:log-proxy")
@@ -108,21 +123,15 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     _assert_topology_labels()
 
     # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
-    try:
-        assert_internal_logs_in_loki(juju, "loki")
-    except Exception:
-        # RETRY re-raises as tenacity.RetryError (not AssertionError), so catch broadly.
-        # Dump otelcol/loki diagnostics once (after RETRY is exhausted) to root-cause CI failures.
-        _dump_internal_logs_diagnostics(juju, "otelcol", "loki")
-        raise
+    _assert_internal_logs_in_loki(juju, "loki")
 
 
 def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: log forwarding via Pebble log forwarding."""
     # GIVEN a model with flog, blackbox-exporter, otel-collector, and loki charms
     juju.deploy(charm, "otelcol-pebble", resources=charm_resources, trust=True)
-    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="2/edge", trust=True)
-    juju.deploy("loki-k8s", "loki-pebble", channel="2/edge", trust=True)
+    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="dev/edge", trust=True)
+    juju.deploy("loki-k8s", "loki-pebble", channel="dev/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface
     juju.integrate("otelcol-pebble:receive-loki-logs", "blackbox")
@@ -140,7 +149,7 @@ def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: 
     assert "application" in labels
 
     # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
-    assert_internal_logs_in_loki(juju, "loki-pebble")
+    _assert_internal_logs_in_loki(juju, "loki-pebble")
 
 
 def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
@@ -149,35 +158,18 @@ def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
     juju.config("otelcol", {"debug_exporter_for_metrics": True})
     juju.wait(lambda status: jubilant.all_active(status, "otelcol"), delay=5, timeout=300)
 
-    # AND the send-loki-logs exporter is failing (Loki workload stopped), which makes it emit
+    # AND the loop-breaker filter has not dropped any logs yet (Loki is healthy)
+    assert not _filter_dropped_logs(juju)
+
+    # WHEN the send-loki-logs exporter is failing (Loki workload stopped), which makes it emit
     # "Exporting failed" internal logs that recurse into the logs pipeline and must be dropped.
     juju.ssh(target="loki/leader", command="pebble stop loki", container="loki")
 
-    try:
-        # THEN the loop-breaker filter drops the looping exporter's own internal logs, visible as a
-        # positive `otelcol_processor_filter_logs.filtered` counter for the loop-breaker filter.
-        @RETRY
-        def _assert_filter_dropped_logs() -> None:
-            logs = juju.ssh(
-                target="otelcol/leader",
-                command="pebble logs -n 1000",
-                container="otelcol",
-            )
-            for line in logs.splitlines():
-                if "otelcol_processor_filter_logs.filtered" in line and "loop-breaker" in line:
-                    value = float(line.rsplit(" ", 1)[-1])
-                    if value > 0:
-                        return
-                    raise AssertionError(f"filter counter not > 0: {line}")
-            raise AssertionError(
-                "otelcol_processor_filter_logs.filtered (loop-breaker) not found in Pebble logs"
-            )
-
-        _assert_filter_dropped_logs()
-    finally:
-        # cleanup: bring Loki back and disable the debug exporter so later tests aren't affected
-        juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
-        juju.config("otelcol", {"debug_exporter_for_metrics": False})
+    # THEN the loop-breaker filter drops the looping exporter's own internal logs, visible as a
+    # positive `otelcol_processor_filter_logs.filtered` counter for the loop-breaker filter.
+    assert _filter_dropped_logs(juju)
+    juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
+    assert_pebble_service_active(juju, "loki/leader", "loki", "loki")
 
 
 def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.Juju):
@@ -186,40 +178,59 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
     The loop-breaker filter drops ONLY logs emitted by exporters on the LOGS pipeline (matched on
     `otelcol.component.id` AND `otelcol.signal == "logs"`). Failure logs from exporters on other
     pipelines (here: `prometheusremotewrite/0` on the metrics pipeline, which emits
-    `otelcol.signal: metrics`) must be preserved and forwarded to Loki, proving the fix is not
-    Loki-specific and does not over-drop cross-signal visibility.
+    `otelcol.signal: metrics`) must be preserved and forwarded to Loki.
     """
-    # GIVEN Loki is up and otelcol is related to a Prometheus over send-remote-write
-    juju.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True)
+
+    @RETRY
+    def _metrics_exporter_failure_logs_in_loki() -> bool:
+        # We match on the log BODY (`|= "Exporting failed"`): `send-loki-logs` stores logs with
+        # `loki.format: raw`, so the line is only the record body -- the `otelcol.component.id`
+        # lives on the instrumentation scope and is neither in the line nor a label. Since Loki is
+        # up (so `send-loki-logs` is healthy) and `prometheusremotewrite` is the only failing
+        # exporter.
+        result = juju.ssh(
+            target="loki/leader",
+            command=(
+                "/usr/bin/logcli query --quiet --limit=5 "
+                "--output=jsonl '{job=\"otelcol-internal\"} |= `Exporting failed`'"
+            ),
+            container="loki",
+        )
+        # {"labels":{},"line":"Exporting failed. Dropping data.","timestamp":"2026-07-16T17:58:18.118744382Z"}
+        return _jsonl_has_entries(result)
+
+    # GIVEN Loki is up and otelcol is related to a Prometheus over send-remote-write, with the
+    # metrics debug exporter on so the loop-breaker filter counter is printed to otelcol Pebble logs
+    juju.deploy("prometheus-k8s", "prometheus", channel="dev/edge", trust=True)
     juju.integrate("otelcol:send-remote-write", "prometheus")
+    juju.config("otelcol", {"debug_exporter_for_metrics": True})
     juju.wait(jubilant.all_active, delay=10, timeout=600)
+    assert not _metrics_exporter_failure_logs_in_loki()
 
     # WHEN the remote-write target is down, the metrics exporter (`prometheusremotewrite/0`) emits
     # "Exporting failed" internal logs carrying `otelcol.signal: metrics`.
     juju.ssh(target="prometheus/leader", command="pebble stop prometheus", container="prometheus")
 
     try:
-        # THEN those metrics-signal failure logs are NOT dropped by the loop-breaker filter and
-        # still arrive in Loki under {job="otelcol-internal"}, tagged with the metrics exporter id.
-        @RETRY
-        def _assert_metrics_exporter_failure_logs_in_loki() -> None:
-            result = juju.ssh(
-                target="loki/leader",
-                command=(
-                    "/usr/bin/logcli query --quiet --limit=5 --output=jsonl "
-                    "'{job=\"otelcol-internal\"} |= `prometheusremotewrite`'"
-                ),
-                container="loki",
-            )
-            assert result.strip(), (
-                "Metrics-exporter failure logs were not forwarded to Loki (over-dropped by the "
-                f"loop-breaker?): {result!r}"
-            )
+        # THEN those metrics-signal failure logs still arrive in Loki under {job="otelcol-internal"}.
+        breakpoint()
+        assert _metrics_exporter_failure_logs_in_loki()
 
-        _assert_metrics_exporter_failure_logs_in_loki()
+        # AND the loop-breaker did NOT drop them: with Loki healthy there are no logs-pipeline
+        # failures to legitimately drop, so the filter's drop counter must stay flat even while the
+        # metrics exporter keeps failing. Sampled twice, late (after the Loki check above), so
+        # pre-restart samples have scrolled out of the log window.
+        filtered = _loop_breaker_filtered_count(juju) or 0.0
+        time.sleep(30)  # let more metrics-signal failures flow through the filter
+        filtered_later = _loop_breaker_filtered_count(juju) or 0.0
+        assert filtered_later == filtered, (
+            "loop-breaker filter dropped logs during a metrics-only outage (over-dropping "
+            f"cross-signal logs?): {filtered} -> {filtered_later}"
+        )
     finally:
-        # cleanup: bring Prometheus back and remove the relation so later tests aren't affected
         juju.ssh(
             target="prometheus/leader", command="pebble start prometheus", container="prometheus"
         )
+        assert_pebble_service_active(juju, "prometheus/leader", "prometheus", "prometheus")
         juju.remove_relation("otelcol:send-remote-write", "prometheus")
+        juju.config("otelcol", {"debug_exporter_for_metrics": False})

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -7,6 +7,7 @@ import pathlib
 from typing import Dict
 
 import jubilant
+import tenacity
 
 # pyright: reportAttributeAccessIssue = false
 
@@ -37,6 +38,36 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
 
     for label in topology:
         assert label in labels, f"Expected '{label}' label in Loki, got: {labels}"
+
+
+def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
+    """Scenario: when the Loki exporter is down, the loop-breaker filter drops its own failure logs.
+
+    Guards the runtime contract that unit tests cannot: that the OTTL condition
+    (instrumentation_scope.attributes["otelcol.component.id"] + otelcol.signal) actually matches the
+    collector's self-ingested internal logs. Reuses the otelcol+loki deployment from the promtail test.
+    """
+    # GIVEN the send-loki-logs exporter is failing (Loki workload stopped)
+    juju.ssh(target="loki/leader", command="pebble stop --all", container="loki")
+
+    # THEN the loop-breaker filter drops the looping exporter's own internal logs
+    @tenacity.retry(stop=tenacity.stop_after_attempt(12), wait=tenacity.wait_fixed(10))
+    def _filter_dropped_logs() -> None:
+        metrics = juju.ssh(
+            target="otelcol/leader",
+            command="curl -s localhost:8888/metrics",
+            container="otelcol",
+        )
+        for line in metrics.splitlines():
+            if line.startswith("otelcol_processor_filter_logs_filtered") and "loop-breaker" in line:
+                assert float(line.rsplit(" ", 1)[-1]) > 0, f"filter not dropping: {line}"
+                return
+        raise AssertionError("otelcol_processor_filter_logs_filtered metric not found")
+
+    _filter_dropped_logs()
+
+    # cleanup: bring Loki back so later tests aren't affected
+    juju.ssh(target="loki/leader", command="pebble start --all", container="loki")
 
 
 def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -74,7 +74,7 @@ def assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str) -> None:
     """
     result = juju.ssh(
         target=f"{loki_app}/leader",
-        command="/usr/bin/logcli query --limit=1 --output=jsonl '{job=\"otelcol-internal\"}'",
+        command="/usr/bin/logcli query --quiet --limit=1 --output=jsonl '{job=\"otelcol-internal\"}'",
         container="loki",
     )
     assert result.strip(), f"No internal logs (job=otelcol-internal) found in Loki: {result!r}"
@@ -206,7 +206,7 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
             result = juju.ssh(
                 target="loki/leader",
                 command=(
-                    "/usr/bin/logcli query --limit=5 --output=jsonl "
+                    "/usr/bin/logcli query --quiet --limit=5 --output=jsonl "
                     "'{job=\"otelcol-internal\"} |= `prometheusremotewrite`'"
                 ),
                 container="loki",

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -69,6 +69,21 @@ def _loop_breaker_filtered_count(juju: jubilant.Juju) -> Optional[float]:
 
 
 @RETRY
+def _assert_loop_breaker_dropped_more(juju: jubilant.Juju, baseline: float) -> None:
+    """Assert otelcol's loop-breaker `filtered` counter has climbed above `baseline`.
+
+    Requires `debug_exporter_for_metrics=True` so the counter is printed to the Pebble logs (see
+    `_loop_breaker_filtered_count`). We assert on the DELTA rather than an absolute value because
+    the counter can already be > 0 due to transient logs-signal failures (e.g. Loki "not ready"
+    windows) that the loop-breaker legitimately drops.
+    """
+    current = _loop_breaker_filtered_count(juju) or 0.0
+    assert current > baseline, (
+        f"loop-breaker filter drop counter did not increase: {baseline} -> {current}"
+    )
+
+
+@RETRY
 def _assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str) -> None:
     """Assert the collector's own internal telemetry logs (job=otelcol-internal) reach Loki."""
     result = juju.ssh(
@@ -158,19 +173,10 @@ def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
     try:
         # THEN the loop-breaker drop counter climbs above the baseline as it drops the looping
         # exporter's own internal logs.
-        @RETRY
-        def _assert_filter_dropped_more() -> None:
-            current = _loop_breaker_filtered_count(juju) or 0.0
-            assert current > baseline, (
-                f"loop-breaker filter drop counter did not increase: {baseline} -> {current}"
-            )
-
-        _assert_filter_dropped_more()
+        _assert_loop_breaker_dropped_more(juju, baseline)
     finally:
         juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
         assert_pebble_service_active(juju, "loki/leader", "loki", "loki")
-        juju.config("otelcol", {"debug_exporter_for_metrics": False})
-
 
 
 def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.Juju):
@@ -186,27 +192,34 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
     juju.integrate("otelcol:send-remote-write", "prometheus")
     juju.wait(jubilant.all_active, delay=10, timeout=600)
 
+    # AND the metrics debug exporter is on, so the loop-breaker's drop counter is printed to the
+    # Pebble logs (see `_loop_breaker_filtered_count`).
+    juju.config("otelcol", {"debug_exporter_for_metrics": True})
+    juju.wait(lambda status: jubilant.all_active(status, "otelcol"), delay=5, timeout=300)
+
+    # Baseline the loop-breaker drop counter so we can later assert on the DELTA (it may already
+    # be > 0 from transient logs-signal failures).
+    baseline = _loop_breaker_filtered_count(juju) or 0.0
+
     # WHEN the remote-write target is down, the metrics exporter (`prometheusremotewrite/0`) emits
     # "Exporting failed" internal logs carrying `otelcol.signal: metrics`.
     juju.ssh(target="prometheus/leader", command="pebble stop prometheus", container="prometheus")
 
     try:
-        # THEN those metrics-signal failure logs arrive in Loki under {job="otelcol-internal"}.
+        # THEN the metrics-exporter's logs reach Loki, proving they were not over-dropped.
         #
-        # This is both the "forwarded" and the "not over-dropped" proof: the loop-breaker drops
-        # every LOGS-signal "Exporting failed" (so those never reach Loki), and
-        # `prometheusremotewrite` is the only failing non-logs exporter -- so any "Exporting failed"
-        # that reaches Loki is necessarily its metrics-signal log, proving it was preserved. We
-        # match on the log BODY (`|= "Exporting failed"`) because `send-loki-logs` stores logs with
-        # `loki.format: raw`: the line is only the record body, and `otelcol.component.id`/`signal`
-        # live on the instrumentation scope (neither in the line nor a label).
+        # `loki.format: logfmt` mangles the body text (`Exporting failed` is no longer a contiguous
+        # substring), so we match the scope attributes instead, which logfmt emits verbatim as
+        # `instrumentation_scope_attribute_<key>=<value>`.
         @RETRY
         def _assert_metrics_exporter_failure_logs_in_loki() -> None:
             result = juju.ssh(
                 target="loki/leader",
                 command=(
-                    "/usr/bin/logcli query --quiet --limit=5 "
-                    "--output=jsonl '{job=\"otelcol-internal\"} |= `Exporting failed`'"
+                    "/usr/bin/logcli query --quiet --limit=5 --output=jsonl "
+                    '\'{job="otelcol-internal"} '
+                    "|= `otelcol.component.id=prometheusremotewrite` "
+                    "|= `otelcol.signal=metrics`'"
                 ),
                 container="loki",
             )
@@ -216,10 +229,16 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
             )
 
         _assert_metrics_exporter_failure_logs_in_loki()
+
+        # AND the loop-breaker keeps dropping logs-signal failures (its counter still climbs above
+        # the baseline). Together with the assertion above, this proves the loop-breaker
+        # discriminates by signal: it drops `otelcol.signal: logs` failures while preserving the
+        # metrics-signal ones.
+        _assert_loop_breaker_dropped_more(juju, baseline)
     finally:
         juju.ssh(
             target="prometheus/leader", command="pebble start prometheus", container="prometheus"
         )
         assert_pebble_service_active(juju, "prometheus/leader", "prometheus", "prometheus")
+        juju.config("otelcol", {"debug_exporter_for_metrics": False})
         juju.remove_relation("otelcol:send-remote-write", "prometheus")
-

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -60,3 +60,4 @@ def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: 
     # FIXME: The Pebble log forwarding library sets different label names
     # Once they match, change this to `juju_application`
     assert "application" in labels
+    # TODO: Assert that internal logs reach loki

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -43,12 +43,12 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
 def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
     """Scenario: when the Loki exporter is down, the loop-breaker filter drops its own failure logs.
 
-    Guards the runtime contract that unit tests cannot: that the OTTL condition
-    (instrumentation_scope.attributes["otelcol.component.id"] + otelcol.signal) actually matches the
-    collector's self-ingested internal logs. Reuses the otelcol+loki deployment from the promtail test.
+    Checks that the OTTL condition
+    (instrumentation_scope.attributes["otelcol.component.id"] + otelcol.signal) actually matches
+    the collector's self-ingested internal logs.
     """
     # GIVEN the send-loki-logs exporter is failing (Loki workload stopped)
-    juju.ssh(target="loki/leader", command="pebble stop --all", container="loki")
+    juju.ssh(target="loki/leader", command="pebble stop loki", container="loki")
 
     # THEN the loop-breaker filter drops the looping exporter's own internal logs
     @tenacity.retry(stop=tenacity.stop_after_attempt(12), wait=tenacity.wait_fixed(10))
@@ -67,7 +67,7 @@ def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
     _filter_dropped_logs()
 
     # cleanup: bring Loki back so later tests aren't affected
-    juju.ssh(target="loki/leader", command="pebble start --all", container="loki")
+    juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
 
 
 def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -3,16 +3,67 @@
 
 """Feature: Ingested logs are forwarded."""
 
+import logging
 import pathlib
 from typing import Dict
 
 import jubilant
 from helpers import RETRY
 
+logger = logging.getLogger(__name__)
+
 # pyright: reportAttributeAccessIssue = false
 
 # Juju is a strictly confined snap that cannot see /tmp, so we need to use something else
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
+
+
+def _dump_internal_logs_diagnostics(juju: jubilant.Juju, otelcol_app: str, loki_app: str) -> None:
+    """Log diagnostics to disambiguate why internal logs didn't reach Loki (CI-vs-local).
+
+    Distinguishes the two possible failure boundaries:
+      * self-ingest boundary: the collector exports its own logs to its OWN OTLP receiver
+        (http://localhost:4318). If this fails, `otelcol_receiver_accepted_log_records` for the
+        otlp receiver stays at 0 and the otelcol logs show connection/TLS errors to :4318.
+      * Loki boundary: logs are ingested locally but never forwarded (send-loki-logs failing) or
+        arrive under a different label than `job=otelcol-internal`.
+    """
+
+    def _ssh(target: str, container: str, command: str) -> str:
+        try:
+            return juju.ssh(target=target, command=command, container=container)
+        except Exception as exc:  # noqa: BLE001 - diagnostics must never mask the real failure
+            return f"<ssh failed: {exc}>"
+
+    # 1) Self-export boundary: the collector exports its OWN logs to http://localhost:4318.
+    #    If that connection fails, the otelcol log tail shows connection/TLS errors to :4318, and
+    #    the internal logs never enter the pipeline (so they can't reach Loki). `curl` is NOT in
+    #    the rock, so we rely on the Pebble log tail, which is always available.
+    otelcol_logs = _ssh(f"{otelcol_app}/leader", "otelcol", "pebble logs -n 300")
+    suspicious = "\n".join(
+        line
+        for line in otelcol_logs.splitlines()
+        if any(
+            token in line.lower()
+            for token in ("4318", "x509", "certificate", "refused", "otelcol-internal", "error")
+        )
+    )
+    # 2) Loki boundary: what labels/streams actually exist? If ingestion works but the `job` label
+    #    differs in CI, `job` will list values other than (or missing) `otelcol-internal`.
+    loki_labels = _ssh(f"{loki_app}/leader", "loki", "/usr/bin/logcli labels")
+    loki_jobs = _ssh(f"{loki_app}/leader", "loki", "/usr/bin/logcli labels job")
+
+    logger.error(
+        "INTERNAL-LOGS DIAGNOSTICS\n"
+        "=== otelcol suspicious log lines (self-export to :4318 / errors) ===\n%s\n"
+        "=== loki labels ===\n%s\n"
+        "=== loki `job` label values ===\n%s\n"
+        "=== otelcol log tail (last 300) ===\n%s",
+        suspicious or "<no suspicious lines>",
+        loki_labels,
+        loki_jobs,
+        otelcol_logs,
+    )
 
 
 @RETRY
@@ -57,7 +108,12 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     _assert_topology_labels()
 
     # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
-    assert_internal_logs_in_loki(juju, "loki")
+    try:
+        assert_internal_logs_in_loki(juju, "loki")
+    except AssertionError:
+        # Dump otelcol/loki diagnostics once (after RETRY is exhausted) to root-cause CI failures.
+        _dump_internal_logs_diagnostics(juju, "otelcol", "loki")
+        raise
 
 
 def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -110,7 +110,8 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
     try:
         assert_internal_logs_in_loki(juju, "loki")
-    except AssertionError:
+    except Exception:
+        # RETRY re-raises as tenacity.RetryError (not AssertionError), so catch broadly.
         # Dump otelcol/loki diagnostics once (after RETRY is exhausted) to root-cause CI failures.
         _dump_internal_logs_diagnostics(juju, "otelcol", "loki")
         raise

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -23,7 +23,7 @@ def assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str) -> None:
     """
     result = juju.ssh(
         target=f"{loki_app}/leader",
-        command='/usr/bin/logcli query --limit=1 --output=jsonl \'{job="otelcol-internal"}\'',
+        command="/usr/bin/logcli query --limit=1 --output=jsonl '{job=\"otelcol-internal\"}'",
         container="loki",
     )
     assert result.strip(), f"No internal logs (job=otelcol-internal) found in Loki: {result!r}"
@@ -58,6 +58,32 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
 
     # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
     assert_internal_logs_in_loki(juju, "loki")
+
+
+def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
+    """Scenario: log forwarding via Pebble log forwarding."""
+    # GIVEN a model with flog, blackbox-exporter, otel-collector, and loki charms
+    juju.deploy(charm, "otelcol-pebble", resources=charm_resources, trust=True)
+    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="2/edge", trust=True)
+    juju.deploy("loki-k8s", "loki-pebble", channel="2/edge", trust=True)
+
+    # WHEN they are related to over the loki_push_api interface
+    juju.integrate("otelcol-pebble:receive-loki-logs", "blackbox")
+    juju.integrate("otelcol-pebble:send-loki-logs", "loki-pebble")
+    juju.wait(jubilant.all_active, delay=10, timeout=600)
+
+    # THEN logs arrive in loki
+    labels = juju.ssh(
+        target="loki-pebble/leader",
+        command="/usr/bin/logcli labels",
+        container="loki",
+    )
+    # FIXME: The Pebble log forwarding library sets different label names
+    # Once they match, change this to `juju_application`
+    assert "application" in labels
+
+    # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
+    assert_internal_logs_in_loki(juju, "loki-pebble")
 
 
 def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
@@ -97,27 +123,46 @@ def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
         juju.config("otelcol", {"debug_exporter_for_metrics": False})
 
 
-def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
-    """Scenario: log forwarding via Pebble log forwarding."""
-    # GIVEN a model with flog, blackbox-exporter, otel-collector, and loki charms
-    juju.deploy(charm, "otelcol-pebble", resources=charm_resources, trust=True)
-    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="2/edge", trust=True)
-    juju.deploy("loki-k8s", "loki-pebble", channel="2/edge", trust=True)
+def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.Juju):
+    """Scenario: a metrics exporter's failure logs still reach Loki (they are NOT loop-dropped).
 
-    # WHEN they are related to over the loki_push_api interface
-    juju.integrate("otelcol-pebble:receive-loki-logs", "blackbox")
-    juju.integrate("otelcol-pebble:send-loki-logs", "loki-pebble")
+    The loop-breaker filter drops ONLY logs emitted by exporters on the LOGS pipeline (matched on
+    `otelcol.component.id` AND `otelcol.signal == "logs"`). Failure logs from exporters on other
+    pipelines (here: `prometheusremotewrite/0` on the metrics pipeline, which emits
+    `otelcol.signal: metrics`) must be preserved and forwarded to Loki, proving the fix is not
+    Loki-specific and does not over-drop cross-signal visibility.
+    """
+    # GIVEN Loki is up and otelcol is related to a Prometheus over send-remote-write
+    juju.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True)
+    juju.integrate("otelcol:send-remote-write", "prometheus")
     juju.wait(jubilant.all_active, delay=10, timeout=600)
 
-    # THEN logs arrive in loki
-    labels = juju.ssh(
-        target="loki-pebble/leader",
-        command="/usr/bin/logcli labels",
-        container="loki",
-    )
-    # FIXME: The Pebble log forwarding library sets different label names
-    # Once they match, change this to `juju_application`
-    assert "application" in labels
+    # WHEN the remote-write target is down, the metrics exporter (`prometheusremotewrite/0`) emits
+    # "Exporting failed" internal logs carrying `otelcol.signal: metrics`.
+    juju.ssh(target="prometheus/leader", command="pebble stop prometheus", container="prometheus")
 
-    # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
-    assert_internal_logs_in_loki(juju, "loki-pebble")
+    try:
+        # THEN those metrics-signal failure logs are NOT dropped by the loop-breaker filter and
+        # still arrive in Loki under {job="otelcol-internal"}, tagged with the metrics exporter id.
+        @RETRY
+        def _assert_metrics_exporter_failure_logs_in_loki() -> None:
+            result = juju.ssh(
+                target="loki/leader",
+                command=(
+                    "/usr/bin/logcli query --limit=5 --output=jsonl "
+                    "'{job=\"otelcol-internal\"} |= `prometheusremotewrite`'"
+                ),
+                container="loki",
+            )
+            assert result.strip(), (
+                "Metrics-exporter failure logs were not forwarded to Loki (over-dropped by the "
+                f"loop-breaker?): {result!r}"
+            )
+
+        _assert_metrics_exporter_failure_logs_in_loki()
+    finally:
+        # cleanup: bring Prometheus back and remove the relation so later tests aren't affected
+        juju.ssh(
+            target="prometheus/leader", command="pebble start prometheus", container="prometheus"
+        )
+        juju.remove_relation("otelcol:send-remote-write", "prometheus")

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -7,12 +7,26 @@ import pathlib
 from typing import Dict
 
 import jubilant
-import tenacity
+from helpers import RETRY
 
 # pyright: reportAttributeAccessIssue = false
 
 # Juju is a strictly confined snap that cannot see /tmp, so we need to use something else
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
+
+
+@RETRY
+def assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str) -> None:
+    """Assert the collector's own internal telemetry logs (job=otelcol-internal) reach Loki.
+
+    Ref: https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/323
+    """
+    result = juju.ssh(
+        target=f"{loki_app}/leader",
+        command='/usr/bin/logcli query --limit=1 --output=jsonl \'{job="otelcol-internal"}\'',
+        container="loki",
+    )
+    assert result.strip(), f"No internal logs (job=otelcol-internal) found in Loki: {result!r}"
 
 
 def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
@@ -28,46 +42,59 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     juju.wait(jubilant.all_active, delay=10, timeout=600)
 
     # THEN logs arrive in loki with juju topology labels preserved
-    # Ref: https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/172
-    labels = juju.ssh(
-        target="loki/leader",
-        command="/usr/bin/logcli labels",
-        container="loki",
-    )
     topology = {"juju_application", "juju_charm", "juju_unit", "juju_model", "juju_model_uuid"}
 
-    for label in topology:
-        assert label in labels, f"Expected '{label}' label in Loki, got: {labels}"
+    @RETRY
+    def _assert_topology_labels() -> None:
+        labels = juju.ssh(
+            target="loki/leader",
+            command="/usr/bin/logcli labels",
+            container="loki",
+        )
+        for label in topology:
+            assert label in labels, f"Expected '{label}' label in Loki, got: {labels}"
+
+    _assert_topology_labels()
+
+    # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
+    assert_internal_logs_in_loki(juju, "loki")
 
 
 def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
-    """Scenario: when the Loki exporter is down, the loop-breaker filter drops its own failure logs.
+    """Scenario: when the Loki exporter is down, the loop-breaker filter drops its own failure logs."""
+    # GIVEN the metrics debug exporter is on, so internal metrics are printed to the Pebble logs
+    juju.config("otelcol", {"debug_exporter_for_metrics": True})
+    juju.wait(lambda status: jubilant.all_active(status, "otelcol"), delay=5, timeout=300)
 
-    Checks that the OTTL condition
-    (instrumentation_scope.attributes["otelcol.component.id"] + otelcol.signal) actually matches
-    the collector's self-ingested internal logs.
-    """
-    # GIVEN the send-loki-logs exporter is failing (Loki workload stopped)
+    # AND the send-loki-logs exporter is failing (Loki workload stopped), which makes it emit
+    # "Exporting failed" internal logs that recurse into the logs pipeline and must be dropped.
     juju.ssh(target="loki/leader", command="pebble stop loki", container="loki")
 
-    # THEN the loop-breaker filter drops the looping exporter's own internal logs
-    @tenacity.retry(stop=tenacity.stop_after_attempt(12), wait=tenacity.wait_fixed(10))
-    def _filter_dropped_logs() -> None:
-        metrics = juju.ssh(
-            target="otelcol/leader",
-            command="curl -s localhost:8888/metrics",
-            container="otelcol",
-        )
-        for line in metrics.splitlines():
-            if line.startswith("otelcol_processor_filter_logs_filtered") and "loop-breaker" in line:
-                assert float(line.rsplit(" ", 1)[-1]) > 0, f"filter not dropping: {line}"
-                return
-        raise AssertionError("otelcol_processor_filter_logs_filtered metric not found")
+    try:
+        # THEN the loop-breaker filter drops the looping exporter's own internal logs, visible as a
+        # positive `otelcol_processor_filter_logs.filtered` counter for the loop-breaker filter.
+        @RETRY
+        def _assert_filter_dropped_logs() -> None:
+            logs = juju.ssh(
+                target="otelcol/leader",
+                command="pebble logs -n 1000",
+                container="otelcol",
+            )
+            for line in logs.splitlines():
+                if "otelcol_processor_filter_logs.filtered" in line and "loop-breaker" in line:
+                    value = float(line.rsplit(" ", 1)[-1])
+                    if value > 0:
+                        return
+                    raise AssertionError(f"filter counter not > 0: {line}")
+            raise AssertionError(
+                "otelcol_processor_filter_logs.filtered (loop-breaker) not found in Pebble logs"
+            )
 
-    _filter_dropped_logs()
-
-    # cleanup: bring Loki back so later tests aren't affected
-    juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
+        _assert_filter_dropped_logs()
+    finally:
+        # cleanup: bring Loki back and disable the debug exporter so later tests aren't affected
+        juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
+        juju.config("otelcol", {"debug_exporter_for_metrics": False})
 
 
 def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
@@ -91,4 +118,6 @@ def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: 
     # FIXME: The Pebble log forwarding library sets different label names
     # Once they match, change this to `juju_application`
     assert "application" in labels
-    # TODO: Assert that internal logs reach loki
+
+    # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
+    assert_internal_logs_in_loki(juju, "loki-pebble")

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -6,7 +6,6 @@
 import json
 import logging
 import pathlib
-import time
 from typing import Dict, Optional
 
 import jubilant
@@ -21,21 +20,19 @@ TEMP_DIR = pathlib.Path(__file__).parent.resolve()
 
 
 def _jsonl_has_entries(result: str) -> bool:
-    """Assert `logcli query --output=jsonl` returned at least one real log entry.
+    """Return True if `logcli query --output=jsonl` output has at least one real log entry.
 
     Each line is a JSON object like `{"labels": {...}, "line": "...", "timestamp": "..."}`. We parse
-    it (rather than a bare truthiness check on stdout) and require at least one entry with a
-    non-empty `line`. The caller's stream selector (e.g. `{job="otelcol-internal"}`) is what
-    guarantees the labels on the returned entries -- `logcli` strips labels common to all returned
-    streams from the per-line `labels` field (so it is often `{}`), which is why we do NOT assert on
-    that field here. Use `logcli series` when you need to assert the label set explicitly.
+    it (rather than a bare truthiness check on stdout, which would also match `logcli` metadata) and
+    require at least one entry with a non-empty `line`. This is a pure predicate; callers wrap it in
+    an assertion (typically under `@RETRY`). The caller's stream selector (e.g.
+    `{job="otelcol-internal"}`) is what guarantees the labels on the returned entries -- `logcli`
+    strips labels common to all returned streams from the per-line `labels` field (so it is often
+    `{}`), which is why we do NOT assert on that field here; use `logcli series` for that.
     """
-    entries = [line for line in result.splitlines() if line.strip()]
-    assert entries, f"logcli returned no log entries: {result!r}"
-    for line in entries:
-        if json.loads(line).get("line", "").strip():
+    for line in result.splitlines():
+        if line.strip() and json.loads(line).get("line", "").strip():
             return True
-    logger.error("logcli returned entries but none had a log line: %s", result)
     return False
 
 
@@ -69,16 +66,6 @@ def _loop_breaker_filtered_count(juju: jubilant.Juju) -> Optional[float]:
         if "otelcol_processor_filter_logs.filtered" in line and "loop-breaker" in line:
             value = float(line.rsplit(" ", 1)[-1])  # keep the most recent sample
     return value
-
-
-@RETRY
-def _filter_dropped_logs(juju: jubilant.Juju) -> bool:
-    value = _loop_breaker_filtered_count(juju)
-    if value is None:
-        logger.warning("loop-breaker filter dropped logs counter not found in Pebble logs")
-        return False
-    logger.info("loop-breaker filter dropped logs counter: %s", value)
-    return value > 0
 
 
 @RETRY
@@ -158,18 +145,32 @@ def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
     juju.config("otelcol", {"debug_exporter_for_metrics": True})
     juju.wait(lambda status: jubilant.all_active(status, "otelcol"), delay=5, timeout=300)
 
-    # AND the loop-breaker filter has not dropped any logs yet (Loki is healthy)
-    assert not _filter_dropped_logs(juju)
+    # Baseline the loop-breaker drop counter. It may already be > 0: Loki can have transient
+    # "not ready" windows (e.g. ingester warmup) during which send-loki-logs fails and the
+    # loop-breaker correctly drops those recursive logs-signal failures. So we assert on the DELTA
+    # once we stop Loki, never on an absolute zero.
+    baseline = _loop_breaker_filtered_count(juju) or 0.0
 
     # WHEN the send-loki-logs exporter is failing (Loki workload stopped), which makes it emit
     # "Exporting failed" internal logs that recurse into the logs pipeline and must be dropped.
     juju.ssh(target="loki/leader", command="pebble stop loki", container="loki")
 
-    # THEN the loop-breaker filter drops the looping exporter's own internal logs, visible as a
-    # positive `otelcol_processor_filter_logs.filtered` counter for the loop-breaker filter.
-    assert _filter_dropped_logs(juju)
-    juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
-    assert_pebble_service_active(juju, "loki/leader", "loki", "loki")
+    try:
+        # THEN the loop-breaker drop counter climbs above the baseline as it drops the looping
+        # exporter's own internal logs.
+        @RETRY
+        def _assert_filter_dropped_more() -> None:
+            current = _loop_breaker_filtered_count(juju) or 0.0
+            assert current > baseline, (
+                f"loop-breaker filter drop counter did not increase: {baseline} -> {current}"
+            )
+
+        _assert_filter_dropped_more()
+    finally:
+        juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
+        assert_pebble_service_active(juju, "loki/leader", "loki", "loki")
+        juju.config("otelcol", {"debug_exporter_for_metrics": False})
+
 
 
 def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.Juju):
@@ -180,57 +181,45 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
     pipelines (here: `prometheusremotewrite/0` on the metrics pipeline, which emits
     `otelcol.signal: metrics`) must be preserved and forwarded to Loki.
     """
-
-    @RETRY
-    def _metrics_exporter_failure_logs_in_loki() -> bool:
-        # We match on the log BODY (`|= "Exporting failed"`): `send-loki-logs` stores logs with
-        # `loki.format: raw`, so the line is only the record body -- the `otelcol.component.id`
-        # lives on the instrumentation scope and is neither in the line nor a label. Since Loki is
-        # up (so `send-loki-logs` is healthy) and `prometheusremotewrite` is the only failing
-        # exporter.
-        result = juju.ssh(
-            target="loki/leader",
-            command=(
-                "/usr/bin/logcli query --quiet --limit=5 "
-                "--output=jsonl '{job=\"otelcol-internal\"} |= `Exporting failed`'"
-            ),
-            container="loki",
-        )
-        # {"labels":{},"line":"Exporting failed. Dropping data.","timestamp":"2026-07-16T17:58:18.118744382Z"}
-        return _jsonl_has_entries(result)
-
-    # GIVEN Loki is up and otelcol is related to a Prometheus over send-remote-write, with the
-    # metrics debug exporter on so the loop-breaker filter counter is printed to otelcol Pebble logs
-    juju.deploy("prometheus-k8s", "prometheus", channel="dev/edge", trust=True)
+    # GIVEN Loki is up and otelcol is related to a Prometheus over send-remote-write
+    juju.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True)
     juju.integrate("otelcol:send-remote-write", "prometheus")
-    juju.config("otelcol", {"debug_exporter_for_metrics": True})
     juju.wait(jubilant.all_active, delay=10, timeout=600)
-    assert not _metrics_exporter_failure_logs_in_loki()
 
     # WHEN the remote-write target is down, the metrics exporter (`prometheusremotewrite/0`) emits
     # "Exporting failed" internal logs carrying `otelcol.signal: metrics`.
     juju.ssh(target="prometheus/leader", command="pebble stop prometheus", container="prometheus")
 
     try:
-        # THEN those metrics-signal failure logs still arrive in Loki under {job="otelcol-internal"}.
-        breakpoint()
-        assert _metrics_exporter_failure_logs_in_loki()
+        # THEN those metrics-signal failure logs arrive in Loki under {job="otelcol-internal"}.
+        #
+        # This is both the "forwarded" and the "not over-dropped" proof: the loop-breaker drops
+        # every LOGS-signal "Exporting failed" (so those never reach Loki), and
+        # `prometheusremotewrite` is the only failing non-logs exporter -- so any "Exporting failed"
+        # that reaches Loki is necessarily its metrics-signal log, proving it was preserved. We
+        # match on the log BODY (`|= "Exporting failed"`) because `send-loki-logs` stores logs with
+        # `loki.format: raw`: the line is only the record body, and `otelcol.component.id`/`signal`
+        # live on the instrumentation scope (neither in the line nor a label).
+        @RETRY
+        def _assert_metrics_exporter_failure_logs_in_loki() -> None:
+            result = juju.ssh(
+                target="loki/leader",
+                command=(
+                    "/usr/bin/logcli query --quiet --limit=5 "
+                    "--output=jsonl '{job=\"otelcol-internal\"} |= `Exporting failed`'"
+                ),
+                container="loki",
+            )
+            assert _jsonl_has_entries(result), (
+                "Metrics-exporter failure logs were not forwarded to Loki (over-dropped by the "
+                f"loop-breaker?): {result!r}"
+            )
 
-        # AND the loop-breaker did NOT drop them: with Loki healthy there are no logs-pipeline
-        # failures to legitimately drop, so the filter's drop counter must stay flat even while the
-        # metrics exporter keeps failing. Sampled twice, late (after the Loki check above), so
-        # pre-restart samples have scrolled out of the log window.
-        filtered = _loop_breaker_filtered_count(juju) or 0.0
-        time.sleep(30)  # let more metrics-signal failures flow through the filter
-        filtered_later = _loop_breaker_filtered_count(juju) or 0.0
-        assert filtered_later == filtered, (
-            "loop-breaker filter dropped logs during a metrics-only outage (over-dropping "
-            f"cross-signal logs?): {filtered} -> {filtered_later}"
-        )
+        _assert_metrics_exporter_failure_logs_in_loki()
     finally:
         juju.ssh(
             target="prometheus/leader", command="pebble start prometheus", container="prometheus"
         )
         assert_pebble_service_active(juju, "prometheus/leader", "prometheus", "prometheus")
         juju.remove_relation("otelcol:send-remote-write", "prometheus")
-        juju.config("otelcol", {"debug_exporter_for_metrics": False})
+

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -192,14 +192,9 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
     juju.integrate("otelcol:send-remote-write", "prometheus")
     juju.wait(jubilant.all_active, delay=10, timeout=600)
 
-    # AND the metrics debug exporter is on, so the loop-breaker's drop counter is printed to the
-    # Pebble logs (see `_loop_breaker_filtered_count`).
+    # AND the metrics debug exporter is on, so internal metrics are printed to the Pebble logs.
     juju.config("otelcol", {"debug_exporter_for_metrics": True})
     juju.wait(lambda status: jubilant.all_active(status, "otelcol"), delay=5, timeout=300)
-
-    # Baseline the loop-breaker drop counter so we can later assert on the DELTA (it may already
-    # be > 0 from transient logs-signal failures).
-    baseline = _loop_breaker_filtered_count(juju) or 0.0
 
     # WHEN the remote-write target is down, the metrics exporter (`prometheusremotewrite/0`) emits
     # "Exporting failed" internal logs carrying `otelcol.signal: metrics`.
@@ -229,12 +224,6 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
             )
 
         _assert_metrics_exporter_failure_logs_in_loki()
-
-        # AND the loop-breaker keeps dropping logs-signal failures (its counter still climbs above
-        # the baseline). Together with the assertion above, this proves the loop-breaker
-        # discriminates by signal: it drops `otelcol.signal: logs` failures while preserving the
-        # metrics-signal ones.
-        _assert_loop_breaker_dropped_more(juju, baseline)
     finally:
         juju.ssh(
             target="prometheus/leader", command="pebble start prometheus", container="prometheus"

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -108,6 +108,45 @@ def test_rendered_default_is_valid():
     assert all(all(condition for condition in pair) for pair in pairs)
 
 
+def test_default_internal_logs_self_export_plaintext():
+    # GIVEN a default config without receiver TLS
+    config = ConfigBuilder(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        receiver_tls=False,
+    )
+    config.add_default_config()
+    logs_telemetry = config._config["service"]["telemetry"]["logs"]
+    # THEN internal logs are tagged so they are distinguishable in Grafana
+    assert logs_telemetry["initial_fields"] == {"job": "otelcol-internal"}
+    # AND internal logs are exported over OTLP to the collector's own OTLP receiver
+    otlp = logs_telemetry["processors"][0]["batch"]["exporter"]["otlp"]
+    assert otlp["protocol"] == "http/protobuf"
+    # AND the loopback endpoint uses plaintext HTTP with no CA certificate
+    assert otlp["endpoint"] == "http://localhost:4318"
+    assert "certificate" not in otlp
+
+
+def test_default_internal_logs_self_export_tls():
+    # GIVEN a default config WITH receiver TLS
+    config = ConfigBuilder(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        receiver_tls=True,
+    )
+    config.add_default_config()
+    otlp = config._config["service"]["telemetry"]["logs"]["processors"][0]["batch"]["exporter"][
+        "otlp"
+    ]
+    # THEN the loopback endpoint uses HTTPS and trusts the CA cert
+    assert otlp["endpoint"] == "https://localhost:4318"
+    assert otlp["certificate"] == (
+        "/usr/local/share/ca-certificates/juju_receive-ca-cert/cos-ca.crt"
+    )
+
+
 def test_receivers_tls_empty_config():
     # GIVEN an "empty" config
     config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -118,8 +118,11 @@ def test_default_internal_logs_self_export_plaintext():
     )
     config.add_default_config()
     logs_telemetry = config._config["service"]["telemetry"]["logs"]
-    # THEN internal logs are tagged so they are distinguishable in Grafana
-    assert logs_telemetry["initial_fields"] == {"job": "otelcol-internal"}
+    # THEN the collector's own telemetry resource is tagged so the Loki exporter derives
+    # `job=otelcol-internal` from `service.name` deterministically (distinguishable in Grafana)
+    assert config._config["service"]["telemetry"]["resource"] == {
+        "service.name": "otelcol-internal"
+    }
     # AND internal logs are exported over OTLP to the collector's own OTLP receiver
     otlp = logs_telemetry["processors"][0]["batch"]["exporter"]["otlp"]
     assert otlp["protocol"] == "http/protobuf"

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -147,6 +147,28 @@ def test_default_internal_logs_self_export_tls():
     )
 
 
+def test_default_internal_logs_loop_breaker_filter_present():
+    # GIVEN a default config (which self-ingests internal logs into the logs pipeline)
+    config = ConfigBuilder(
+        unit_name="fake/0", global_scrape_interval="", global_scrape_timeout=""
+    )
+    config.add_default_config()
+    # THEN a loop-breaker filter processor exists
+    filter_name = "filter/internal-telemetry-loop-breaker/fake/0"
+    assert filter_name in config._config["processors"]
+    filter_cfg = config._config["processors"][filter_name]
+    # AND it drops ONLY the failure logs of the log exporter(s) the internal logs loop through,
+    # keyed on their otelcol.component.id prefix (so OTHER exporters' failure logs pass through)
+    assert filter_cfg["logs"]["log_record"] == [
+        'IsMatch(attributes["otelcol.component.id"], "^loki/send-loki-logs/")',
+        'IsMatch(attributes["otelcol.component.id"], "^loki/cloud-config")',
+    ]
+    # AND it is resilient to OTTL evaluation errors (does not drop valid data)
+    assert filter_cfg["error_mode"] == "ignore"
+    # AND it is wired into the self-ingested logs pipeline
+    assert filter_name in config._config["service"]["pipelines"]["logs/fake/0"]["processors"]
+
+
 def test_receivers_tls_empty_config():
     # GIVEN an "empty" config
     config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -148,11 +148,8 @@ def test_default_internal_logs_self_export_tls():
         otlp["endpoint"]
         == "https://otelcol-0.otelcol-endpoints.o11y.svc.cluster.local:4318"
     )
-    # AND no explicit CA is configured: trust is via the system root store (the charm installs the
-    # server CA with update-ca-certificates), so the exporter falls back to the system cert pool
+    # AND no explicit CA is configured: trust is via the system root store
     assert "certificate" not in otlp
-    # AND no skip-verify knob is needed (endpoint matches the SAN); the OTel SDK schema has no
-    # `tls`/`insecure_skip_verify` anyway
     assert "insecure" not in otlp
     assert "tls" not in otlp
 

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -158,75 +158,43 @@ def test_default_internal_logs_self_export_tls():
 
 
 def test_default_internal_logs_loop_breaker_filter_present():
-    # GIVEN a default config (which self-ingests internal logs into the logs pipeline)
-    config = ConfigBuilder(
-        unit_name="fake/0", global_scrape_interval="", global_scrape_timeout=""
-    )
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config.add_default_config()
-    # THEN a loop-breaker filter processor exists on the self-ingested logs pipeline
     filter_name = "filter/internal-telemetry-loop-breaker/fake/0"
-    assert filter_name in config._config["processors"]
     filter_cfg = config._config["processors"][filter_name]
-    # AND it is resilient to OTTL evaluation errors (does not drop valid data)
+    # Filter is wired into the logs pipeline and tolerates OTTL eval errors (keeps valid data).
     assert filter_cfg["error_mode"] == "ignore"
-    # AND it is wired into the logs pipeline
     assert filter_name in config._config["service"]["pipelines"]["logs/fake/0"]["processors"]
-    # AND before build() its drop conditions are empty (populated dynamically at build time)
-    assert filter_cfg["logs"]["log_record"] == []
 
 
 def test_loop_breaker_filter_conditions_populated_from_logs_exporters():
-    # GIVEN a default config with a real log exporter and a nop-only build
-    config = ConfigBuilder(
-        unit_name="fake/0", global_scrape_interval="", global_scrape_timeout=""
-    )
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config.add_default_config()
-    # AND a couple of log exporters wired into the logs pipeline (as add_log_forwarding would)
+    for name in ("loki/send-loki-logs/0", "otlphttp/rel-1/fake/0"):
+        config.add_component(Component.exporter, name, {"endpoint": "x"}, pipelines=["logs/fake/0"])
+    # A non-log exporter (metrics pipeline) must NOT be covered.
     config.add_component(
-        Component.exporter,
-        "loki/send-loki-logs/0",
-        {"endpoint": "http://loki/loki/api/v1/push"},
-        pipelines=["logs/fake/0"],
+        Component.exporter, "prometheusremotewrite/0", {"endpoint": "x"}, pipelines=["metrics/fake/0"]
     )
-    config.add_component(
-        Component.exporter,
-        "otlphttp/rel-1/fake/0",
-        {"endpoint": "http://otlp-logs:4318"},
-        pipelines=["logs/fake/0"],
-    )
-    # AND a NON-log exporter on the metrics pipeline (must NOT be covered)
-    config.add_component(
-        Component.exporter,
-        "prometheusremotewrite/send-remote-write/0",
-        {"endpoint": "http://mimir/api/v1/push"},
-        pipelines=["metrics/fake/0"],
-    )
-    # WHEN the config is built (populates the loop-breaker conditions dynamically)
     built = yaml.safe_load(config.build())
-    filter_name = "filter/internal-telemetry-loop-breaker/fake/0"
-    conditions = built["processors"][filter_name]["logs"]["log_record"]
-    # THEN every LOG-pipeline exporter is covered by an exact component-id match
-    assert set(conditions) == {
-        'attributes["otelcol.component.id"] == "loki/send-loki-logs/0"',
-        'attributes["otelcol.component.id"] == "otlphttp/rel-1/fake/0"',
-    }
-    # AND the non-log (Mimir) exporter is NOT covered, so its failure logs still reach Loki
-    assert not any("prometheusremotewrite" in cond for cond in conditions)
-    # AND the auto-injected nop/debug exporters are excluded
-    assert not any("nop" in cond or "debug" in cond for cond in conditions)
+    conditions = built["processors"]["filter/internal-telemetry-loop-breaker/fake/0"]["logs"][
+        "log_record"
+    ]
+    # Every logs-pipeline exporter is covered, each scoped to the logs signal; nothing else is.
+    assert all('instrumentation_scope.attributes["otelcol.signal"] == "logs"' in c for c in conditions)
+    covered = {c for eid in ("loki/send-loki-logs/0", "otlphttp/rel-1/fake/0") for c in conditions if eid in c}
+    assert len(covered) == 2
+    assert not any("prometheusremotewrite" in c or "nop" in c or "debug" in c for c in conditions)
 
 
 def test_loop_breaker_filter_conditions_empty_without_log_exporter():
-    # GIVEN a default config with NO log exporter (only the fallback nop after build)
-    config = ConfigBuilder(
-        unit_name="fake/0", global_scrape_interval="", global_scrape_timeout=""
-    )
+    # With no log exporter (only the fallback nop), nothing can recurse -> no drop conditions.
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
     config.add_default_config()
-    # WHEN built
     built = yaml.safe_load(config.build())
-    filter_name = "filter/internal-telemetry-loop-breaker/fake/0"
-    # THEN there are no drop conditions (nothing can recurse; nop is excluded)
-    assert built["processors"][filter_name]["logs"]["log_record"] == []
+    assert built["processors"]["filter/internal-telemetry-loop-breaker/fake/0"]["logs"][
+        "log_record"
+    ] == []
 
 
 def test_receivers_tls_empty_config():

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -123,28 +123,38 @@ def test_default_internal_logs_self_export_plaintext():
     # AND internal logs are exported over OTLP to the collector's own OTLP receiver
     otlp = logs_telemetry["processors"][0]["batch"]["exporter"]["otlp"]
     assert otlp["protocol"] == "http/protobuf"
-    # AND the loopback endpoint uses plaintext HTTP with no CA certificate
+    # AND the loopback endpoint uses plaintext HTTP with no CA certificate and no TLS block
     assert otlp["endpoint"] == "http://localhost:4318"
     assert "certificate" not in otlp
+    assert "tls" not in otlp
 
 
 def test_default_internal_logs_self_export_tls():
-    # GIVEN a default config WITH receiver TLS
+    # GIVEN a default config WITH receiver TLS and the unit FQDN the server cert is valid for
     config = ConfigBuilder(
         unit_name="fake/0",
         global_scrape_interval="",
         global_scrape_timeout="",
         receiver_tls=True,
+        internal_host="otelcol-0.otelcol-endpoints.o11y.svc.cluster.local",
     )
     config.add_default_config()
     otlp = config._config["service"]["telemetry"]["logs"]["processors"][0]["batch"]["exporter"][
         "otlp"
     ]
-    # THEN the loopback endpoint uses HTTPS and trusts the CA cert
-    assert otlp["endpoint"] == "https://localhost:4318"
-    assert otlp["certificate"] == (
-        "/usr/local/share/ca-certificates/juju_receive-ca-cert/cos-ca.crt"
+    # THEN the loopback endpoint targets the FQDN (a name present in the cert SANs) over HTTPS, so
+    # verification succeeds -- NOT `localhost`, which would fail ("valid for <fqdn>, not localhost")
+    assert (
+        otlp["endpoint"]
+        == "https://otelcol-0.otelcol-endpoints.o11y.svc.cluster.local:4318"
     )
+    # AND no explicit CA is configured: trust is via the system root store (the charm installs the
+    # server CA with update-ca-certificates), so the exporter falls back to the system cert pool
+    assert "certificate" not in otlp
+    # AND no skip-verify knob is needed (endpoint matches the SAN); the OTel SDK schema has no
+    # `tls`/`insecure_skip_verify` anyway
+    assert "insecure" not in otlp
+    assert "tls" not in otlp
 
 
 def test_default_internal_logs_loop_breaker_filter_present():
@@ -153,20 +163,70 @@ def test_default_internal_logs_loop_breaker_filter_present():
         unit_name="fake/0", global_scrape_interval="", global_scrape_timeout=""
     )
     config.add_default_config()
-    # THEN a loop-breaker filter processor exists
+    # THEN a loop-breaker filter processor exists on the self-ingested logs pipeline
     filter_name = "filter/internal-telemetry-loop-breaker/fake/0"
     assert filter_name in config._config["processors"]
     filter_cfg = config._config["processors"][filter_name]
-    # AND it drops ONLY the failure logs of the log exporter(s) the internal logs loop through,
-    # keyed on their otelcol.component.id prefix (so OTHER exporters' failure logs pass through)
-    assert filter_cfg["logs"]["log_record"] == [
-        'IsMatch(attributes["otelcol.component.id"], "^loki/send-loki-logs/")',
-        'IsMatch(attributes["otelcol.component.id"], "^loki/cloud-config")',
-    ]
     # AND it is resilient to OTTL evaluation errors (does not drop valid data)
     assert filter_cfg["error_mode"] == "ignore"
-    # AND it is wired into the self-ingested logs pipeline
+    # AND it is wired into the logs pipeline
     assert filter_name in config._config["service"]["pipelines"]["logs/fake/0"]["processors"]
+    # AND before build() its drop conditions are empty (populated dynamically at build time)
+    assert filter_cfg["logs"]["log_record"] == []
+
+
+def test_loop_breaker_filter_conditions_populated_from_logs_exporters():
+    # GIVEN a default config with a real log exporter and a nop-only build
+    config = ConfigBuilder(
+        unit_name="fake/0", global_scrape_interval="", global_scrape_timeout=""
+    )
+    config.add_default_config()
+    # AND a couple of log exporters wired into the logs pipeline (as add_log_forwarding would)
+    config.add_component(
+        Component.exporter,
+        "loki/send-loki-logs/0",
+        {"endpoint": "http://loki/loki/api/v1/push"},
+        pipelines=["logs/fake/0"],
+    )
+    config.add_component(
+        Component.exporter,
+        "otlphttp/rel-1/fake/0",
+        {"endpoint": "http://otlp-logs:4318"},
+        pipelines=["logs/fake/0"],
+    )
+    # AND a NON-log exporter on the metrics pipeline (must NOT be covered)
+    config.add_component(
+        Component.exporter,
+        "prometheusremotewrite/send-remote-write/0",
+        {"endpoint": "http://mimir/api/v1/push"},
+        pipelines=["metrics/fake/0"],
+    )
+    # WHEN the config is built (populates the loop-breaker conditions dynamically)
+    built = yaml.safe_load(config.build())
+    filter_name = "filter/internal-telemetry-loop-breaker/fake/0"
+    conditions = built["processors"][filter_name]["logs"]["log_record"]
+    # THEN every LOG-pipeline exporter is covered by an exact component-id match
+    assert set(conditions) == {
+        'attributes["otelcol.component.id"] == "loki/send-loki-logs/0"',
+        'attributes["otelcol.component.id"] == "otlphttp/rel-1/fake/0"',
+    }
+    # AND the non-log (Mimir) exporter is NOT covered, so its failure logs still reach Loki
+    assert not any("prometheusremotewrite" in cond for cond in conditions)
+    # AND the auto-injected nop/debug exporters are excluded
+    assert not any("nop" in cond or "debug" in cond for cond in conditions)
+
+
+def test_loop_breaker_filter_conditions_empty_without_log_exporter():
+    # GIVEN a default config with NO log exporter (only the fallback nop after build)
+    config = ConfigBuilder(
+        unit_name="fake/0", global_scrape_interval="", global_scrape_timeout=""
+    )
+    config.add_default_config()
+    # WHEN built
+    built = yaml.safe_load(config.build())
+    filter_name = "filter/internal-telemetry-loop-breaker/fake/0"
+    # THEN there are no drop conditions (nothing can recurse; nop is excluded)
+    assert built["processors"][filter_name]["logs"]["log_record"] == []
 
 
 def test_receivers_tls_empty_config():

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -152,6 +152,46 @@ def test_internal_logs_full_record_rendered_to_loki():
     }
 
 
+def test_internal_logs_topology_labels_promoted_to_loki_labels():
+    # GIVEN a config built with this collector's own Juju topology
+    topology = {
+        "juju_application": "otelcol",
+        "juju_charm": "opentelemetry-collector-k8s",
+        "juju_model": "mymodel",
+        "juju_model_uuid": "abcd-1234",
+        "juju_unit": "otelcol/0",
+    }
+    config = ConfigBuilder(
+        unit_name="otelcol/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        topology_labels=topology,
+    )
+    config.add_default_config()
+    resource = config._config["service"]["telemetry"]["resource"]
+    # THEN the topology is attached to the internal-telemetry resource ...
+    for key, value in topology.items():
+        assert resource[key] == value
+    # AND `service.instance.id` is pinned to the Juju unit (so the Loki `instance` label is stable
+    # and correlatable, instead of a random per-process UUID that churns on every restart)
+    assert resource["service.instance.id"] == "otelcol/0"
+    # AND the job label is still derived from service.name
+    assert resource["service.name"] == "otelcol-internal"
+    # AND ONLY the bounded topology keys are promoted to Loki labels (no high-cardinality otelcol
+    # attributes like `error`/`target_labels`/`scrape_timestamp` are promoted)
+    promoted = {label.strip() for label in resource["loki.resource.labels"].split(",")}
+    assert promoted == set(topology.keys())
+
+
+def test_internal_logs_without_topology_labels_are_unchanged():
+    # GIVEN no topology is supplied (the historical behaviour)
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    resource = config._config["service"]["telemetry"]["resource"]
+    # THEN no topology labels, no pinned instance id, and no label-promotion hint are injected
+    assert resource == {"service.name": "otelcol-internal", "loki.format": "logfmt"}
+
+
 def test_default_internal_logs_self_export_tls():
     # GIVEN a default config WITH receiver TLS and the unit FQDN the server cert is valid for
     config = ConfigBuilder(
@@ -205,6 +245,58 @@ def test_loop_breaker_filter_conditions_populated_from_logs_exporters():
     covered = {c for eid in ("loki/send-loki-logs/0", "otlphttp/rel-1/fake/0") for c in conditions if eid in c}
     assert len(covered) == 2
     assert not any("prometheusremotewrite" in c or "nop" in c or "debug" in c for c in conditions)
+
+
+def test_loop_breaker_filter_covers_exporters_on_custom_logs_pipelines():
+    # A user-supplied config can add its own logs pipeline (e.g. `logs/custom`) with its own
+    # exporters. Those can still fail-and-recurse, so the loop-breaker must cover them too, not
+    # just exporters on the charm-managed `logs/<unit>` pipeline.
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    # Exporter on the charm-managed logs pipeline.
+    config.add_component(
+        Component.exporter, "loki/send-loki-logs/0", {"endpoint": "x"}, pipelines=["logs/fake/0"]
+    )
+    # Exporter on a user-defined logs pipeline in a different namespace.
+    config.add_component(
+        Component.exporter, "otlphttp/user-custom", {"endpoint": "x"}, pipelines=["logs/custom"]
+    )
+    # A bare `logs` pipeline (no `/<name>` suffix) is also a logs pipeline.
+    config.add_component(
+        Component.exporter, "kafka/user-bare", {"endpoint": "x"}, pipelines=["logs"]
+    )
+    # A metrics-pipeline exporter must NOT be covered even on a custom namespace.
+    config.add_component(
+        Component.exporter, "prometheusremotewrite/user", {"endpoint": "x"}, pipelines=["metrics/custom"]
+    )
+    built = yaml.safe_load(config.build())
+    conditions = built["processors"]["filter/internal-telemetry-loop-breaker/fake/0"]["logs"][
+        "log_record"
+    ]
+    covered = {
+        eid
+        for eid in ("loki/send-loki-logs/0", "otlphttp/user-custom", "kafka/user-bare")
+        if any(eid in c for c in conditions)
+    }
+    assert covered == {"loki/send-loki-logs/0", "otlphttp/user-custom", "kafka/user-bare"}
+    assert not any("prometheusremotewrite" in c for c in conditions)
+
+
+def test_loop_breaker_filter_deduplicates_shared_exporter_across_logs_pipelines():
+    # An exporter shared by multiple logs pipelines must yield exactly one drop condition.
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    config.add_component(
+        Component.exporter,
+        "loki/send-loki-logs/0",
+        {"endpoint": "x"},
+        pipelines=["logs/fake/0", "logs/custom"],
+    )
+    built = yaml.safe_load(config.build())
+    conditions = built["processors"]["filter/internal-telemetry-loop-breaker/fake/0"]["logs"][
+        "log_record"
+    ]
+    assert sum("loki/send-loki-logs/0" in c for c in conditions) == 1
 
 
 def test_loop_breaker_filter_conditions_empty_without_log_exporter():

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -120,8 +120,10 @@ def test_default_internal_logs_self_export_plaintext():
     logs_telemetry = config._config["service"]["telemetry"]["logs"]
     # THEN the collector's own telemetry resource is tagged so the Loki exporter derives
     # `job=otelcol-internal` from `service.name` deterministically (distinguishable in Grafana)
+    # AND the full internal log record (body + attributes) is rendered into the Loki line
     assert config._config["service"]["telemetry"]["resource"] == {
-        "service.name": "otelcol-internal"
+        "service.name": "otelcol-internal",
+        "loki.format": "logfmt",
     }
     # AND internal logs are exported over OTLP to the collector's own OTLP receiver
     otlp = logs_telemetry["processors"][0]["batch"]["exporter"]["otlp"]
@@ -130,6 +132,24 @@ def test_default_internal_logs_self_export_plaintext():
     assert otlp["endpoint"] == "http://localhost:4318"
     assert "certificate" not in otlp
     assert "tls" not in otlp
+
+
+def test_internal_logs_full_record_rendered_to_loki():
+    # GIVEN a default config
+    config = ConfigBuilder(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        receiver_tls=False,
+    )
+    config.add_default_config()
+    resource = config._config["service"]["telemetry"]["resource"]
+    # THEN `loki.format: logfmt` renders the full record (so in-log context like `target_labels`
+    # survives), and no otelcol-own topology labels are injected
+    assert resource == {
+        "service.name": "otelcol-internal",
+        "loki.format": "logfmt",
+    }
 
 
 def test_default_internal_logs_self_export_tls():

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -246,6 +246,8 @@ def test_add_remote_write():
             {
                 "logs/otelcol/0": {
                     "receivers": ["otlp/otelcol/0"],
+                    # The loop-breaker filter is always present on the self-ingested logs pipeline
+                    "processors": ["filter/internal-telemetry-loop-breaker/otelcol/0"],
                     "exporters": ["debug/juju-config-enabled"],
                 },
                 "metrics/otelcol/0": {
@@ -263,6 +265,8 @@ def test_add_remote_write():
             {
                 "logs/otelcol/0": {
                     "receivers": ["otlp/otelcol/0"],
+                    # The loop-breaker filter is always present on the self-ingested logs pipeline
+                    "processors": ["filter/internal-telemetry-loop-breaker/otelcol/0"],
                     "exporters": ["debug/juju-config-enabled"],
                 },
                 "metrics/otelcol/0": {"receivers": ["otlp/otelcol/0"]},
@@ -367,6 +371,9 @@ def test_add_otlp_forwarding():
     expected_pipelines = {
         "logs/otelcol/0": {
             "receivers": ["otlp/otelcol/0"],
+            # The loop-breaker filter is always present on the self-ingested logs pipeline, so any
+            # log exporter (here an OTLP-logs exporter) is guarded against the recursion.
+            "processors": ["filter/internal-telemetry-loop-breaker/otelcol/0"],
             "exporters": [f"otlphttp/rel-1/{unit_name}", f"otlp/rel-2/{unit_name}"],
         },
         "metrics/otelcol/0": {
@@ -380,3 +387,68 @@ def test_add_otlp_forwarding():
     }
     assert config_manager.config._config["exporters"] == expected_exporters
     assert config_manager.config._config["service"]["pipelines"] == expected_pipelines
+
+
+def test_self_ingest_loop_breaker_invariant_all_log_exporters():
+    """INVARIANT: every log exporter on the self-ingested pipeline is covered by the loop-breaker.
+
+    The collector self-ingests its own internal logs into `logs/<unit>` and exports them. Only the
+    LOG exporter(s) those internal logs loop through can recurse when their endpoint is down. The
+    filter drops exactly those exporters' failure logs, keyed on their `otelcol.component.id`
+    prefix (LOOPABLE_LOG_EXPORTER_ID_PREFIXES). This test enables every feature that attaches a
+    LOG exporter to the pipeline (Loki forwarding + cloud-integrator Loki) and asserts:
+      1. the filter is present on the logs pipeline, and
+      2. EVERY log exporter's id is matched by one of the filter conditions.
+    If a future log exporter is wired into the logs pipeline without adding its id prefix to
+    LOOPABLE_LOG_EXPORTER_ID_PREFIXES, assertion (2) fails at authoring time.
+    """
+    from src.constants import LOOPABLE_LOG_EXPORTER_ID_PREFIXES
+
+    unit_name = "otelcol/0"
+    filter_name = f"filter/internal-telemetry-loop-breaker/{unit_name}"
+    config_manager = ConfigManager(
+        unit_name=unit_name,
+        global_scrape_interval="",
+        global_scrape_timeout="",
+    )
+    # WHEN every LOG-exporting feature is enabled ...
+    config_manager.add_log_forwarding(
+        endpoints=[{"url": "http://loki/loki/api/v1/push"}],
+        insecure_skip_verify=False,
+    )
+    config_manager.add_cloud_integrator(
+        username=None,
+        password=None,
+        prometheus_url=None,
+        loki_url="http://cloud-loki/loki/api/v1/push",
+        tempo_url=None,
+    )
+    # ... AND a NON-log exporter is also enabled (remote-write to Mimir), whose failure logs must
+    # NOT be dropped (they cannot recurse while the log path is up and are the most useful logs).
+    config_manager.add_remote_write(endpoints=[{"url": "http://mimir/api/v1/push"}])
+
+    config = config_manager.config._config
+    pipelines = config["service"]["pipelines"]
+    logs_pipeline = pipelines[f"logs/{unit_name}"]
+    # THEN the loop-breaker filter is present on the self-ingested logs pipeline.
+    # NOTE: internal telemetry is only self-ingested for the `logs` signal today. If a future
+    # change self-ingests `metrics`/`traces`, extend this invariant (and the filter) accordingly.
+    assert filter_name in logs_pipeline.get("processors", [])
+
+    # AND every LOG exporter on the pipeline is matched by one of the filter's id-prefix conditions
+    prefixes = LOOPABLE_LOG_EXPORTER_ID_PREFIXES
+    for exporter_id in logs_pipeline.get("exporters", []):
+        assert any(exporter_id.startswith(prefix) for prefix in prefixes), (
+            f"log exporter '{exporter_id}' on the self-ingested pipeline is NOT covered by the "
+            f"loop-breaker filter; add its id prefix to LOOPABLE_LOG_EXPORTER_ID_PREFIXES"
+        )
+
+    # AND the NON-log Mimir exporter is NOT covered by the filter, so its "Exporting failed" logs
+    # would pass through to Loki (visibility of cross-signal export failures is preserved).
+    mimir_id = next(
+        e for e in config["exporters"] if e.startswith("prometheusremotewrite/send-remote-write/")
+    )
+    assert not any(mimir_id.startswith(prefix) for prefix in prefixes), (
+        f"non-log exporter '{mimir_id}' must NOT be covered by the loop-breaker filter; its "
+        "failure logs are the most useful logs and cannot recurse while the log path is up"
+    )

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -448,18 +448,13 @@ def test_self_ingest_loop_breaker_invariant_all_log_exporters():
     # change self-ingests `metrics`/`traces`, extend the filter/build() to those pipelines too.
     assert filter_name in logs_pipeline.get("processors", [])
 
-    # AND every non-nop/debug exporter on the logs pipeline is covered by an exact-id condition
+    # Every non-nop/debug logs-pipeline exporter (incl. the send-otlp logs exporter) is covered,
+    # scoped to the logs signal; the metrics-only Mimir exporter is not.
     for exporter_id in logs_pipeline.get("exporters", []):
         if exporter_id.split("/")[0] in ("nop", "debug"):
             continue
-        expected = f'attributes["otelcol.component.id"] == "{exporter_id}"'
-        assert expected in conditions, (
-            f"log exporter '{exporter_id}' on the self-ingested pipeline is NOT covered by the "
-            "loop-breaker filter (see ConfigBuilder._populate_loop_breaker_filter)"
-        )
-
-    # AND the send-otlp LOGS exporter specifically is covered (the previously-unguarded path)
-    assert any("otlphttp/rel-" in cond for cond in conditions)
-
-    # AND the NON-log Mimir exporter is NOT covered, so its failure logs still reach Loki
-    assert not any("prometheusremotewrite" in cond for cond in conditions)
+        covering = [c for c in conditions if exporter_id in c]
+        assert covering, f"log exporter '{exporter_id}' not covered by loop-breaker filter"
+        assert all('instrumentation_scope.attributes["otelcol.signal"] == "logs"' in c for c in covering)
+    assert any("otlphttp/rel-" in c for c in conditions)
+    assert not any("prometheusremotewrite" in c for c in conditions)

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -3,11 +3,13 @@
 
 """Feature: Opentelemetry-collector config builder."""
 
-from src.config_manager import ConfigManager
-from charmlibs.interfaces.otlp import OtlpEndpoint
 import copy
 
 import pytest
+import yaml
+from charmlibs.interfaces.otlp import OtlpEndpoint
+
+from src.config_manager import ConfigManager
 
 
 def test_add_prometheus_scrape():
@@ -187,9 +189,9 @@ def test_add_traces_forwarding_multiple_endpoints():
     assert exporters["otlphttp/send-traces-1"]["endpoint"] == "http://tempo2.example.com:4318"
 
     # AND both exporters are wired into the traces pipeline
-    pipeline_exporters = config_manager.config._config["service"]["pipelines"][
-        "traces/otelcol/0"
-    ]["exporters"]
+    pipeline_exporters = config_manager.config._config["service"]["pipelines"]["traces/otelcol/0"][
+        "exporters"
+    ]
     assert "otlphttp/send-traces-0" in pipeline_exporters
     assert "otlphttp/send-traces-1" in pipeline_exporters
 
@@ -390,29 +392,28 @@ def test_add_otlp_forwarding():
 
 
 def test_self_ingest_loop_breaker_invariant_all_log_exporters():
-    """INVARIANT: every exporter on the self-ingested logs pipeline is covered by the loop-breaker.
+    """Every exporter on the self-ingested logs pipeline is covered by the loop-breaker.
 
     The collector self-ingests its own internal logs into `logs/<unit>` and exports them. Any
     exporter on THAT pipeline can recurse when its endpoint is down. The loop-breaker filter's drop
     conditions are enumerated dynamically at build time from the logs-pipeline exporters, so it
     covers EVERY log exporter automatically. This test enables every feature that attaches a log
-    exporter -- Loki forwarding, cloud-integrator Loki, AND a `send-otlp` LOGS exporter -- plus a
+    exporter: Loki forwarding, cloud-integrator Loki, AND a `send-otlp` LOGS exporter, plus a
     NON-log exporter (Mimir remote-write on the metrics pipeline), then asserts:
       1. every log-pipeline exporter is covered by an exact component-id condition, and
       2. the non-log (Mimir) exporter is NOT covered (its failure logs still reach Loki).
     If a future log exporter is wired into the logs pipeline, (1) covers it with no code change;
     if the dynamic enumeration regresses, this test fails.
     """
-    import yaml
-
     unit_name = "otelcol/0"
     filter_name = f"filter/internal-telemetry-loop-breaker/{unit_name}"
+    # GIVEN a base config manager
     config_manager = ConfigManager(
         unit_name=unit_name,
         global_scrape_interval="",
         global_scrape_timeout="",
     )
-    # WHEN every LOG-exporting feature is enabled ...
+    # WHEN every LOG-exporting feature is enabled
     config_manager.add_log_forwarding(
         endpoints=[{"url": "http://loki/loki/api/v1/push"}],
         insecure_skip_verify=False,
@@ -424,7 +425,6 @@ def test_self_ingest_loop_breaker_invariant_all_log_exporters():
         loki_url="http://cloud-loki/loki/api/v1/push",
         tempo_url=None,
     )
-    # ... including a `send-otlp` LOGS exporter (the previously-unguarded loop path) ...
     config_manager.add_otlp_forwarding(
         relation_map={
             0: OtlpEndpoint(
@@ -435,8 +435,7 @@ def test_self_ingest_loop_breaker_invariant_all_log_exporters():
             ),
         }
     )
-    # ... AND a NON-log exporter (remote-write to Mimir), whose failure logs must NOT be dropped
-    # (they cannot recurse while the log path is up and are the most useful logs).
+    # AND WHEN a NON-log exporter, whose failure logs must NOT be dropped, is added
     config_manager.add_remote_write(endpoints=[{"url": "http://mimir/api/v1/push"}])
 
     built = yaml.safe_load(config_manager.config.build())
@@ -444,8 +443,6 @@ def test_self_ingest_loop_breaker_invariant_all_log_exporters():
     logs_pipeline = pipelines[f"logs/{unit_name}"]
     conditions = built["processors"][filter_name]["logs"]["log_record"]
     # THEN the filter is present on the self-ingested logs pipeline.
-    # NOTE: internal telemetry is only self-ingested for the `logs` signal today. If a future
-    # change self-ingests `metrics`/`traces`, extend the filter/build() to those pipelines too.
     assert filter_name in logs_pipeline.get("processors", [])
 
     # Every non-nop/debug logs-pipeline exporter (incl. the send-otlp logs exporter) is covered,
@@ -455,6 +452,8 @@ def test_self_ingest_loop_breaker_invariant_all_log_exporters():
             continue
         covering = [c for c in conditions if exporter_id in c]
         assert covering, f"log exporter '{exporter_id}' not covered by loop-breaker filter"
-        assert all('instrumentation_scope.attributes["otelcol.signal"] == "logs"' in c for c in covering)
+        assert all(
+            'instrumentation_scope.attributes["otelcol.signal"] == "logs"' in c for c in covering
+        )
     assert any("otlphttp/rel-" in c for c in conditions)
     assert not any("prometheusremotewrite" in c for c in conditions)

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -390,19 +390,20 @@ def test_add_otlp_forwarding():
 
 
 def test_self_ingest_loop_breaker_invariant_all_log_exporters():
-    """INVARIANT: every log exporter on the self-ingested pipeline is covered by the loop-breaker.
+    """INVARIANT: every exporter on the self-ingested logs pipeline is covered by the loop-breaker.
 
-    The collector self-ingests its own internal logs into `logs/<unit>` and exports them. Only the
-    LOG exporter(s) those internal logs loop through can recurse when their endpoint is down. The
-    filter drops exactly those exporters' failure logs, keyed on their `otelcol.component.id`
-    prefix (LOOPABLE_LOG_EXPORTER_ID_PREFIXES). This test enables every feature that attaches a
-    LOG exporter to the pipeline (Loki forwarding + cloud-integrator Loki) and asserts:
-      1. the filter is present on the logs pipeline, and
-      2. EVERY log exporter's id is matched by one of the filter conditions.
-    If a future log exporter is wired into the logs pipeline without adding its id prefix to
-    LOOPABLE_LOG_EXPORTER_ID_PREFIXES, assertion (2) fails at authoring time.
+    The collector self-ingests its own internal logs into `logs/<unit>` and exports them. Any
+    exporter on THAT pipeline can recurse when its endpoint is down. The loop-breaker filter's drop
+    conditions are enumerated dynamically at build time from the logs-pipeline exporters, so it
+    covers EVERY log exporter automatically. This test enables every feature that attaches a log
+    exporter -- Loki forwarding, cloud-integrator Loki, AND a `send-otlp` LOGS exporter -- plus a
+    NON-log exporter (Mimir remote-write on the metrics pipeline), then asserts:
+      1. every log-pipeline exporter is covered by an exact component-id condition, and
+      2. the non-log (Mimir) exporter is NOT covered (its failure logs still reach Loki).
+    If a future log exporter is wired into the logs pipeline, (1) covers it with no code change;
+    if the dynamic enumeration regresses, this test fails.
     """
-    from src.constants import LOOPABLE_LOG_EXPORTER_ID_PREFIXES
+    import yaml
 
     unit_name = "otelcol/0"
     filter_name = f"filter/internal-telemetry-loop-breaker/{unit_name}"
@@ -423,32 +424,42 @@ def test_self_ingest_loop_breaker_invariant_all_log_exporters():
         loki_url="http://cloud-loki/loki/api/v1/push",
         tempo_url=None,
     )
-    # ... AND a NON-log exporter is also enabled (remote-write to Mimir), whose failure logs must
-    # NOT be dropped (they cannot recurse while the log path is up and are the most useful logs).
+    # ... including a `send-otlp` LOGS exporter (the previously-unguarded loop path) ...
+    config_manager.add_otlp_forwarding(
+        relation_map={
+            0: OtlpEndpoint(
+                protocol="http",
+                endpoint="http://otlp-logs:4318",
+                telemetries=["logs"],
+                insecure=True,
+            ),
+        }
+    )
+    # ... AND a NON-log exporter (remote-write to Mimir), whose failure logs must NOT be dropped
+    # (they cannot recurse while the log path is up and are the most useful logs).
     config_manager.add_remote_write(endpoints=[{"url": "http://mimir/api/v1/push"}])
 
-    config = config_manager.config._config
-    pipelines = config["service"]["pipelines"]
+    built = yaml.safe_load(config_manager.config.build())
+    pipelines = built["service"]["pipelines"]
     logs_pipeline = pipelines[f"logs/{unit_name}"]
-    # THEN the loop-breaker filter is present on the self-ingested logs pipeline.
+    conditions = built["processors"][filter_name]["logs"]["log_record"]
+    # THEN the filter is present on the self-ingested logs pipeline.
     # NOTE: internal telemetry is only self-ingested for the `logs` signal today. If a future
-    # change self-ingests `metrics`/`traces`, extend this invariant (and the filter) accordingly.
+    # change self-ingests `metrics`/`traces`, extend the filter/build() to those pipelines too.
     assert filter_name in logs_pipeline.get("processors", [])
 
-    # AND every LOG exporter on the pipeline is matched by one of the filter's id-prefix conditions
-    prefixes = LOOPABLE_LOG_EXPORTER_ID_PREFIXES
+    # AND every non-nop/debug exporter on the logs pipeline is covered by an exact-id condition
     for exporter_id in logs_pipeline.get("exporters", []):
-        assert any(exporter_id.startswith(prefix) for prefix in prefixes), (
+        if exporter_id.split("/")[0] in ("nop", "debug"):
+            continue
+        expected = f'attributes["otelcol.component.id"] == "{exporter_id}"'
+        assert expected in conditions, (
             f"log exporter '{exporter_id}' on the self-ingested pipeline is NOT covered by the "
-            f"loop-breaker filter; add its id prefix to LOOPABLE_LOG_EXPORTER_ID_PREFIXES"
+            "loop-breaker filter (see ConfigBuilder._populate_loop_breaker_filter)"
         )
 
-    # AND the NON-log Mimir exporter is NOT covered by the filter, so its "Exporting failed" logs
-    # would pass through to Loki (visibility of cross-signal export failures is preserved).
-    mimir_id = next(
-        e for e in config["exporters"] if e.startswith("prometheusremotewrite/send-remote-write/")
-    )
-    assert not any(mimir_id.startswith(prefix) for prefix in prefixes), (
-        f"non-log exporter '{mimir_id}' must NOT be covered by the loop-breaker filter; its "
-        "failure logs are the most useful logs and cannot recurse while the log path is up"
-    )
+    # AND the send-otlp LOGS exporter specifically is covered (the previously-unguarded path)
+    assert any("otlphttp/rel-" in cond for cond in conditions)
+
+    # AND the NON-log Mimir exporter is NOT covered, so its failure logs still reach Loki
+    assert not any("prometheusremotewrite" in cond for cond in conditions)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/325, https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/15 (missing traces internal telemetry, but logs and metrics are covered); we can create a new issue in the future.

## Solution
<!-- A summary of the solution addressing the above issue -->
In tandem:
- https://github.com/canonical/observability-stack/pull/461

The collector self-ingests its own internal telemetry logs into the `logs/<unit>` pipeline so they are forwarded to Loki alongside received/forwarded logs, tagged `job=otelcol-internal`. This creates a recursion risk, which is broken at the **self-ingestion boundary** with a single `filter` processor, added unconditionally to the base config so it always sits upstream of every log exporter.

The filter drops the internal logs emitted by **exactly the exporter components attached to the logs pipeline** — the only components that can recurse. Logs from every other component (receivers, processors, and exporters on the **metrics/traces** pipelines like Mimir/Tempo/OTLP-metrics) are **preserved** — they cannot form a cycle while the logs path is healthy.

- **Dynamically enumerated at build time** from the exporters wired into the `logs` pipeline — no static list to maintain (`send-loki-logs`, cloud-integrator, `send-otlp` logs, and any future log exporter are covered automatically).
- Matched on **exact component id** (`== "<exporter_id>"`), not message text or a blunt "any exporter" match, so it never over-drops other pipelines' failure logs.
- `otelcol.component.id` is carried on the log's **instrumentation scope**, so the OTTL condition uses `instrumentation_scope.attributes[...]` (verified against the OTLP-decoded logs; see Testing).
- The loopback OTLP self-exporter is in-memory by default (no `file_storage`), so the self-ingest path cannot consume the PVC; `sending_queue_config` defaults are left unchanged (`max_elapsed_time` stays finite).

```mermaid
flowchart LR
  IN[internal logs<br/>service.telemetry.logs<br/>OTLP → unit FQDN:4318] --> RCV[otlp/unit receiver]
  EXT[received/forwarded logs] --> RCV
  RCV --> FILT[["filter/internal-telemetry-loop-breaker<br/>error_mode: ignore<br/>drop instrumentation_scope.attributes[otelcol.component.id] ==<br/>each logs-pipeline exporter (built dynamically)"]]
  FILT --> PL[logs/unit pipeline<br/>+ label processors]
  PL --> EXP{exporter}
  EXP -->|today: send-loki-logs| LOKI[(Loki push)]
  EXP -.->|future: send-otlp logs auto-covered| LOKIOTLP[(Loki OTLP)]

  EXP -. logs endpoint down: Exporting failed log .-> IN
  FILT x==x|severs cycle: logs-pipeline exporter logs dropped| PL

  MIMIR[(Mimir / Tempo / OTLP metrics·traces)] -. down: Exporting failed log id=prometheusremotewrite/* .-> IN
  FILT ==>|passes through: most useful logs reach Loki| PL

  classDef fix fill:#d1f2d1,stroke:#2e7d32,stroke-width:2px,color:#000;
  classDef keep fill:#e3f0ff,stroke:#1565c0,color:#000;
  class FILT fix;
  class MIMIR keep;
```

The filter is populated at build time once the full set of logs-pipeline exporters is known, matching on both `otelcol.component.id` **and** `otelcol.signal == "logs"`. The signal condition matters because a single `send-otlp` exporter with `telemetries: [logs, metrics]` becomes one component on both pipelines: only its `signal: logs` failures can recurse, while its `signal: metrics` failures pass through once and are kept (matching id alone would over-drop them).

```yaml
filter/internal-telemetry-loop-breaker/<unit>:
  error_mode: ignore  # OTTL eval errors are logged but never drop valid data
  logs:
    log_record:  # OR-ed; one entry per logs-pipeline exporter, built dynamically at build time
      - 'instrumentation_scope.attributes["otelcol.component.id"] == "loki/send-loki-logs/0" and instrumentation_scope.attributes["otelcol.signal"] == "logs"'
      - 'instrumentation_scope.attributes["otelcol.component.id"] == "otlphttp/rel-1/otelcol/0" and instrumentation_scope.attributes["otelcol.signal"] == "logs"'
```

> [!NOTE]
> `nop`/`debug` exporters are excluded (no remote endpoint → cannot fail-and-recurse). With no log exporter related, the condition list is empty.

### `job=otelcol-internal` label
The self-ingested internal logs land in Loki under `{job="otelcol-internal"}`, distinguishable from forwarded logs. The collector's own telemetry resource is tagged with `service.name: otelcol-internal`:

```yaml
service:
  telemetry:
    resource:
      service.name: otelcol-internal
```

The Loki exporter derives the `job` label from `service.namespace/service.name` (`default_labels_enabled: {job: true}`), so this deterministically yields `job=otelcol-internal` for every internal log record. `service.name` is the OTel-standard service identifier and is exporter-agnostic, so it also distinguishes the collector's own telemetry for any other backend (OTLP, remote-write, etc.). Only `service.name` is overridden; `service.instance.id` and `service.version` remain auto-populated.

### Full log body via `loki.format: logfmt`
Internal telemetry carries its context (`error`, `interval`, `target_labels`, ...) as log-record **attributes**, not in the body. The default `loki.format: raw` renders only the body, dropping that context. The internal-telemetry resource therefore also sets `loki.format: logfmt`, which renders the full record (body + attributes) into the Loki line — so an admin can see, e.g., which scraped target a "Failed to scrape" refers to (`target_labels` carries the *scraped target's* topology, like `juju_unit=loki-read/0`).

This is scoped to internal logs only: `add_log_forwarding` sets `loki.format: raw` with an `insert` action, which does not overwrite the pre-existing hint, so scraped charm logs keep `raw`. Note the internal logs do **not** carry the collector's *own* `juju_*` labels — that context lives in the record and is intentionally surfaced in the line rather than promoted to (high-cardinality, per-target) labels.

> [!NOTE]
> The `pebble logs` output is preserved meaning: if a user wants to inspect internal logs related to a down Loki exporter endpoint, they can do so with Juju and Pebble logs.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch.
	- [ ] Requires a `track/0.130` backport
- [ ] Tandem VM-charm PR needed
- [x] Test the filter metric to check if it increases when Prom exporter endpoint goes down

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
- This will not break our [otelcol_error_logs assertions](https://github.com/canonical/observability-stack/blob/7b37a80bcfd997b40bd41f25ddcc5670fddbd985/tests/integration/helpers.py#L154) in the product solution tests.
- The syslog explosion was previously worked around in the VM charm ([#138](https://github.com/canonical/opentelemetry-collector-operator/pull/138)) by routing internal logs to a file **off** the pipeline; that fixes the loop but means those logs are not forwarded — hence a tandem PR is required for parity.
- **Loopback TLS:** when receiver TLS is enabled, the self-ingest exporter targets the unit **FQDN** (`socket.getfqdn()`, the name in the OTLP receiver cert's SANs) over HTTPS — *not* `localhost`, which fails verification (`certificate is valid for <fqdn>, not localhost`). CA trust is via the system root store (the charm installs the CA with `update-ca-certificates`); no explicit `certificate`, `insecure`, or `tls` keys are set.
- **`job` label derivation:** the Loki exporter builds `job` from the resource `service.name`; log-attribute-based tagging is not reliably surfaced on the OTLP self-export path, so the label is driven from `service.name` directly.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
### Manual
With COS (internal-TLS) deployed and a locally packed otelcol, check the internal-telemetry and filter config. The collector's own telemetry resource is tagged `service.name: otelcol-internal`, and the loopback self-exporter targets the FQDN over HTTPS:
```json
    "telemetry": {
      "logs": {
        "disable_stacktrace": true,
        "level": "INFO",
        "processors": [
          {
            "batch": {
              "exporter": {
                "otlp": {
                  "endpoint": "https://otelcol-0.otelcol-endpoints.o11y.svc.cluster.local:4318",
                  "protocol": "http/protobuf"}}}}]},
      "metrics": {"level": "normal"},
      "resource": {
        "juju_application": "otelcol",
        "juju_charm": "opentelemetry-collector-k8s",
        "juju_model": "o11y",
        "juju_model_uuid": "3a5e3040-2fdd-4876-8924-8745a47aeb4f",
        "juju_unit": "otelcol/0",
        "loki.format": "logfmt",
        "loki.resource.labels": "juju_application, juju_charm, juju_model, juju_model_uuid, juju_unit",
        "service.instance.id": "otelcol/0",
        "service.name": "otelcol-internal"}
```
```json
    "filter/internal-telemetry-loop-breaker/otelcol/0": {
      "error_mode": "ignore",
      "logs": {
        "log_record": [
          "instrumentation_scope.attributes[\"otelcol.component.id\"] == \"otlp/rel-83/otelcol/0\" and instrumentation_scope.attributes[\"otelcol.signal\"] == \"logs\"",
          "instrumentation_scope.attributes[\"otelcol.component.id\"] == \"loki/send-loki-logs/0\" and instrumentation_scope.attributes[\"otelcol.signal\"] == \"logs\""]}},
```
```json
    "pipelines": {
      "logs/otelcol/0": {
        "exporters": ["otlp/rel-83/otelcol/0", "loki/send-loki-logs/0"],
        "processors": ["filter/internal-telemetry-loop-breaker/otelcol/0","resource/send-loki-logs","attributes/send-loki-logs"],
```

Confirm the internal logs land in Loki under the expected job label (`--quiet` keeps stdout free of `logcli` metadata):
```shell
jsshc loki loki/0 "/usr/bin/logcli query --quiet --limit=5 --output=jsonl '{job=\"otelcol-internal\"}'"
jsshc loki loki/0 "/usr/bin/logcli labels job"   # lists otelcol-internal (not otelcol)
```

Stop Loki and inspect the debug logs:
```shell
jsshc nginx loki/0 pebble stop nginx
```
The OTLP-decoded internal `Exporting failed` log shows `otelcol.component.id` under the **instrumentation scope** (this is why the filter uses `instrumentation_scope.attributes[...]`):
```
2026-07-14T12:41:58.176Z [otelcol] 2026-07-14T08:41:58.175-0400	info	internal/retry_sender.go:133	Exporting failed. Will retry the request after interval.	{"resource": {"service.instance.id": "fd9029db-2b3b-4f65-a13a-e6afaf8af175", "service.name": "otelcol-internal", "service.version": "0.130.1"}, "otelcol.component.id": "loki/send-loki-logs/0", "otelcol.component.kind": "exporter", "otelcol.signal": "logs", "error": "HTTP 502 \"Bad Gateway\": Bad Gateway", "interval": "38.743425757s"}
2026-07-14T12:41:58.631Z [otelcol] Logs	{"resource logs": 1, "log records": 1}
2026-07-14T12:41:58.631Z [otelcol] ResourceLog #0
2026-07-14T12:41:58.631Z [otelcol] ScopeLogs #0
2026-07-14T12:41:58.631Z [otelcol] InstrumentationScope attributes:
2026-07-14T12:41:58.631Z [otelcol]      -> otelcol.component.id: Str(loki/send-loki-logs/0)
2026-07-14T12:41:58.631Z [otelcol]      -> otelcol.component.kind: Str(exporter)
2026-07-14T12:41:58.631Z [otelcol]      -> otelcol.signal: Str(logs)
2026-07-14T12:41:58.631Z [otelcol] LogRecord #0
2026-07-14T12:41:58.631Z [otelcol] ObservedTimestamp: 2026-07-14 12:41:58.176065936 +0000 UTC
2026-07-14T12:41:58.631Z [otelcol] Timestamp: 2026-07-14 12:41:58.17597333 +0000 UTC
2026-07-14T12:41:58.631Z [otelcol] SeverityText: info
2026-07-14T12:41:58.631Z [otelcol] SeverityNumber: Info(9)
2026-07-14T12:41:58.631Z [otelcol] Body: Str(Exporting failed. Will retry the request after interval.)
2026-07-14T12:41:58.631Z [otelcol] Attributes:
2026-07-14T12:41:58.631Z [otelcol]      -> error: Str(HTTP 502 "Bad Gateway": Bad Gateway)
2026-07-14T12:41:58.631Z [otelcol]      -> loki.attribute.labels: Str(container, job, filename, juju_application, juju_charm, juju_model, juju_model_uuid, juju_unit, snap_name, path, pebble_service)
```

Confirm the filter is actively dropping during the outage:
```shell
jsshc otelcol otelcol/0 "curl -s localhost:8888/metrics" | grep otelcol_processor_filter_logs_filtered
# otelcol_processor_filter_logs_filtered{filter="filter/internal-telemetry-loop-breaker/otelcol/0", ...} 1345
```

Validated:
- ✅ Self-ingest delivers internal logs into the logs pipeline (`otelcol_receiver_accepted_log_records{receiver="otlp/otelcol/0"} = 674`).
- ✅ Internal logs reach Loki under `{job="otelcol-internal"}` deterministically (derived from `service.name`).
- ✅ Loopback TLS works (FQDN endpoint matches the cert SAN; no `insecure`/`tls`/`certificate` keys).
- ✅ Loop-breaker filter matches and drops (`otelcol_processor_filter_logs_filtered = 1345` and climbing during the Loki outage); the recursion is severed.
- ✅ Cross-signal preservation — the filter only targets logs-pipeline exporter ids, so Mimir/Tempo failure logs still reach Loki.

### Grafana UI

<img width="1939" height="456" alt="image" src="https://github.com/user-attachments/assets/0b9a440d-72e8-4930-9523-43121e963819" />

<img width="1920" height="844" alt="image" src="https://github.com/user-attachments/assets/4d0d4dd4-4479-4482-bae9-1d78c8581eed" />

<img width="1920" height="548" alt="image" src="https://github.com/user-attachments/assets/a57f4623-f9d6-4044-a41c-6b45a2408b4c" />

<img width="1920" height="548" alt="image" src="https://github.com/user-attachments/assets/a83def32-f747-472a-9f56-3056c8d09c40" />

<img width="1920" height="548" alt="image" src="https://github.com/user-attachments/assets/59440c07-bb36-441a-9000-bed4113e8831" />



## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
- Internal telemetry logs are now forwarded to Loki, tagged `job=otelcol-internal` (derived from the collector's own `service.name=otelcol-internal`). Query them with `{job="otelcol-internal"}`.
- Internal logs are rendered with `loki.format: logfmt` (full record: body + attributes), so context like `error`, `interval` and the scraped target's topology (`target_labels`) appears in the log line. Scraped charm logs are unaffected (they stay `raw`).
- The collector's own telemetry resource reports `service.name=otelcol-internal`. This affects only the collector's *self* telemetry; the self-monitoring metrics `job` label is unchanged (set by the scrape `job_name`), and the shipped dashboard groups by `service_name` rather than filtering on it.
- Internal logs emitted by exporters **on the logs pipeline** (`send-loki-logs`, cloud-integrator Loki, `send-otlp` logs) are intentionally dropped from the self-ingested pipeline to prevent recursion. Failure logs from exporters on **other** pipelines (Mimir/remote-write, Tempo, OTLP metrics/traces) are unaffected and still reach Loki.
