### PR TITLE
feat: update cosl to 1.10.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 2
-requires-python = ">=3.14.0, <3.15"
+revision = 3
+requires-python = "==3.14.*"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -345,18 +345,19 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.10.1"
+version = "1.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "diskcache" },
     { name = "ops" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/84/6da25e5e0da58419b8d3252a6707bb97f05866fa7c6098ae35e302626c65/cosl-1.10.1.tar.gz", hash = "sha256:6f49482707e5e5163fd47fc90226189d51c0867d49ff65109d3e96ccf9dad5e4", size = 152093, upload-time = "2026-07-14T15:51:48.262Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/18/9199c798915b667c9516ce664152dbc1f14d80aed963c22f640a0400c253/cosl-1.10.2.tar.gz", hash = "sha256:911981f89a3447dd3f26e1f69f8cdd44b5935fb1e2cfdbd60e75c28d86a17e6d", size = 157045, upload-time = "2026-07-17T21:32:13.709Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/e6/c576f8ebc071dc5edd18a56f66eb0388511d3ece04188812996d4dc72e5b/cosl-1.10.1-py3-none-any.whl", hash = "sha256:845bdbaaaf22b992e5b8dfa87af3e8f3f8004a14ba172b07017274f844aaa9bc", size = 39269, upload-time = "2026-07-14T15:51:46.887Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/53/26902ea5662f0016282c672214bdfbf99251135eeec35ace6875f7784c8d/cosl-1.10.2-py3-none-any.whl", hash = "sha256:ff4aa756ab084def1f49fe31b49781aa584176ac7eec107dd192ae0c87899fc0", size = 41117, upload-time = "2026-07-17T21:32:12.535Z" },
 ]
 
 [[package]]
@@ -449,6 +450,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
     { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
     { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR updates `cos-lib` to [its latest version](https://github.com/canonical/cos-lib/pull/203) that includes the cache persistence

## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 



## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


Deploy a K8s model with an otelcol packed from this PR and expose it otlp interface.
Consume an otlp offer from a COS deployment

```yaml
bundle: kubernetes
saas:
  otelcol:
    url: ck8s:admin/cos-lite.otelcol
  remote-a804064654cf4eb48a73219f219402cc: {}
applications:
  otelcol-cosl:
    charm: local:opentelemetry-collector-k8s-1
    base: ubuntu@26.04/stable
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/edge
    revision: 381
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 173
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - traefik:traefik-route
  - otelcol-cosl:ingress
- - otelcol-cosl:send-otlp
  - otelcol:receive-otlp
- - otelcol-cosl:receive-otlp
  - remote-a804064654cf4eb48a73219f219402cc:send-otlp
--- # overlay.yaml
applications:
  otelcol-cosl:
    offers:
      otelcol-cosl:
        endpoints:
        - receive-otlp
        acl:
          admin: admin
```


Deploy the following model, consume the otlp offer and relate to otelcol

```yaml
default-base: ubuntu@22.04/stable
saas:
  otelcol-cosl:
    url: ck8s:admin/aggreg.otelcol-cosl
applications:
  otelcol:
    charm: opentelemetry-collector
    channel: dev/edge
    revision: 325
  zoo:
    charm: zookeeper
    channel: 3/stable
    revision: 163
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      data: rootfs,1,1024M
machines:
  "0":
    constraints: arch=amd64
relations:
- - otelcol:cos-agent
  - zoo:cos-agent
- - otelcol-cosl:receive-otlp
  - otelcol:send-otlp
```
