### PR TITLE
fix: bump otelcol to 0.152 so profiles reach Pyroscope v2

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -78,7 +78,7 @@ resources:
   opentelemetry-collector-image:
     type: oci-image
     description: OCI image for opentelemetry-collector
-    upstream-source: ubuntu/opentelemetry-collector@sha256:6df3cad7e93ef008014e85caf66765a69859f4507f1356fdb968f17e68b5766c  # renovate: oci-image tag: 0.130-26.04
+    upstream-source: ubuntu/opentelemetry-collector@sha256:bd09c2c5989edf13a95e9d56f18bd8f659b2debaa004a4fe97712a4e222bc0dc  # renovate: oci-image tag: 0.152-26.04
 
 provides:
   grafana-dashboards-provider:


### PR DESCRIPTION
Bumps the workload image from `0.130-26.04` to `0.152-26.04`.

Fixes #334. 0.130 predates the OTLP profiles layout Pyroscope v2 parses, so the `profiling` relation silently drops everything. 0.152 is the only 26.04 tag past the 0.148 threshold.

Verified against a Pyroscope v2 cluster: 0 of 5 pushes stored before, 6 of 6 after.
