### PR TITLE
fix: Integration test app channels use `dev/edge`

### DIFF
--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -208,7 +208,7 @@ def test_internal_logs_cross_signal_preserved_on_metrics_outage(juju: jubilant.J
     `otelcol.signal: metrics`) must be preserved and forwarded to Loki.
     """
     # GIVEN Loki is up and otelcol is related to a Prometheus over send-remote-write
-    juju.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True)
+    juju.deploy("prometheus-k8s", "prometheus", channel="dev/edge", trust=True)
     juju.integrate("otelcol:send-remote-write", "prometheus")
     juju.wait(jubilant.all_active, delay=10, timeout=600)
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -34,7 +34,7 @@ def _retry_prom_jobs_api(endpoint: str):
 
 @retry(stop=stop_after_attempt(10), wait=wait_fixed(10))
 def _retry_avalanche_metrics_arrive_prom(prom_ip: str):
-    params = {"query": 'count({__name__=~"avalanche_metric_.+"})'}
+    params = {"query": 'count({__name__=~"avalanche_.*"})'}
     data = json.loads(request("GET", f"http://{prom_ip}:9090/api/v1/query", params=params).text)[
         "data"
     ]
@@ -52,6 +52,7 @@ def test_metrics_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict
     juju.integrate("avalanche", "otelcol:metrics-endpoint")
     juju.integrate("otelcol:send-remote-write", "prometheus")
     juju.wait(jubilant.all_active, delay=10, timeout=600)
+    breakpoint()
     prom_ip = juju.status().apps["prometheus"].units["prometheus/0"].address
     # THEN the AlwaysFiring alerts from Avalanche arrive in prometheus
     _retry_prom_alerts_api(f"http://{prom_ip}:9090/api/v1/alerts")

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -45,8 +45,8 @@ def _retry_avalanche_metrics_arrive_prom(prom_ip: str):
 def test_metrics_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: scrape-to-remote-write forwarding."""
     # GIVEN a model with avalanche, otel-collector, and prometheus charms
-    juju.deploy("avalanche-k8s", app="avalanche", channel="2/edge", trust=True)
-    juju.deploy("prometheus-k8s", app="prometheus", channel="2/edge", trust=True)
+    juju.deploy("avalanche-k8s", app="avalanche", channel="dev/edge", trust=True)
+    juju.deploy("prometheus-k8s", app="prometheus", channel="dev/edge", trust=True)
     juju.deploy(charm, app="otelcol", resources=charm_resources, trust=True)
     # WHEN they are related via scrape and remote-write
     juju.integrate("avalanche", "otelcol:metrics-endpoint")

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -52,7 +52,6 @@ def test_metrics_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict
     juju.integrate("avalanche", "otelcol:metrics-endpoint")
     juju.integrate("otelcol:send-remote-write", "prometheus")
     juju.wait(jubilant.all_active, delay=10, timeout=600)
-    breakpoint()
     prom_ip = juju.status().apps["prometheus"].units["prometheus/0"].address
     # THEN the AlwaysFiring alerts from Avalanche arrive in prometheus
     _retry_prom_alerts_api(f"http://{prom_ip}:9090/api/v1/alerts")

--- a/tests/integration/test_profiling.py
+++ b/tests/integration/test_profiling.py
@@ -23,9 +23,9 @@ async def test_smoke(juju: jubilant.Juju, charm: str, charm_resources: Dict[str,
         resources=charm_resources,
         trust=True,
     )
-    juju.deploy(charm="grafana-k8s", app="grafana", channel="2/edge", trust=True)
-    juju.deploy(charm="pyroscope-coordinator-k8s", app="pyroscope", channel="2/edge", trust=True)
-    juju.deploy(charm="pyroscope-worker-k8s", app="pyroscope-worker", channel="2/edge", trust=True)
+    juju.deploy(charm="grafana-k8s", app="grafana", channel="dev/edge", trust=True)
+    juju.deploy(charm="pyroscope-coordinator-k8s", app="pyroscope", channel="dev/edge", trust=True)
+    juju.deploy(charm="pyroscope-worker-k8s", app="pyroscope-worker", channel="dev/edge", trust=True)
     # Set up minio and s3-integrator
     juju.deploy(
         charm="minio",

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -36,9 +36,9 @@ async def test_traces_pipeline(juju: jubilant.Juju, charm: str, charm_resources:
         resources=charm_resources,
         trust=True,
     )
-    juju.deploy(charm="grafana-k8s", app="grafana", channel="2/edge", trust=True)
-    juju.deploy(charm="tempo-coordinator-k8s", app="tempo", channel="2/edge", trust=True)
-    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker", channel="2/edge", trust=True)
+    juju.deploy(charm="grafana-k8s", app="grafana", channel="dev/edge", trust=True)
+    juju.deploy(charm="tempo-coordinator-k8s", app="tempo", channel="dev/edge", trust=True)
+    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker", channel="dev/edge", trust=True)
     deploy_seaweedfs(juju, app="seaweedfs-tempo", s3_requirer_app="tempo")
     juju.integrate("tempo:tempo-cluster", "tempo-worker")
     # WHEN we add relations to send charm traces to tempo
@@ -70,8 +70,8 @@ async def test_traces_multiple_backends(
 ):
     """Scenario: traces are forwarded to two Tempo backends simultaneously."""
     # GIVEN a second Tempo stack is deployed
-    juju.deploy(charm="tempo-coordinator-k8s", app="tempo2", channel="2/edge", trust=True)
-    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker2", channel="2/edge", trust=True)
+    juju.deploy(charm="tempo-coordinator-k8s", app="tempo2", channel="dev/edge", trust=True)
+    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker2", channel="dev/edge", trust=True)
     deploy_seaweedfs(juju, app="seaweedfs-tempo2", s3_requirer_app="tempo2")
     juju.integrate("tempo2:tempo-cluster", "tempo-worker2")
     juju.wait(lambda status: jubilant.all_active(status, "tempo2"), delay=10, timeout=900)
@@ -99,7 +99,7 @@ async def test_traces_multiple_backends(
 async def test_traces_with_tls(juju: jubilant.Juju):
     """Scenario: TLS is added to the tracing pipeline."""
     # WHEN TLS is added to Tempo and to otelcol
-    juju.deploy(charm="grafana-k8s", app="coconut", channel="2/edge", trust=True)
+    juju.deploy(charm="grafana-k8s", app="coconut", channel="dev/edge", trust=True)
     juju.deploy(charm="self-signed-certificates", app="ssc", channel="edge")
     juju.integrate("tempo:certificates", "ssc")
     juju.integrate("otelcol:receive-ca-cert", "ssc")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The `main` branch should be tied to `track/dev` and our integration tests need to reflect that.

## Solution
<!-- A summary of the solution addressing the above issue -->
Update the channels from which the apps in integration tests deploy from. Exceptions include:
- Charms not owned by the O11y team e.g., s3-integrator, Traefik, etc.

### Checklist
- [ ] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
See CI.