### PR TITLE
fix(track/0.130): Integration test app channels use `WORKLOAD/edge`

### DIFF
--- a/tests/integration/test_forwarding_otlp_telemetry.py
+++ b/tests/integration/test_forwarding_otlp_telemetry.py
@@ -38,7 +38,7 @@ def test_otlp_setup(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, 
     juju.integrate("flog:log-proxy", "requirer")
 
     # AND a Grafana which sends its traces to the `requirer`
-    juju.deploy("grafana-k8s", "grafana", channel="dev/edge", trust=True)
+    juju.deploy("grafana-k8s", "grafana", channel="12.4/edge", trust=True)
     juju.integrate("grafana:charm-tracing", "requirer")
 
     # WHEN the requirer is related to the provider over the OTLP endpoints

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -138,7 +138,7 @@ def test_health_through_traefik_ingress(
     """Scenario: log forwarding via the LogProxyConsumer."""
     # GIVEN a model with otel-collector and traefik
     juju.deploy(charm, "otelcol", resources=charm_resources, trust=True)
-    juju.deploy("traefik-k8s", "traefik", channel="latest/stable", trust=True)
+    juju.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True)
 
     # WHEN otel-collector is related to an ingress provider
     juju.integrate("otelcol:ingress", "traefik")
@@ -156,7 +156,7 @@ def test_push_logs_through_traefik_ingress(
     # GIVEN a model with otel-collector and traefik
     # AND a receive-loki-logs relation
 
-    juju.deploy("opentelemetry-collector-k8s", "otelcol-push", channel="dev/edge", trust=True)
+    juju.deploy("opentelemetry-collector-k8s", "otelcol-push", channel="0.130/edge", trust=True)
     juju.integrate("otelcol:receive-loki-logs", "otelcol-push")
     juju.wait(
         lambda status: jubilant.all_active(status, "traefik", "otelcol-push"),
@@ -202,8 +202,8 @@ def test_remove_traefik_ingress(juju: jubilant.Juju):
 def test_integrate_istio_ingress(juju: jubilant.Juju, preset: str):
     # GIVEN otelcol is not ingressed
     # WHEN Istio applications are deployed
-    juju.deploy("istio-ingress-k8s", channel="dev/edge", trust=True)
-    juju.deploy("istio-k8s", channel="dev/edge", trust=True)
+    juju.deploy("istio-ingress-k8s", channel="1.29/edge", trust=True)
+    juju.deploy("istio-k8s", channel="1.29/edge", trust=True)
 
     if preset == "k8s":
         # https://canonical-service-mesh-documentation.readthedocs-hosted.com/latest/how-to/use-charmed-istio-with-canonical-kubernetes/

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -18,8 +18,8 @@ def test_logs_pipeline_promtail(juju: jubilant.Juju, charm: str, charm_resources
     """Scenario: log forwarding via the LogProxyConsumer."""
     # GIVEN a model with flog, otel-collector, and loki
     juju.deploy(charm, "otelcol", resources=charm_resources, trust=True)
-    juju.deploy("flog-k8s", "flog", channel="latest/stable")
-    juju.deploy("loki-k8s", "loki", channel="2/edge", trust=True)
+    juju.deploy("flog-k8s", "flog", channel="latest/edge")
+    juju.deploy("loki-k8s", "loki", channel="3.7/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface
     juju.integrate("otelcol:receive-loki-logs", "flog:log-proxy")
@@ -43,8 +43,8 @@ def test_logs_pipeline_pebble(juju: jubilant.Juju, charm: str, charm_resources: 
     """Scenario: log forwarding via Pebble log forwarding."""
     # GIVEN a model with flog, blackbox-exporter, otel-collector, and loki charms
     juju.deploy(charm, "otelcol-pebble", resources=charm_resources, trust=True)
-    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="2/edge", trust=True)
-    juju.deploy("loki-k8s", "loki-pebble", channel="2/edge", trust=True)
+    juju.deploy("blackbox-exporter-k8s", "blackbox", channel="0.28/edge", trust=True)
+    juju.deploy("loki-k8s", "loki-pebble", channel="3.7/edge", trust=True)
 
     # WHEN they are related to over the loki_push_api interface
     juju.integrate("otelcol-pebble:receive-loki-logs", "blackbox")

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -34,7 +34,7 @@ def _retry_prom_jobs_api(endpoint: str):
 
 @retry(stop=stop_after_attempt(10), wait=wait_fixed(10))
 def _retry_avalanche_metrics_arrive_prom(prom_ip: str):
-    params = {"query": 'count({__name__=~"avalanche_metric_.+"})'}
+    params = {"query": 'count({__name__=~"avalanche_.*"})'}
     data = json.loads(request("GET", f"http://{prom_ip}:9090/api/v1/query", params=params).text)[
         "data"
     ]

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -45,8 +45,8 @@ def _retry_avalanche_metrics_arrive_prom(prom_ip: str):
 def test_metrics_pipeline(juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]):
     """Scenario: scrape-to-remote-write forwarding."""
     # GIVEN a model with avalanche, otel-collector, and prometheus charms
-    juju.deploy("avalanche-k8s", app="avalanche", channel="2/edge", trust=True)
-    juju.deploy("prometheus-k8s", app="prometheus", channel="2/edge", trust=True)
+    juju.deploy("avalanche-k8s", app="avalanche", channel="0.7/edge", trust=True)
+    juju.deploy("prometheus-k8s", app="prometheus", channel="3.11/edge", trust=True)
     juju.deploy(charm, app="otelcol", resources=charm_resources, trust=True)
     # WHEN they are related via scrape and remote-write
     juju.integrate("avalanche", "otelcol:metrics-endpoint")

--- a/tests/integration/test_profiling.py
+++ b/tests/integration/test_profiling.py
@@ -23,9 +23,9 @@ async def test_smoke(juju: jubilant.Juju, charm: str, charm_resources: Dict[str,
         resources=charm_resources,
         trust=True,
     )
-    juju.deploy(charm="grafana-k8s", app="grafana", channel="2/edge", trust=True)
-    juju.deploy(charm="pyroscope-coordinator-k8s", app="pyroscope", channel="2/edge", trust=True)
-    juju.deploy(charm="pyroscope-worker-k8s", app="pyroscope-worker", channel="2/edge", trust=True)
+    juju.deploy(charm="grafana-k8s", app="grafana", channel="12.4/edge", trust=True)
+    juju.deploy(charm="pyroscope-coordinator-k8s", app="pyroscope", channel="1.18/edge", trust=True)
+    juju.deploy(charm="pyroscope-worker-k8s", app="pyroscope-worker", channel="1.18/edge", trust=True)
     # Set up minio and s3-integrator
     juju.deploy(
         charm="minio",

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -36,9 +36,9 @@ async def test_traces_pipeline(juju: jubilant.Juju, charm: str, charm_resources:
         resources=charm_resources,
         trust=True,
     )
-    juju.deploy(charm="grafana-k8s", app="grafana", channel="2/edge", trust=True)
-    juju.deploy(charm="tempo-coordinator-k8s", app="tempo", channel="2/edge", trust=True)
-    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker", channel="2/edge", trust=True)
+    juju.deploy(charm="grafana-k8s", app="grafana", channel="12.4/edge", trust=True)
+    juju.deploy(charm="tempo-coordinator-k8s", app="tempo", channel="2.10/edge", trust=True)
+    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker", channel="2.10/edge", trust=True)
     deploy_seaweedfs(juju, app="seaweedfs-tempo", s3_requirer_app="tempo")
     juju.integrate("tempo:tempo-cluster", "tempo-worker")
     # WHEN we add relations to send charm traces to tempo
@@ -70,8 +70,8 @@ async def test_traces_multiple_backends(
 ):
     """Scenario: traces are forwarded to two Tempo backends simultaneously."""
     # GIVEN a second Tempo stack is deployed
-    juju.deploy(charm="tempo-coordinator-k8s", app="tempo2", channel="2/edge", trust=True)
-    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker2", channel="2/edge", trust=True)
+    juju.deploy(charm="tempo-coordinator-k8s", app="tempo2", channel="2.10/edge", trust=True)
+    juju.deploy(charm="tempo-worker-k8s", app="tempo-worker2", channel="2.10/edge", trust=True)
     deploy_seaweedfs(juju, app="seaweedfs-tempo2", s3_requirer_app="tempo2")
     juju.integrate("tempo2:tempo-cluster", "tempo-worker2")
     juju.wait(lambda status: jubilant.all_active(status, "tempo2"), delay=10, timeout=900)
@@ -99,7 +99,7 @@ async def test_traces_multiple_backends(
 async def test_traces_with_tls(juju: jubilant.Juju):
     """Scenario: TLS is added to the tracing pipeline."""
     # WHEN TLS is added to Tempo and to otelcol
-    juju.deploy(charm="grafana-k8s", app="coconut", channel="2/edge", trust=True)
+    juju.deploy(charm="grafana-k8s", app="coconut", channel="12.4/edge", trust=True)
     juju.deploy(charm="self-signed-certificates", app="ssc", channel="edge")
     juju.integrate("tempo:certificates", "ssc")
     juju.integrate("otelcol:receive-ca-cert", "ssc")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The `track/0.130` branch should be tied to `track/WORKLOAD` for all charms and our integration tests need to reflect that.

## Solution
<!-- A summary of the solution addressing the above issue -->
Update the channels from which the apps in integration tests deploy from. Exceptions include:
- Charms not owned by the O11y team e.g., s3-integrator, Traefik, etc.

### Checklist
- [ ] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
See CI.