### PR TITLE
feat: blocked on invalid scrape jobs

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 62
+LIBPATCH = 63
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1055,11 +1055,16 @@ class MetricsEndpointConsumer(Object):
                 try:
                     _validate_scrape_jobs(static_scrape_jobs)
                 except subprocess.CalledProcessError as e:
+                    logger.error(f"Invalid scrape job file: {e}")
                     if self._charm.unit.is_leader():
                         data = json.loads(relation.data[self._charm.app].get("event", "{}"))
                         data["scrape_job_errors"] = str(e)
                         relation.data[self._charm.app]["event"] = json.dumps(data)
                 else:
+                    if self._charm.unit.is_leader():
+                        data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+                        data.pop("scrape_job_errors", None)
+                        relation.data[self._charm.app]["event"] = json.dumps(data)
                     scrape_jobs.extend(static_scrape_jobs)
 
         scrape_jobs = _dedupe_job_names(scrape_jobs)

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 """A Juju charm for OpenTelemetry Collector on Kubernetes."""
 
+import json
 import logging
 import os
 import re
@@ -390,6 +391,10 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
                     "unit, with nothing sent to non-leader units."
                 )
 
+        # Invalid scrape jobs
+        if self._has_invalid_scrape_job():
+            self.unit.status = BlockedStatus("Invalid scrape jobs. See debug-log")
+
         # Workload version
         self.unit.set_workload_version(self._otelcol_version or "")
 
@@ -545,6 +550,29 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
     @property
     def _has_server_cert_relation(self) -> bool:
         return any(self.model.relations.get("receive-server-cert", []))
+
+    def _has_invalid_scrape_job(self) -> bool:
+        """Check if any metrics-endpoint relation reported invalid scrape jobs."""
+        for relation in self.model.relations.get("metrics-endpoint", []):
+            app_data = relation.data.get(self.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if event_data.get("scrape_job_errors"):
+                logger.error(
+                    "Scrape job validation error on relation %s: %s",
+                    relation.id,
+                    event_data["scrape_job_errors"],
+                )
+                return True
+
+        return False
 
     def _resource_reqs_from_config(self) -> ResourceRequirements:
         limits = {

--- a/tests/unit/test_scrape_job_filtering.py
+++ b/tests/unit/test_scrape_job_filtering.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Feature: block when a metrics-endpoint relation reports invalid scrape jobs.
+
+The charm consumes scrape jobs over the `metrics-endpoint` relation. The
+`prometheus_scrape` lib validates each scrape job with cos-tool and records any
+validation failures in the leader's relation app data (under `event.scrape_job_errors`).
+An invalid scrape job is excluded from the resulting jobs list, so the only way to
+detect it is to inspect that same relation data. The charm should set `blocked` when
+any such error is present, and return to `active` once the errors are cleared.
+"""
+
+import dataclasses
+import json
+
+from ops.testing import Model, Relation, State
+
+MODEL_NAME = "test"
+MODEL_UUID = "20ce8299-3634-4bef-8bd8-5ace6c8816b4"
+
+
+def _scrape_jobs(job_name: str, valid: bool) -> str:
+    job = {
+        "job_name": job_name,
+        "metrics_path": "/metrics",
+        "static_configs": [{"targets": ["192.0.2.1:9090"]}],
+    }
+    if not valid:
+        # `sample_limit` must be a number; a dict makes the scrape job invalid.
+        job["sample_limit"] = {"not_a_key": "not_a_value"}
+    return json.dumps([job])
+
+
+def _scrape_metadata(app_name: str) -> str:
+    return json.dumps(
+        {
+            "model": MODEL_NAME,
+            "model_uuid": MODEL_UUID,
+            "application": app_name,
+            "charm_name": f"{app_name}-charm",
+        }
+    )
+
+
+VALID_SCRAPE_JOB_RELATION = Relation(
+    "metrics-endpoint",
+    remote_app_name="scrape-job-valid",
+    remote_app_data={
+        "scrape_jobs": _scrape_jobs("valid-job", valid=True),
+        "scrape_metadata": _scrape_metadata("scrape-job-valid"),
+    },
+)
+
+INVALID_SCRAPE_JOB_RELATION = Relation(
+    "metrics-endpoint",
+    remote_app_name="scrape-job-invalid",
+    remote_app_data={
+        "scrape_jobs": _scrape_jobs("invalid-job", valid=False),
+        "scrape_metadata": _scrape_metadata("scrape-job-invalid"),
+    },
+)
+
+MODEL = Model(MODEL_NAME, uuid=MODEL_UUID)
+
+# `metrics-endpoint` must be paired with a metrics sink (see `_get_missing_mandatory_relations`),
+# otherwise the charm blocks on missing relations rather than on scrape job validity.
+SEND_REMOTE_WRITE = Relation(
+    "send-remote-write",
+    interface="prometheus_remote_write",
+    remote_units_data={
+        0: {"remote_write": '{"url": "http://fqdn-0:9090/api/v1/write"}'},
+    },
+)
+
+
+def test_valid_scrape_job_relation_remains_active(ctx, otelcol_container):
+    # GIVEN a scrape relation with a valid scrape job
+    state = State(
+        leader=True,
+        relations=[VALID_SCRAPE_JOB_RELATION, SEND_REMOTE_WRITE],
+        containers=otelcol_container,
+        model=MODEL,
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the charm stays active
+    assert state_out.unit_status.name == "active"
+
+
+def test_invalid_scrape_job_relation_blocks(ctx, otelcol_container):
+    # GIVEN a scrape relation with an invalid scrape job
+    state = State(
+        leader=True,
+        relations=[INVALID_SCRAPE_JOB_RELATION, SEND_REMOTE_WRITE],
+        containers=otelcol_container,
+        model=MODEL,
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the charm is blocked with a helpful message
+    assert state_out.unit_status.name == "blocked"
+    assert state_out.unit_status.message == "Invalid scrape jobs. See debug-log"
+
+
+def test_invalid_scrape_job_relation_broken_recovers_to_active(ctx, otelcol_container):
+    # GIVEN an invalid scrape relation has already blocked the charm
+    state = State(
+        leader=True,
+        relations=[INVALID_SCRAPE_JOB_RELATION, SEND_REMOTE_WRITE],
+        containers=otelcol_container,
+        model=MODEL,
+    )
+    blocked_state = ctx.run(ctx.on.update_status(), state=state)
+    assert blocked_state.unit_status.name == "blocked"
+
+    # WHEN the invalid scrape relation is removed
+    removed_relation = blocked_state.get_relation(INVALID_SCRAPE_JOB_RELATION.id)
+    state_out = ctx.run(ctx.on.relation_broken(removed_relation), blocked_state)
+
+    # THEN the charm is active again
+    assert state_out.unit_status.name == "active"
+
+
+def test_invalid_scrape_job_relation_becoming_valid_recovers_to_active(
+    ctx, otelcol_container
+):
+    # GIVEN an invalid scrape relation has already blocked the charm
+    state = State(
+        leader=True,
+        relations=[INVALID_SCRAPE_JOB_RELATION, SEND_REMOTE_WRITE],
+        containers=otelcol_container,
+        model=MODEL,
+    )
+    blocked_state = ctx.run(ctx.on.update_status(), state=state)
+    assert blocked_state.unit_status.name == "blocked"
+    relation_after_invalid = blocked_state.get_relation(INVALID_SCRAPE_JOB_RELATION.id)
+
+    # WHEN the same scrape relation updates its jobs to become valid
+    now_valid_relation = dataclasses.replace(
+        relation_after_invalid,
+        remote_app_data={
+            **relation_after_invalid.remote_app_data,
+            "scrape_jobs": VALID_SCRAPE_JOB_RELATION.remote_app_data["scrape_jobs"],
+        },
+    )
+    recovered_state = ctx.run(
+        ctx.on.relation_changed(now_valid_relation),
+        dataclasses.replace(
+            blocked_state, relations=[now_valid_relation, SEND_REMOTE_WRITE]
+        ),
+    )
+
+    # THEN the charm is active again
+    assert recovered_state.unit_status.name == "active"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #338.
Based on https://github.com/canonical/prometheus-k8s-operator/pull/849

## Solution
<!-- A summary of the solution addressing the above issue -->
Similar to https://github.com/canonical/prometheus-k8s-operator/pull/849, we:
1. Write validation errors from Cos Tool to local app data (only the leader can do that). This was already implemented.
2. If there are any scrape jobs with validation errors when reconciling, we set blocked.
3. If the relation changes and the validation errors go away, we clear local app data.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
For testing purposes, this charm has been released to `dev/edge/pr339`.
All testing can be done using this bundle:
```yaml
bundle: kubernetes
applications:
  otelcol:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 224
    resources:
      opentelemetry-collector-image: 11
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  prom:
    charm: prometheus-k8s
    channel: dev/edge
    revision: 316
    resources:
      prometheus-image: 155
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  scrape:
    charm: prometheus-scrape-target-k8s
    channel: dev/edge
    revision: 42
    scale: 1
    options:
      labels: dns_name:k8s-cluster-ai-1.maas,kubernetes_node:k8s-cluster-ai-1
      metrics_path: /metrics
      params: ""
      scheme: http
      targets: 10.0.85.90:32094
    constraints: arch=amd64
    trust: true
relations:
- - otelcol:metrics-endpoint
  - scrape:metrics-endpoint
- - otelcol:send-remote-write
  - prom:receive-remote-write

```

### Before
Observe the "before" behaviour by following the steps below.
1. Initially, since the job is valid, it should be in Otelcol's receiver config.
```
jsshc otelcol otelcol/0 cat /etc/otelcol/config.yaml | yq '.receivers.prometheus/metrics-endpoint/otelcol/0'                                                               130 ↵
config:
  scrape_configs:
    - job_name: juju_test2_8fa1ebd_scrape_external_jobs
      metrics_path: /metrics
      scheme: http
      scrape_interval: 1m
      scrape_timeout: 10s
      static_configs:
        - labels:
            dns_name: k8s-cluster-ai-1.maas
            kubernetes_node: k8s-cluster-ai-1
          targets:
            - 10.0.85.90:32094
      tls_config:
        insecure_skip_verify: false

```
2. Create an invalid scrape job by setting the `params` config option in Prometheus Scrape Target to an invalid option (this value is invalid because it's a dict of string to string, not string to [string]: `jc scrape params='{"auth": "snmp_v3", "module": "if_mib_if_name", "target": "192.168.100.200"}'`
3. Now, Otelcol should write the validation errors to relation data with Prometheus Scrape. 
```
jshu scrape/0                                                                                               
scrape/0:
  workload-version: n/a
  opened-ports: []
  charm: ch:amd64/prometheus-scrape-target-k8s-42
  leader: true
  life: alive
  relation-info:
  - relation-id: 2
    endpoint: metrics-endpoint
    related-endpoint: metrics-endpoint
    application-data:
      event: '{"scrape_job_errors": "Command ''[''/var/lib/juju/agents/unit-otelcol-0/charm/cos-tool-amd64'',
        ''validate-config'', ''/tmp/tmpxjch6wwq.yaml'']'' returned non-zero exit status
        1."}'
    related-units:
      otelcol/0:
        in-scope: true
        data:
          egress-subnets: 10.152.183.224/32
          ingress-address: 10.152.183.224
          private-address: 10.152.183.224
  provider-id: scrape-0
  address: 10.1.0.242

```
5. The scrape job should no longer be part of Otelcol's scrape config:
```
jsshc otelcol otelcol/0 cat /etc/otelcol/config.yaml | yq '.receivers.prometheus/metrics-endpoint/otelcol/0'
null

```
6. However, Otelcol remains `active/idle`.
7. Unset `params`: `jc scrape params=`
8. Now, the scrape job will be part of Otelcol's config again.
9. But, the validation errors are not cleared from relation data.

### After 
1. First refresh the charm revision to the ephemeral charm released to `dev/edge/pr339`.
2. Make the scrape job be invalid: `jc scrape params='{"auth": "snmp_v3", "module": "if_mib_if_name", "target": "192.168.100.200"}'`
3. Otelcol becomes blocked with the status message "Invalid scrape jobs. See debug-log"
5. The scrape job is not part of Otelcol's config.
6. The errors are written to rel data with Prom Scrape:
```
  - relation-id: 2
    endpoint: metrics-endpoint
    related-endpoint: metrics-endpoint
    application-data:
      event: '{"scrape_job_errors": "Command ''[''/var/lib/juju/agents/unit-otelcol-0/charm/cos-tool-amd64'',
        ''validate-config'', ''/tmp/tmp0sflrgp6.yaml'']'' returned non-zero exit status
        1."}'
    related-units:
      otelcol/0:

```
7. Now, unset the invalid config option: `jc scrape params=`.
8. Otelcol becomes `active` again.
9. The validation errors are cleared from rel data with Prom Scrape:
```
  - relation-id: 2
    endpoint: metrics-endpoint
    related-endpoint: metrics-endpoint
    application-data:
      event: '{}'
    related-units:
      otelcol/0:

```
10. The scrape job is re-written to the Otelcol config.
## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
