### PR TITLE
fix(track/0.130)!: Forward internal telemetry

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -221,6 +221,14 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
                 return
 
         # Create the config manager
+        topology = JujuTopology.from_charm(self)
+        topology_labels = {
+            "juju_charm": topology.charm_name,
+            "juju_model": topology.model,
+            "juju_model_uuid": topology.model_uuid,
+            "juju_application": topology.application,
+            "juju_unit": topology.unit,
+        }
         config_manager = ConfigManager(
             global_scrape_interval=global_configs["global_scrape_interval"],
             global_scrape_timeout=global_configs["global_scrape_timeout"],
@@ -229,6 +237,8 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             queue_size=cast(int, self.config.get("queue_size")),
             max_elapsed_time_min=cast(int, self.config.get("max_elapsed_time_min")),
             unit_name=self.unit.name,
+            internal_host=socket.getfqdn(),
+            topology_labels=topology_labels,
         )
 
         # TODO: if/when we support multiple feature gates, make this a list and find out how to
@@ -253,16 +263,11 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         config_manager.add_log_forwarding(loki_endpoints, insecure_skip_verify)
 
         # Metrics setup
-        topology = JujuTopology.from_charm(self)
         config_manager.add_self_scrape(
             identifier=topology.identifier,
             labels={
                 "instance": f"{topology.identifier}_{topology.unit}",
-                "juju_charm": topology.charm_name,
-                "juju_model": topology.model,
-                "juju_model_uuid": topology.model_uuid,
-                "juju_application": topology.application,
-                "juju_unit": topology.unit,
+                **topology_labels,
             },
         )
         # For now, the only incoming and outgoing metrics relations are remote-write/scrape

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -7,7 +7,13 @@ from enum import Enum, unique
 
 import yaml
 
-from constants import SERVER_CERT_PATH, SERVER_CERT_PRIVATE_KEY_PATH
+from constants import (
+    INTERNAL_LOGS_FILTER_ID,
+    INTERNAL_TELEMETRY_SERVICE_NAME,
+    NON_LOOPING_EXPORTER_PREFIXES,
+    SERVER_CERT_PATH,
+    SERVER_CERT_PRIVATE_KEY_PATH,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +98,8 @@ class ConfigBuilder:
         global_scrape_timeout: str,
         receiver_tls: bool = False,
         exporter_skip_verify: bool = False,
+        internal_host: str = "localhost",
+        topology_labels: Optional[Dict[str, str]] = None,
     ):
         """Generate an empty OpenTelemetry collector config.
 
@@ -101,6 +109,9 @@ class ConfigBuilder:
             global_scrape_timeout: value for `scrape_timeout` in all prometheus receivers
             receiver_tls: whether to inject TLS config in all receivers on build
             exporter_skip_verify: value for `insecure_skip_verify` in all exporters
+            internal_host: the unit FQDN the OTLP receiver's server cert is valid for
+            topology_labels: this collector's own deployment topology. Attached to the collector's
+                internal telemetry so logs from multiple otelcol apps/units are distinguishable.
         """
         self._config = {
             "extensions": {},
@@ -115,8 +126,10 @@ class ConfigBuilder:
             },
         }
         self._unit_name = unit_name
+        self._topology_labels = dict(topology_labels or {})
         self._receiver_tls = receiver_tls
         self._exporter_skip_verify = exporter_skip_verify
+        self._internal_host = internal_host
         self._scrape_interval = global_scrape_interval
         self._scrape_timeout = global_scrape_timeout
 
@@ -132,6 +145,7 @@ class ConfigBuilder:
             str: A YAML string representing the complete configuration.
         """
         self._add_missing_nop_exporters()
+        self._populate_loop_breaker_filter()
         if self._receiver_tls:
             self._add_tls_to_all_receivers()
         self._set_prometheus_receiver_global_timeout_and_interval(
@@ -140,6 +154,49 @@ class ConfigBuilder:
         )
         self._add_exporter_insecure_skip_verify(self._exporter_skip_verify)
         return yaml.safe_dump(self._config)
+
+    def _populate_loop_breaker_filter(self):
+        """Populate the internal-telemetry loop-breaker filter's drop conditions.
+
+        The collector self-ingests its own internal logs into the `logs/<unit>` pipeline. Any
+        exporter on ANY logs pipeline can recurse: its "Exporting failed" log is itself an internal
+        log that re-enters the pipeline and is re-exported. To break the cycle we drop the logs
+        emitted by exactly those exporter components for the LOGS signal, matched on
+        `otelcol.component.id` AND `otelcol.signal`.
+
+        We enumerate the exporters across EVERY logs pipeline dynamically (at build time, after all
+        components and the fallback nop exporter have been added), not just the charm-managed
+        `logs/<unit>` pipeline. This is important because a user-supplied config can add its own
+        logs pipeline (e.g. `logs/custom`) and/or exporters; those would otherwise fail-and-recurse
+        without being covered by the filter. As a result the filter automatically covers EVERY log
+        exporter: send-loki-logs, cloud-integrator, send-otlp logs, custom user exporters, and any
+        future one. Exporters on the metrics/traces pipelines are never included, so their failure
+        logs still reach Loki.
+
+        The auto-injected `nop`/`debug` exporters are excluded: they have no remote endpoint, so
+        they cannot fail-and-recurse.
+        """
+        filter_name = f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}"
+        if filter_name not in self._config["processors"]:
+            return
+        # A pipeline is a logs pipeline when its name is `logs` or `logs/<something>`; its type is
+        # the segment before the first `/`. Collect exporters across ALL such pipelines, preserving
+        # order and de-duplicating (an exporter may be shared by several logs pipelines).
+        log_exporter_ids: List[str] = []
+        for pipeline_name, pipeline in self._config["service"]["pipelines"].items():
+            if pipeline_name.split("/")[0] != "logs":
+                continue
+            for exporter_id in pipeline.get("exporters", []):
+                if (
+                    exporter_id.split("/")[0] not in NON_LOOPING_EXPORTER_PREFIXES
+                    and exporter_id not in log_exporter_ids
+                ):
+                    log_exporter_ids.append(exporter_id)
+        self._config["processors"][filter_name]["logs"]["log_record"] = [
+            f'instrumentation_scope.attributes["otelcol.component.id"] == "{exporter_id}" '
+            f'and instrumentation_scope.attributes["otelcol.signal"] == "logs"'
+            for exporter_id in log_exporter_ids
+        ]
 
     @property
     def hash(self):
@@ -172,14 +229,74 @@ class ConfigBuilder:
         # FIXME https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11780
         # Add TLS config to extensions
         self.add_extension("health_check", {"endpoint": f"0.0.0.0:{Port.health.value}"})
+        self._add_internal_telemetry_loop_breaker()
+        self.add_telemetry("metrics", {"level": "normal"})
+
+    def _add_internal_telemetry_loop_breaker(self):
+        """Configure the loop-breaker and self-ingestion of the collector's internal telemetry.
+
+        We feed the collector's OWN internal logs back into the `logs/<unit>` pipeline, so they
+        can be exported (e.g. to Loki) with topology labels. This creates a recursion risk: any
+        exporter ATTACHED TO THE LOGS PIPELINE emits an "Exporting failed" log when its endpoint
+        is down; that log is itself internal telemetry, so it re-enters the same pipeline, is
+        re-exported, fails again; an unbounded feedback loop.
+
+        We add the filter here (unconditionally, on the base config) so it always sits UPSTREAM
+        of every log exporter. Its drop conditions are left EMPTY here and are populated at build
+        time by `_populate_loop_breaker_filter`, once the full set of exporters on the logs
+        pipeline is known.
+        """
+        self.add_component(
+            Component.processor,
+            f"filter/{INTERNAL_LOGS_FILTER_ID}/{self._unit_name}",
+            {
+                "error_mode": "ignore",
+                # Populated at build time from the logs-pipeline exporters (see build()).
+                "logs": {"log_record": []},
+            },
+            pipelines=[f"logs/{self._unit_name}"],
+        )
+        internal_logs_otlp_exporter: Dict[str, Any] = {
+            "protocol": "http/protobuf",
+            "endpoint": (
+                f"https://{self._internal_host}:{Port.otlp_http.value}"
+                if self._receiver_tls
+                else f"http://localhost:{Port.otlp_http.value}"
+            ),
+        }
+        # Tag ALL of the collector's own telemetry (logs/metrics/traces) with a dedicated
+        # `service.name`. The Loki exporter derives its `job` label from
+        # `service.namespace/service.name`, so this lands the self-ingested internal logs under
+        # `job=otelcol-internal`.
+        resource: Dict[str, Any] = {
+            "service.name": INTERNAL_TELEMETRY_SERVICE_NAME,
+            "loki.format": "logfmt",
+        }
+        if self._topology_labels:
+            resource.update(self._topology_labels)
+            # Pin `service.instance.id` to the Juju unit so the Loki `instance` label is stable and
+            # correlatable with Juju. Otherwise the collector defaults it to a random per-process
+            # UUID that changes on every restart; cardinality churn.
+            if "juju_unit" in self._topology_labels:
+                resource["service.instance.id"] = self._topology_labels["juju_unit"]
+            # Promote ONLY the bounded topology keys to Loki labels via the exporter's
+            # `loki.resource.labels` hint.
+            resource["loki.resource.labels"] = ", ".join(sorted(self._topology_labels))
+        self._config["service"]["telemetry"]["resource"] = resource
         self.add_telemetry(
             "logs",
             {
                 "level": "INFO",
                 "disable_stacktrace": True,
+                "processors": [
+                    {
+                        "batch": {
+                            "exporter": {"otlp": internal_logs_otlp_exporter},
+                        }
+                    }
+                ],
             },
         )
-        self.add_telemetry("metrics", {"level": "normal"})
 
     def add_component(
         self,

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -114,6 +114,8 @@ class ConfigManager:
         insecure_skip_verify: bool = False,
         queue_size: int = 1000,
         max_elapsed_time_min: int = 5,
+        internal_host: str = "localhost",
+        topology_labels: Optional[Dict[str, str]] = None,
     ):
         """Generate a default OpenTelemetry collector ConfigManager.
 
@@ -127,6 +129,9 @@ class ConfigManager:
             insecure_skip_verify: value for `insecure_skip_verify` in all exporters
             queue_size: size of the sending queue for exporters
             max_elapsed_time_min: maximum elapsed time for retrying failed requests in minutes
+            internal_host: the unit FQDN the OTLP receiver's server cert is valid for
+            topology_labels: this collector's own Juju topology labels, attached to its internal
+                telemetry so logs from multiple otelcol apps/units are distinguishable in Loki
         """
         self._unit_name = unit_name
         self._insecure_skip_verify = insecure_skip_verify
@@ -138,6 +143,8 @@ class ConfigManager:
             global_scrape_timeout=global_scrape_timeout,
             receiver_tls=receiver_tls,
             exporter_skip_verify=insecure_skip_verify,
+            internal_host=internal_host,
+            topology_labels=topology_labels,
         )
         self.config.add_default_config()
         self.config.add_extension("file_storage", {"directory": FILE_STORAGE_DIRECTORY})

--- a/src/constants.py
+++ b/src/constants.py
@@ -22,3 +22,6 @@ FILE_STORAGE_DIRECTORY: Final[str] = "/otelcol"
 CERTS_DIR: Final[str] = "/etc/otelcol/certs/"
 EXTERNAL_CONFIG_SECRETS_DIR: Final[str] = "/etc/otelcol/external_config_secrets/"
 INGRESS_IP_MATCHER: Final[str] = "ClientIP(`0.0.0.0/0`)"
+INTERNAL_LOGS_FILTER_ID: Final[str] = "internal-telemetry-loop-breaker"
+INTERNAL_TELEMETRY_SERVICE_NAME: Final[str] = "otelcol-internal"
+NON_LOOPING_EXPORTER_PREFIXES: Final[tuple] = ("nop", "debug")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,7 +2,46 @@
 # See LICENSE file for licensing details.
 """Shared helpers for integration tests."""
 
+import logging
+
 import jubilant
+from tenacity import (
+    after_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+# Reusable retry decorator for polling assertions in integration tests.
+# Retries only on AssertionError (so real errors surface immediately), with exponential backoff.
+RETRY = retry(
+    retry=retry_if_exception_type(AssertionError),
+    wait=wait_exponential(multiplier=1, min=2, max=45),
+    stop=stop_after_attempt(10),
+    after=after_log(logger, logging.INFO),
+)
+
+
+@RETRY
+def assert_pebble_service_active(
+    juju: jubilant.Juju, unit: str, container: str, service: str
+) -> None:
+    """Assert a Pebble service in a workload container is running (Current == active)."""
+    out = juju.ssh(target=unit, command=f"pebble services {service}", container=container)
+    # `pebble services <name>` prints a header then one row per service:
+    #   Service  Startup  Current  Since
+    #   <name>   enabled  active   ...
+    for line in out.splitlines():
+        cols = line.split()
+        if cols and cols[0] == service:
+            assert "active" in cols, f"pebble service {service!r} is not active: {out!r}"
+            return
+    raise AssertionError(
+        f"pebble service {service!r} not found in container {container!r}: {out!r}"
+    )
 
 
 def deploy_seaweedfs(juju: jubilant.Juju, app: str, s3_requirer_app: str) -> None:

--- a/tests/integration/test_forwarding_otlp_telemetry.py
+++ b/tests/integration/test_forwarding_otlp_telemetry.py
@@ -6,25 +6,10 @@
 import logging
 from typing import Dict
 
-from tenacity import (
-    after_log,
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
-
 import jubilant
-
+from helpers import RETRY
 
 logger = logging.getLogger(__name__)
-
-RETRY = retry(
-    retry=retry_if_exception_type(AssertionError),
-    wait=wait_exponential(multiplier=1, min=2, max=45),
-    stop=stop_after_attempt(10),
-    after=after_log(logger, logging.INFO),
-)
 
 
 def test_otlp_setup(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -208,7 +208,7 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
     `otelcol.signal: metrics`) must be preserved and forwarded to Loki.
     """
     # GIVEN Loki is up and otelcol is related to a Prometheus over send-remote-write
-    juju.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True)
+    juju.deploy("prometheus-k8s", "prometheus", channel="3.11/edge", trust=True)
     juju.integrate("otelcol:send-remote-write", "prometheus")
     juju.wait(jubilant.all_active, delay=10, timeout=600)
 

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -153,7 +153,7 @@ def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: 
     # GIVEN a model with flog, blackbox-exporter, otel-collector, and loki charms
     juju.deploy(charm, "otelcol-pebble", resources=charm_resources, trust=True)
     juju.deploy("blackbox-exporter-k8s", "blackbox", channel="0.28/edge", trust=True)
-    juju.deploy("loki-k8s", "loki-pebble", channel="dev/edge", trust=True)
+    juju.deploy("loki-k8s", "loki-pebble", channel="3.7/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface
     juju.integrate("otelcol-pebble:receive-loki-logs", "blackbox")

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -122,7 +122,7 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     # GIVEN a model with flog, otel-collector, and loki
     juju.deploy(charm, "otelcol", resources=charm_resources, trust=True)
     juju.deploy("flog-k8s", "flog", channel="latest/stable")
-    juju.deploy("loki-k8s", "loki", channel="dev/edge", trust=True)
+    juju.deploy("loki-k8s", "loki", channel="3.7/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface
     juju.integrate("otelcol:receive-loki-logs", "flog:log-proxy")

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -152,7 +152,7 @@ def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: 
     """Scenario: log forwarding via Pebble log forwarding."""
     # GIVEN a model with flog, blackbox-exporter, otel-collector, and loki charms
     juju.deploy(charm, "otelcol-pebble", resources=charm_resources, trust=True)
-    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="dev/edge", trust=True)
+    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="0.28/edge", trust=True)
     juju.deploy("loki-k8s", "loki-pebble", channel="dev/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -3,10 +3,15 @@
 
 """Feature: Ingested logs are forwarded."""
 
+import json
+import logging
 import pathlib
-from typing import Dict
+from typing import Dict, Optional
 
 import jubilant
+from helpers import RETRY, assert_pebble_service_active
+
+logger = logging.getLogger(__name__)
 
 # pyright: reportAttributeAccessIssue = false
 
@@ -14,12 +19,110 @@ import jubilant
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
 
 
+def _jsonl_has_entries(result: str) -> bool:
+    """Return True if `logcli query --output=jsonl` output has at least one real log entry.
+
+    Each line is a JSON object like `{"labels": {...}, "line": "...", "timestamp": "..."}`. We parse
+    it (rather than a bare truthiness check on stdout, which would also match `logcli` metadata) and
+    require at least one entry with a non-empty `line`. This is a pure predicate; callers wrap it in
+    an assertion (typically under `@RETRY`). The caller's stream selector (e.g.
+    `{job="otelcol-internal"}`) is what guarantees the labels on the returned entries -- `logcli`
+    strips labels common to all returned streams from the per-line `labels` field (so it is often
+    `{}`), which is why we do NOT assert on that field here; use `logcli series` for that.
+    """
+    for line in result.splitlines():
+        if line.strip() and json.loads(line).get("line", "").strip():
+            return True
+    return False
+
+
+def _loop_breaker_filtered_count(juju: jubilant.Juju) -> Optional[float]:
+    """Return the latest loop-breaker `filtered` counter from otelcol's Pebble logs, else None.
+
+    Requires `debug_exporter_for_metrics=True` so the collector's internal metrics are printed to
+    the Pebble logs.
+
+    Note: the Pebble log ring buffer persists across the collector restarts triggered by config
+    changes, so callers that compare values over time should sample late (after enough fresh logs
+    have scrolled older, pre-restart samples out of the `-n 1000` window).
+
+    Sample:
+        2026-07-16T17:52:13.115Z [otelcol] otelcol_processor_filter_logs.filtered{
+            filter=filter/internal-telemetry-loop-breaker/otelcol/0,
+            juju_application=otelcol,
+            juju_charm=opentelemetry-collector-k8s,
+            juju_model=jubilant-14697ea3,
+            juju_model_uuid=35054976-38b2-4f7c-8c50-a793733187e2,
+            juju_unit=otelcol/0,
+            otel_scope_name=github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor,
+            service.instance.id=aaa3c609-a192-4bee-9b48-641cb2e92dcf,
+            service.name=otelcol-internal,
+            service.version=0.130.1
+        } 14
+    """
+    logs = juju.ssh(target="otelcol/leader", command="pebble logs -n 1000", container="otelcol")
+    value: Optional[float] = None
+    for line in logs.splitlines():
+        if "otelcol_processor_filter_logs.filtered" in line and "loop-breaker" in line:
+            value = float(line.rsplit(" ", 1)[-1])  # keep the most recent sample
+    return value
+
+
+@RETRY
+def _assert_loop_breaker_dropped_more(juju: jubilant.Juju, baseline: float) -> None:
+    """Assert otelcol's loop-breaker `filtered` counter has climbed above `baseline`.
+
+    Requires `debug_exporter_for_metrics=True` so the counter is printed to the Pebble logs (see
+    `_loop_breaker_filtered_count`). We assert on the DELTA rather than an absolute value because
+    the counter can already be > 0 due to transient logs-signal failures (e.g. Loki "not ready"
+    windows) that the loop-breaker legitimately drops.
+    """
+    current = _loop_breaker_filtered_count(juju) or 0.0
+    assert current > baseline, (
+        f"loop-breaker filter drop counter did not increase: {baseline} -> {current}"
+    )
+
+
+@RETRY
+def _assert_internal_logs_in_loki(juju: jubilant.Juju, loki_app: str, otelcol_app: str) -> None:
+    """Assert the collector's own internal telemetry logs reach Loki with Juju topology labels.
+
+    The internal logs are tagged with this collector's own Juju topology so that, when multiple
+    otelcol apps ship to the same Loki, their `job=otelcol-internal` streams stay distinguishable.
+    We also pin `service.instance.id` to the Juju unit, so the `instance` label is the unit (stable
+    and correlatable) rather than a random per-process UUID that churns on every restart.
+    """
+    result = juju.ssh(
+        target=f"{loki_app}/leader",
+        command="/usr/bin/logcli series --quiet '{job=\"otelcol-internal\"}'",
+        container="loki",
+    )
+    # {instance="otelcol/0", job="otelcol-internal", juju_application="otelcol", juju_charm="...",
+    #  juju_model="...", juju_model_uuid="...", juju_unit="otelcol/0", level="INFO", ...}
+    assert "otelcol-internal" in result, (
+        f"No `job=otelcol-internal` stream found in Loki: {result!r}"
+    )
+    # Topology labels are present and identify the emitting app/unit ...
+    for label in (
+        f'juju_application="{otelcol_app}"',
+        f'juju_unit="{otelcol_app}/0"',
+        "juju_model=",
+        "juju_model_uuid=",
+        "juju_charm=",
+    ):
+        assert label in result, f"Expected topology label {label!r} on internal logs: {result!r}"
+    # ... and the `instance` label is the Juju unit, not a random UUID.
+    assert f'instance="{otelcol_app}/0"' in result, (
+        f"Expected `instance` label pinned to the Juju unit: {result!r}"
+    )
+
+
 def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: log forwarding via the LogProxyConsumer."""
     # GIVEN a model with flog, otel-collector, and loki
     juju.deploy(charm, "otelcol", resources=charm_resources, trust=True)
     juju.deploy("flog-k8s", "flog", channel="latest/stable")
-    juju.deploy("loki-k8s", "loki", channel="2/edge", trust=True)
+    juju.deploy("loki-k8s", "loki", channel="dev/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface
     juju.integrate("otelcol:receive-loki-logs", "flog:log-proxy")
@@ -27,24 +130,30 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     juju.wait(jubilant.all_active, delay=10, timeout=600)
 
     # THEN logs arrive in loki with juju topology labels preserved
-    # Ref: https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/172
-    labels = juju.ssh(
-        target="loki/leader",
-        command="/usr/bin/logcli labels",
-        container="loki",
-    )
     topology = {"juju_application", "juju_charm", "juju_unit", "juju_model", "juju_model_uuid"}
 
-    for label in topology:
-        assert label in labels, f"Expected '{label}' label in Loki, got: {labels}"
+    @RETRY
+    def _assert_topology_labels() -> None:
+        labels = juju.ssh(
+            target="loki/leader",
+            command="/usr/bin/logcli labels",
+            container="loki",
+        )
+        for label in topology:
+            assert label in labels, f"Expected '{label}' label in Loki, got: {labels}"
+
+    _assert_topology_labels()
+
+    # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
+    _assert_internal_logs_in_loki(juju, "loki", "otelcol")
 
 
 def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: log forwarding via Pebble log forwarding."""
     # GIVEN a model with flog, blackbox-exporter, otel-collector, and loki charms
     juju.deploy(charm, "otelcol-pebble", resources=charm_resources, trust=True)
-    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="2/edge", trust=True)
-    juju.deploy("loki-k8s", "loki-pebble", channel="2/edge", trust=True)
+    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="dev/edge", trust=True)
+    juju.deploy("loki-k8s", "loki-pebble", channel="dev/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface
     juju.integrate("otelcol-pebble:receive-loki-logs", "blackbox")
@@ -60,3 +169,85 @@ def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: 
     # FIXME: The Pebble log forwarding library sets different label names
     # Once they match, change this to `juju_application`
     assert "application" in labels
+
+    # AND the collector's own internal telemetry logs (tagged job=otelcol-internal) reach loki
+    _assert_internal_logs_in_loki(juju, "loki-pebble", "otelcol-pebble")
+
+
+def test_internal_logs_loop_breaker_drops_on_outage(juju: jubilant.Juju):
+    """Scenario: when the Loki exporter is down, the loop-breaker filter drops its own failure logs."""
+    # GIVEN the metrics debug exporter is on, so internal metrics are printed to the Pebble logs
+    juju.config("otelcol", {"debug_exporter_for_metrics": True})
+    juju.wait(lambda status: jubilant.all_active(status, "otelcol"), delay=5, timeout=300)
+
+    # Baseline the loop-breaker drop counter. It may already be > 0: Loki can have transient
+    # "not ready" windows (e.g. ingester warmup) during which send-loki-logs fails and the
+    # loop-breaker correctly drops those recursive logs-signal failures. So we assert on the DELTA
+    # once we stop Loki, never on an absolute zero.
+    baseline = _loop_breaker_filtered_count(juju) or 0.0
+
+    # WHEN the send-loki-logs exporter is failing (Loki workload stopped), which makes it emit
+    # "Exporting failed" internal logs that recurse into the logs pipeline and must be dropped.
+    juju.ssh(target="loki/leader", command="pebble stop loki", container="loki")
+
+    try:
+        # THEN the loop-breaker drop counter climbs above the baseline as it drops the looping
+        # exporter's own internal logs.
+        _assert_loop_breaker_dropped_more(juju, baseline)
+    finally:
+        juju.ssh(target="loki/leader", command="pebble start loki", container="loki")
+        assert_pebble_service_active(juju, "loki/leader", "loki", "loki")
+
+
+def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.Juju):
+    """Scenario: a metrics exporter's failure logs still reach Loki (they are NOT loop-dropped).
+
+    The loop-breaker filter drops ONLY logs emitted by exporters on the LOGS pipeline (matched on
+    `otelcol.component.id` AND `otelcol.signal == "logs"`). Failure logs from exporters on other
+    pipelines (here: `prometheusremotewrite/0` on the metrics pipeline, which emits
+    `otelcol.signal: metrics`) must be preserved and forwarded to Loki.
+    """
+    # GIVEN Loki is up and otelcol is related to a Prometheus over send-remote-write
+    juju.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True)
+    juju.integrate("otelcol:send-remote-write", "prometheus")
+    juju.wait(jubilant.all_active, delay=10, timeout=600)
+
+    # AND the metrics debug exporter is on, so internal metrics are printed to the Pebble logs.
+    juju.config("otelcol", {"debug_exporter_for_metrics": True})
+    juju.wait(lambda status: jubilant.all_active(status, "otelcol"), delay=5, timeout=300)
+
+    # WHEN the remote-write target is down, the metrics exporter (`prometheusremotewrite/0`) emits
+    # "Exporting failed" internal logs carrying `otelcol.signal: metrics`.
+    juju.ssh(target="prometheus/leader", command="pebble stop prometheus", container="prometheus")
+
+    try:
+        # THEN the metrics-exporter's logs reach Loki, proving they were not over-dropped.
+        #
+        # `loki.format: logfmt` mangles the body text (`Exporting failed` is no longer a contiguous
+        # substring), so we match the scope attributes instead, which logfmt emits verbatim as
+        # `instrumentation_scope_attribute_<key>=<value>`.
+        @RETRY
+        def _assert_metrics_exporter_failure_logs_in_loki() -> None:
+            result = juju.ssh(
+                target="loki/leader",
+                command=(
+                    "/usr/bin/logcli query --quiet --limit=5 --output=jsonl "
+                    '\'{job="otelcol-internal"} '
+                    "|= `otelcol.component.id=prometheusremotewrite` "
+                    "|= `otelcol.signal=metrics`'"
+                ),
+                container="loki",
+            )
+            assert _jsonl_has_entries(result), (
+                "Metrics-exporter failure logs were not forwarded to Loki (over-dropped by the "
+                f"loop-breaker?): {result!r}"
+            )
+
+        _assert_metrics_exporter_failure_logs_in_loki()
+    finally:
+        juju.ssh(
+            target="prometheus/leader", command="pebble start prometheus", container="prometheus"
+        )
+        assert_pebble_service_active(juju, "prometheus/leader", "prometheus", "prometheus")
+        juju.config("otelcol", {"debug_exporter_for_metrics": False})
+        juju.remove_relation("otelcol:send-remote-write", "prometheus")

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -108,6 +108,207 @@ def test_rendered_default_is_valid():
     assert all(all(condition for condition in pair) for pair in pairs)
 
 
+def test_default_internal_logs_self_export_plaintext():
+    # GIVEN a default config without receiver TLS
+    config = ConfigBuilder(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        receiver_tls=False,
+    )
+    config.add_default_config()
+    logs_telemetry = config._config["service"]["telemetry"]["logs"]
+    # THEN the collector's own telemetry resource is tagged so the Loki exporter derives
+    # `job=otelcol-internal` from `service.name` deterministically (distinguishable in Grafana)
+    # AND the full internal log record (body + attributes) is rendered into the Loki line
+    assert config._config["service"]["telemetry"]["resource"] == {
+        "service.name": "otelcol-internal",
+        "loki.format": "logfmt",
+    }
+    # AND internal logs are exported over OTLP to the collector's own OTLP receiver
+    otlp = logs_telemetry["processors"][0]["batch"]["exporter"]["otlp"]
+    assert otlp["protocol"] == "http/protobuf"
+    # AND the loopback endpoint uses plaintext HTTP with no CA certificate and no TLS block
+    assert otlp["endpoint"] == "http://localhost:4318"
+    assert "certificate" not in otlp
+    assert "tls" not in otlp
+
+
+def test_internal_logs_full_record_rendered_to_loki():
+    # GIVEN a default config
+    config = ConfigBuilder(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        receiver_tls=False,
+    )
+    config.add_default_config()
+    resource = config._config["service"]["telemetry"]["resource"]
+    # THEN `loki.format: logfmt` renders the full record (so in-log context like `target_labels`
+    # survives), and no otelcol-own topology labels are injected
+    assert resource == {
+        "service.name": "otelcol-internal",
+        "loki.format": "logfmt",
+    }
+
+
+def test_internal_logs_topology_labels_promoted_to_loki_labels():
+    # GIVEN a config built with this collector's own Juju topology
+    topology = {
+        "juju_application": "otelcol",
+        "juju_charm": "opentelemetry-collector-k8s",
+        "juju_model": "mymodel",
+        "juju_model_uuid": "abcd-1234",
+        "juju_unit": "otelcol/0",
+    }
+    config = ConfigBuilder(
+        unit_name="otelcol/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        topology_labels=topology,
+    )
+    config.add_default_config()
+    resource = config._config["service"]["telemetry"]["resource"]
+    # THEN the topology is attached to the internal-telemetry resource ...
+    for key, value in topology.items():
+        assert resource[key] == value
+    # AND `service.instance.id` is pinned to the Juju unit (so the Loki `instance` label is stable
+    # and correlatable, instead of a random per-process UUID that churns on every restart)
+    assert resource["service.instance.id"] == "otelcol/0"
+    # AND the job label is still derived from service.name
+    assert resource["service.name"] == "otelcol-internal"
+    # AND ONLY the bounded topology keys are promoted to Loki labels (no high-cardinality otelcol
+    # attributes like `error`/`target_labels`/`scrape_timestamp` are promoted)
+    promoted = {label.strip() for label in resource["loki.resource.labels"].split(",")}
+    assert promoted == set(topology.keys())
+
+
+def test_internal_logs_without_topology_labels_are_unchanged():
+    # GIVEN no topology is supplied (the historical behaviour)
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    resource = config._config["service"]["telemetry"]["resource"]
+    # THEN no topology labels, no pinned instance id, and no label-promotion hint are injected
+    assert resource == {"service.name": "otelcol-internal", "loki.format": "logfmt"}
+
+
+def test_default_internal_logs_self_export_tls():
+    # GIVEN a default config WITH receiver TLS and the unit FQDN the server cert is valid for
+    config = ConfigBuilder(
+        unit_name="fake/0",
+        global_scrape_interval="",
+        global_scrape_timeout="",
+        receiver_tls=True,
+        internal_host="otelcol-0.otelcol-endpoints.o11y.svc.cluster.local",
+    )
+    config.add_default_config()
+    otlp = config._config["service"]["telemetry"]["logs"]["processors"][0]["batch"]["exporter"][
+        "otlp"
+    ]
+    # THEN the loopback endpoint targets the FQDN (a name present in the cert SANs) over HTTPS, so
+    # verification succeeds -- NOT `localhost`, which would fail ("valid for <fqdn>, not localhost")
+    assert (
+        otlp["endpoint"]
+        == "https://otelcol-0.otelcol-endpoints.o11y.svc.cluster.local:4318"
+    )
+    # AND no explicit CA is configured: trust is via the system root store
+    assert "certificate" not in otlp
+    assert "insecure" not in otlp
+    assert "tls" not in otlp
+
+
+def test_default_internal_logs_loop_breaker_filter_present():
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    filter_name = "filter/internal-telemetry-loop-breaker/fake/0"
+    filter_cfg = config._config["processors"][filter_name]
+    # Filter is wired into the logs pipeline and tolerates OTTL eval errors (keeps valid data).
+    assert filter_cfg["error_mode"] == "ignore"
+    assert filter_name in config._config["service"]["pipelines"]["logs/fake/0"]["processors"]
+
+
+def test_loop_breaker_filter_conditions_populated_from_logs_exporters():
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    for name in ("loki/send-loki-logs/0", "otlphttp/rel-1/fake/0"):
+        config.add_component(Component.exporter, name, {"endpoint": "x"}, pipelines=["logs/fake/0"])
+    # A non-log exporter (metrics pipeline) must NOT be covered.
+    config.add_component(
+        Component.exporter, "prometheusremotewrite/0", {"endpoint": "x"}, pipelines=["metrics/fake/0"]
+    )
+    built = yaml.safe_load(config.build())
+    conditions = built["processors"]["filter/internal-telemetry-loop-breaker/fake/0"]["logs"][
+        "log_record"
+    ]
+    # Every logs-pipeline exporter is covered, each scoped to the logs signal; nothing else is.
+    assert all('instrumentation_scope.attributes["otelcol.signal"] == "logs"' in c for c in conditions)
+    covered = {c for eid in ("loki/send-loki-logs/0", "otlphttp/rel-1/fake/0") for c in conditions if eid in c}
+    assert len(covered) == 2
+    assert not any("prometheusremotewrite" in c or "nop" in c or "debug" in c for c in conditions)
+
+
+def test_loop_breaker_filter_covers_exporters_on_custom_logs_pipelines():
+    # A user-supplied config can add its own logs pipeline (e.g. `logs/custom`) with its own
+    # exporters. Those can still fail-and-recurse, so the loop-breaker must cover them too, not
+    # just exporters on the charm-managed `logs/<unit>` pipeline.
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    # Exporter on the charm-managed logs pipeline.
+    config.add_component(
+        Component.exporter, "loki/send-loki-logs/0", {"endpoint": "x"}, pipelines=["logs/fake/0"]
+    )
+    # Exporter on a user-defined logs pipeline in a different namespace.
+    config.add_component(
+        Component.exporter, "otlphttp/user-custom", {"endpoint": "x"}, pipelines=["logs/custom"]
+    )
+    # A bare `logs` pipeline (no `/<name>` suffix) is also a logs pipeline.
+    config.add_component(
+        Component.exporter, "kafka/user-bare", {"endpoint": "x"}, pipelines=["logs"]
+    )
+    # A metrics-pipeline exporter must NOT be covered even on a custom namespace.
+    config.add_component(
+        Component.exporter, "prometheusremotewrite/user", {"endpoint": "x"}, pipelines=["metrics/custom"]
+    )
+    built = yaml.safe_load(config.build())
+    conditions = built["processors"]["filter/internal-telemetry-loop-breaker/fake/0"]["logs"][
+        "log_record"
+    ]
+    covered = {
+        eid
+        for eid in ("loki/send-loki-logs/0", "otlphttp/user-custom", "kafka/user-bare")
+        if any(eid in c for c in conditions)
+    }
+    assert covered == {"loki/send-loki-logs/0", "otlphttp/user-custom", "kafka/user-bare"}
+    assert not any("prometheusremotewrite" in c for c in conditions)
+
+
+def test_loop_breaker_filter_deduplicates_shared_exporter_across_logs_pipelines():
+    # An exporter shared by multiple logs pipelines must yield exactly one drop condition.
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    config.add_component(
+        Component.exporter,
+        "loki/send-loki-logs/0",
+        {"endpoint": "x"},
+        pipelines=["logs/fake/0", "logs/custom"],
+    )
+    built = yaml.safe_load(config.build())
+    conditions = built["processors"]["filter/internal-telemetry-loop-breaker/fake/0"]["logs"][
+        "log_record"
+    ]
+    assert sum("loki/send-loki-logs/0" in c for c in conditions) == 1
+
+
+def test_loop_breaker_filter_conditions_empty_without_log_exporter():
+    # With no log exporter (only the fallback nop), nothing can recurse -> no drop conditions.
+    config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")
+    config.add_default_config()
+    built = yaml.safe_load(config.build())
+    assert built["processors"]["filter/internal-telemetry-loop-breaker/fake/0"]["logs"][
+        "log_record"
+    ] == []
+
+
 def test_receivers_tls_empty_config():
     # GIVEN an "empty" config
     config = ConfigBuilder(unit_name="fake/0", global_scrape_interval="", global_scrape_timeout="")

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -3,11 +3,13 @@
 
 """Feature: Opentelemetry-collector config builder."""
 
-from src.config_manager import ConfigManager
-from charmlibs.interfaces.otlp import OtlpEndpoint
 import copy
 
 import pytest
+import yaml
+from charmlibs.interfaces.otlp import OtlpEndpoint
+
+from src.config_manager import ConfigManager
 
 
 def test_add_prometheus_scrape():
@@ -187,9 +189,9 @@ def test_add_traces_forwarding_multiple_endpoints():
     assert exporters["otlphttp/send-traces-1"]["endpoint"] == "http://tempo2.example.com:4318"
 
     # AND both exporters are wired into the traces pipeline
-    pipeline_exporters = config_manager.config._config["service"]["pipelines"][
-        "traces/otelcol/0"
-    ]["exporters"]
+    pipeline_exporters = config_manager.config._config["service"]["pipelines"]["traces/otelcol/0"][
+        "exporters"
+    ]
     assert "otlphttp/send-traces-0" in pipeline_exporters
     assert "otlphttp/send-traces-1" in pipeline_exporters
 
@@ -246,6 +248,8 @@ def test_add_remote_write():
             {
                 "logs/otelcol/0": {
                     "receivers": ["otlp/otelcol/0"],
+                    # The loop-breaker filter is always present on the self-ingested logs pipeline
+                    "processors": ["filter/internal-telemetry-loop-breaker/otelcol/0"],
                     "exporters": ["debug/juju-config-enabled"],
                 },
                 "metrics/otelcol/0": {
@@ -263,6 +267,8 @@ def test_add_remote_write():
             {
                 "logs/otelcol/0": {
                     "receivers": ["otlp/otelcol/0"],
+                    # The loop-breaker filter is always present on the self-ingested logs pipeline
+                    "processors": ["filter/internal-telemetry-loop-breaker/otelcol/0"],
                     "exporters": ["debug/juju-config-enabled"],
                 },
                 "metrics/otelcol/0": {"receivers": ["otlp/otelcol/0"]},
@@ -367,6 +373,9 @@ def test_add_otlp_forwarding():
     expected_pipelines = {
         "logs/otelcol/0": {
             "receivers": ["otlp/otelcol/0"],
+            # The loop-breaker filter is always present on the self-ingested logs pipeline, so any
+            # log exporter (here an OTLP-logs exporter) is guarded against the recursion.
+            "processors": ["filter/internal-telemetry-loop-breaker/otelcol/0"],
             "exporters": [f"otlphttp/rel-1/{unit_name}", f"otlp/rel-2/{unit_name}"],
         },
         "metrics/otelcol/0": {
@@ -380,3 +389,71 @@ def test_add_otlp_forwarding():
     }
     assert config_manager.config._config["exporters"] == expected_exporters
     assert config_manager.config._config["service"]["pipelines"] == expected_pipelines
+
+
+def test_self_ingest_loop_breaker_invariant_all_log_exporters():
+    """Every exporter on the self-ingested logs pipeline is covered by the loop-breaker.
+
+    The collector self-ingests its own internal logs into `logs/<unit>` and exports them. Any
+    exporter on THAT pipeline can recurse when its endpoint is down. The loop-breaker filter's drop
+    conditions are enumerated dynamically at build time from the logs-pipeline exporters, so it
+    covers EVERY log exporter automatically. This test enables every feature that attaches a log
+    exporter: Loki forwarding, cloud-integrator Loki, AND a `send-otlp` LOGS exporter, plus a
+    NON-log exporter (Mimir remote-write on the metrics pipeline), then asserts:
+      1. every log-pipeline exporter is covered by an exact component-id condition, and
+      2. the non-log (Mimir) exporter is NOT covered (its failure logs still reach Loki).
+    If a future log exporter is wired into the logs pipeline, (1) covers it with no code change;
+    if the dynamic enumeration regresses, this test fails.
+    """
+    unit_name = "otelcol/0"
+    filter_name = f"filter/internal-telemetry-loop-breaker/{unit_name}"
+    # GIVEN a base config manager
+    config_manager = ConfigManager(
+        unit_name=unit_name,
+        global_scrape_interval="",
+        global_scrape_timeout="",
+    )
+    # WHEN every LOG-exporting feature is enabled
+    config_manager.add_log_forwarding(
+        endpoints=[{"url": "http://loki/loki/api/v1/push"}],
+        insecure_skip_verify=False,
+    )
+    config_manager.add_cloud_integrator(
+        username=None,
+        password=None,
+        prometheus_url=None,
+        loki_url="http://cloud-loki/loki/api/v1/push",
+        tempo_url=None,
+    )
+    config_manager.add_otlp_forwarding(
+        relation_map={
+            0: OtlpEndpoint(
+                protocol="http",
+                endpoint="http://otlp-logs:4318",
+                telemetries=["logs"],
+                insecure=True,
+            ),
+        }
+    )
+    # AND WHEN a NON-log exporter, whose failure logs must NOT be dropped, is added
+    config_manager.add_remote_write(endpoints=[{"url": "http://mimir/api/v1/push"}])
+
+    built = yaml.safe_load(config_manager.config.build())
+    pipelines = built["service"]["pipelines"]
+    logs_pipeline = pipelines[f"logs/{unit_name}"]
+    conditions = built["processors"][filter_name]["logs"]["log_record"]
+    # THEN the filter is present on the self-ingested logs pipeline.
+    assert filter_name in logs_pipeline.get("processors", [])
+
+    # Every non-nop/debug logs-pipeline exporter (incl. the send-otlp logs exporter) is covered,
+    # scoped to the logs signal; the metrics-only Mimir exporter is not.
+    for exporter_id in logs_pipeline.get("exporters", []):
+        if exporter_id.split("/")[0] in ("nop", "debug"):
+            continue
+        covering = [c for c in conditions if exporter_id in c]
+        assert covering, f"log exporter '{exporter_id}' not covered by loop-breaker filter"
+        assert all(
+            'instrumentation_scope.attributes["otelcol.signal"] == "logs"' in c for c in covering
+        )
+    assert any("otlphttp/rel-" in c for c in conditions)
+    assert not any("prometheusremotewrite" in c for c in conditions)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Backport of this feature:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/323

into track/0.130.

## Solution
<!-- A summary of the solution addressing the above issue -->
 This may be a feature, but internal logs were previously omitted in:
 - https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/162

Updating the itest app channels is addressed in:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/331

as a workaround to avoid log explosions in the PVC. This removed a core feature which should exist in the LTS. Not having internal otelcol logs forwarded to a Logging datastore is not acceptable in a professional Observability stack, especially since our collector is the central aggregator; providing important internal logs on failures.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [ ] Backport the docs PR:
	- https://github.com/canonical/observability-stack/pull/461


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
- Internal telemetry logs are now forwarded to Loki, tagged `job=otelcol-internal` (derived from the collector's own `service.name=otelcol-internal`). Query them with `{job="otelcol-internal"}`.
- Internal logs are rendered with `loki.format: logfmt` (full record: body + attributes), so context like `error`, `interval` and the scraped target's topology (`target_labels`) appears in the log line. Scraped charm logs are unaffected (they stay `raw`).
- The collector's own telemetry resource reports `service.name=otelcol-internal`. This affects only the collector's *self* telemetry; the self-monitoring metrics `job` label is unchanged (set by the scrape `job_name`), and the shipped dashboard groups by `service_name` rather than filtering on it.
- Internal logs emitted by exporters **on the logs pipeline** (`send-loki-logs`, cloud-integrator Loki, `send-otlp` logs) are intentionally dropped from the self-ingested pipeline to prevent recursion. Failure logs from exporters on **other** pipelines (Mimir/remote-write, Tempo, OTLP metrics/traces) are unaffected and still reach Loki.