### PR TITLE
feat: blocked on invalid alert rules over `prometheus_scrape`

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 30
+LIBPATCH = 31
 
 PYDEPS = ["cosl"]
 
@@ -1209,6 +1209,42 @@ class LokiPushApiProvider(Object):
             alerts[identifier] = alert_rules
 
         return alerts
+
+    def has_invalid_alert_rules(self) -> bool:
+        """Check whether any relation reported invalid alert rules.
+
+        Validation errors, written to relation app data by the :attr:`alerts`
+        property, are read back to determine whether the relation currently
+        carries invalid alert rules. Non-leader units never write the app data
+        that holds these errors, so they always report no errors.
+
+        Returns:
+            True if any related consumer reported alert rule validation
+            errors, False otherwise.
+        """
+        if not self._charm.unit.is_leader():
+            return False
+
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            app_data = relation.data.get(self._charm.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if error_msg := event_data.get("errors"):
+                logger.error(
+                    "Alert rule validation error on relation %s: %s",
+                    relation.id,
+                    error_msg,
+                )
+                return True
+
+        return False
 
     def _get_identifier_by_alert_rules(
         self, rules: dict

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 63
+LIBPATCH = 65
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1362,6 +1362,65 @@ class MetricsEndpointConsumer(Object):
             parts = [target, "80"]
 
         return parts
+
+    def has_invalid_scrape_jobs(self) -> bool:
+        """Check whether any relation reported invalid scrape jobs.
+
+        Validation errors, written to relation app data by this consumer
+        (see :meth:`jobs`), are read back to determine whether the relationship
+        currently carries an invalid scrape job.
+
+        Returns:
+            True if any related metrics provider reported scrape job validation
+            errors, False otherwise.
+        """
+        return self._has_relation_error("scrape_job_errors", "Scrape job validation error")
+
+    def has_invalid_alert_rules(self) -> bool:
+        """Check whether any relation reported invalid alert rules.
+
+        Validation errors, written to relation app data by this consumer
+        (see :attr:`alerts`), are read back to determine whether the relationship
+        currently carries invalid alert rules.
+
+        Returns:
+            True if any related metrics provider reported alert rule validation
+            errors, False otherwise.
+        """
+        return self._has_relation_error("errors", "Alert rule validation error")
+
+    def _has_relation_error(self, error_key: str, error_label: str) -> bool:
+        """Check whether any relation reported the given validation error.
+
+        Args:
+            error_key: the relation app data key that holds the validation error,
+                i.e. "scrape_job_errors" or "errors".
+            error_label: a human readable description of the validation error
+                type, used for logging, e.g. "Scrape job validation error".
+
+        Returns:
+            True if any related metrics provider reported the validation error,
+            False otherwise.
+        """
+        if not self._charm.unit.is_leader():
+            return False
+
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            app_data = relation.data.get(self._charm.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if error_msg := event_data.get(error_key):
+                logger.error("%s on relation %s: %s", error_label, relation.id, error_msg)
+                return True
+
+        return False
 
 
 def _validate_scrape_jobs(jobs: list) -> bool:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -44,7 +44,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 18
 
 PYDEPS = ["cosl"]
 
@@ -972,4 +972,50 @@ class PrometheusRemoteWriteProvider(Object):
 
         rules["groups"] = modified_groups
         return rules
+
+    def has_invalid_alert_rules(self) -> bool:
+        """Check whether any relation reported invalid alert rules.
+
+        Validation errors, written to relation app data by the :attr:`alerts`
+        property, are read back to determine whether the relation currently
+        carries an invalid set of alert rules.
+
+        Returns:
+            True if any related consumer reported alert rule validation errors,
+            False otherwise.
+        """
+        return self._has_relation_error("errors", "Alert rule validation error")
+
+    def _has_relation_error(self, error_key: str, error_label: str) -> bool:
+        """Check whether any relation reported the given validation error.
+
+        Args:
+            error_key: the relation app data key that holds the validation error,
+                i.e. "errors".
+            error_label: a human readable description of the validation error
+                type, used for logging, e.g. "Alert rule validation error".
+
+        Returns:
+            True if any related consumer reported the validation error,
+            False otherwise.
+        """
+        if not self._charm.unit.is_leader():
+            return False
+
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            app_data = relation.data.get(self._charm.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if error_msg := event_data.get(error_key):
+                logger.error("%s on relation %s: %s", error_label, relation.id, error_msg)
+                return True
+
+        return False
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 """A Juju charm for OpenTelemetry Collector on Kubernetes."""
 
-import json
 import logging
 import os
 import re
@@ -15,6 +14,7 @@ from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     KubernetesComputeResourcesPatch,
     adjust_resource_requirements,
 )
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from cosl import JujuTopology, MandatoryRelationPairs
 from lightkube.models.core_v1 import ResourceRequirements
 from ops import BlockedStatus, CharmBase, Container, StatusBase, main
@@ -137,6 +137,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
     """Charm to run OpenTelemetry Collector on Kubernetes."""
 
     _container_name = "otelcol"
+    metrics_consumer: MetricsEndpointConsumer
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -557,49 +558,11 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
 
     def _has_invalid_prometheus_alerts(self) -> bool:
         """Check if any metrics-endpoint relation reported invalid alert rules."""
-        for relation in self.model.relations.get("metrics-endpoint", []):
-            app_data = relation.data.get(self.app)
-            if not app_data:
-                continue
-
-            event_raw = app_data.get("event", "{}")
-            try:
-                event_data = json.loads(event_raw)
-            except (json.JSONDecodeError, TypeError):
-                continue
-
-            if event_data.get("errors"):
-                logger.error(
-                    "Alert rule validation error on relation %s: %s",
-                    relation.id,
-                    event_data["errors"],
-                )
-                return True
-
-        return False
+        return self.metrics_consumer.has_invalid_alert_rules()
 
     def _has_invalid_scrape_job(self) -> bool:
         """Check if any metrics-endpoint relation reported invalid scrape jobs."""
-        for relation in self.model.relations.get("metrics-endpoint", []):
-            app_data = relation.data.get(self.app)
-            if not app_data:
-                continue
-
-            event_raw = app_data.get("event", "{}")
-            try:
-                event_data = json.loads(event_raw)
-            except (json.JSONDecodeError, TypeError):
-                continue
-
-            if event_data.get("scrape_job_errors"):
-                logger.error(
-                    "Scrape job validation error on relation %s: %s",
-                    relation.id,
-                    event_data["scrape_job_errors"],
-                )
-                return True
-
-        return False
+        return self.metrics_consumer.has_invalid_scrape_jobs()
 
     def _resource_reqs_from_config(self) -> ResourceRequirements:
         limits = {

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 """A Juju charm for OpenTelemetry Collector on Kubernetes."""
 
+import json
 import logging
 import os
 import re
@@ -390,6 +391,10 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
                     "unit, with nothing sent to non-leader units."
                 )
 
+        # Invalid alert rules
+        if self._has_invalid_alert_rules():
+            self.unit.status = BlockedStatus("Invalid alert rules. See debug-log")
+
         # Workload version
         self.unit.set_workload_version(self._otelcol_version or "")
 
@@ -545,6 +550,29 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
     @property
     def _has_server_cert_relation(self) -> bool:
         return any(self.model.relations.get("receive-server-cert", []))
+
+    def _has_invalid_alert_rules(self) -> bool:
+        """Check if any metrics-endpoint relation reported invalid alert rules."""
+        for relation in self.model.relations.get("metrics-endpoint", []):
+            app_data = relation.data.get(self.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if event_data.get("errors"):
+                logger.error(
+                    "Alert rule validation error on relation %s: %s",
+                    relation.id,
+                    event_data["errors"],
+                )
+                return True
+
+        return False
 
     def _resource_reqs_from_config(self) -> ResourceRequirements:
         limits = {

--- a/src/charm.py
+++ b/src/charm.py
@@ -555,7 +555,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
     def _has_server_cert_relation(self) -> bool:
         return any(self.model.relations.get("receive-server-cert", []))
 
-def _has_invalid_prometheus_alerts(self) -> bool:
+    def _has_invalid_prometheus_alerts(self) -> bool:
         """Check if any metrics-endpoint relation reported invalid alert rules."""
         for relation in self.model.relations.get("metrics-endpoint", []):
             app_data = relation.data.get(self.app)

--- a/src/charm.py
+++ b/src/charm.py
@@ -392,8 +392,8 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
                 )
 
         # Invalid alert rules
-        if self._has_invalid_alert_rules():
-            self.unit.status = BlockedStatus("Invalid alert rules. See debug-log")
+        if self._has_invalid_prometheus_alerts():
+            self.unit.status = BlockedStatus("Invalid Prometheus alerts. See debug-log")
 
         # Workload version
         self.unit.set_workload_version(self._otelcol_version or "")
@@ -551,7 +551,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
     def _has_server_cert_relation(self) -> bool:
         return any(self.model.relations.get("receive-server-cert", []))
 
-    def _has_invalid_alert_rules(self) -> bool:
+    def _has_invalid_prometheus_alerts(self) -> bool:
         """Check if any metrics-endpoint relation reported invalid alert rules."""
         for relation in self.model.relations.get("metrics-endpoint", []):
             app_data = relation.data.get(self.app)

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Feature: block when a metrics-endpoint relation reports invalid alert rules.
+
+The charm consumes alert rules over the `metrics-endpoint` relation. The
+`prometheus_scrape` lib validates each rule set with cos-tool and records any
+validation failures in the leader's relation app data (under `event.errors`).
+An invalid rule set is excluded from the resulting alerts, so the only way to
+detect it is to inspect that same relation data. The charm should set `blocked`
+when any such error is present, and return to `active` once the errors are cleared.
+"""
+
+import dataclasses
+import json
+
+from ops.testing import Model, Relation, State
+
+MODEL_NAME = "test"
+MODEL_UUID = "20ce8299-3634-4bef-8bd8-5ace6c8816b4"
+
+
+def _alert_rules(group_name: str, valid: bool) -> str:
+    # This expr is invalid intentionally. It is missing a value after the
+    # '>' operator, which should cause validation to fail.
+    invalid_expr = 'sum(rate({job="invalid"}[5m])) >'
+    return json.dumps(
+        {
+            "groups": [
+                {
+                    "name": group_name,
+                    "rules": [
+                        {
+                            "alert": f"{group_name}Valid",
+                            "expr": 'sum(rate({job="valid"}[5m])) > 0',
+                            "for": "1m",
+                            "labels": {"severity": "warning"},
+                            "annotations": {"summary": "valid-a"},
+                        },
+                        {
+                            "alert": f"{group_name}Rule",
+                            "expr": 'sum(rate({job="valid"}[5m])) > 0'
+                            if valid
+                            else invalid_expr,
+                            "for": "1m",
+                            "labels": {"severity": "warning"},
+                            "annotations": {"summary": "b"},
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+
+def _scrape_metadata(app_name: str) -> str:
+    return json.dumps(
+        {
+            "model": MODEL_NAME,
+            "model_uuid": MODEL_UUID,
+            "application": app_name,
+            "charm_name": f"{app_name}-charm",
+        }
+    )
+
+
+VALID_ALERT_RULE_RELATION = Relation(
+    "metrics-endpoint",
+    remote_app_name="alert-rule-valid",
+    remote_app_data={
+        "alert_rules": _alert_rules("valid-group", valid=True),
+        "scrape_metadata": _scrape_metadata("alert-rule-valid"),
+    },
+)
+
+INVALID_ALERT_RULE_RELATION = Relation(
+    "metrics-endpoint",
+    remote_app_name="alert-rule-invalid",
+    remote_app_data={
+        "alert_rules": _alert_rules("invalid-group", valid=False),
+        "scrape_metadata": _scrape_metadata("alert-rule-invalid"),
+    },
+)
+
+MODEL = Model(MODEL_NAME, uuid=MODEL_UUID)
+
+# `metrics-endpoint` must be paired with a metrics sink (see `_get_missing_mandatory_relations`),
+# otherwise the charm blocks on missing relations rather than on alert rule validity.
+SEND_REMOTE_WRITE = Relation(
+    "send-remote-write",
+    interface="prometheus_remote_write",
+    remote_units_data={
+        0: {"remote_write": '{"url": "http://fqdn-0:9090/api/v1/write"}'},
+    },
+)
+
+# Alert rules are validated only when alert rule forwarding is enabled
+# (see `integrations.metrics_rules`).
+FORWARD_ALERT_RULES: dict[str, str | int | float | bool] = {"forward_alert_rules": True}
+
+
+def test_valid_alert_rule_relation_remains_active(ctx, otelcol_container):
+    # GIVEN a relation with valid alert rules
+    state = State(
+        leader=True,
+        relations=[VALID_ALERT_RULE_RELATION, SEND_REMOTE_WRITE],
+        containers=otelcol_container,
+        model=MODEL,
+        config=FORWARD_ALERT_RULES,
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the charm stays active
+    assert state_out.unit_status.name == "active"
+
+
+def test_invalid_alert_rule_relation_blocks(ctx, otelcol_container):
+    # GIVEN a relation with invalid alert rules
+    state = State(
+        leader=True,
+        relations=[INVALID_ALERT_RULE_RELATION, SEND_REMOTE_WRITE],
+        containers=otelcol_container,
+        model=MODEL,
+        config=FORWARD_ALERT_RULES,
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the charm is blocked with a helpful message
+    assert state_out.unit_status.name == "blocked"
+    assert state_out.unit_status.message == "Invalid alert rules. See debug-log"
+
+
+def test_invalid_alert_rule_relation_broken_recovers_to_active(ctx, otelcol_container):
+    # GIVEN an alert rule relation with invalid rules has already blocked the charm
+    state = State(
+        leader=True,
+        relations=[INVALID_ALERT_RULE_RELATION, SEND_REMOTE_WRITE],
+        containers=otelcol_container,
+        model=MODEL,
+        config=FORWARD_ALERT_RULES,
+    )
+    blocked_state = ctx.run(ctx.on.update_status(), state=state)
+    assert blocked_state.unit_status.name == "blocked"
+
+    # WHEN the invalid relation is removed
+    removed_relation = blocked_state.get_relation(INVALID_ALERT_RULE_RELATION.id)
+    state_out = ctx.run(ctx.on.relation_broken(removed_relation), blocked_state)
+
+    # THEN the charm is active again
+    assert state_out.unit_status.name == "active"
+
+
+def test_invalid_alert_rule_relation_becoming_valid_recovers_to_active(
+    ctx, otelcol_container
+):
+    # GIVEN an alert rule relation with invalid rules has already blocked the charm
+    state = State(
+        leader=True,
+        relations=[INVALID_ALERT_RULE_RELATION, SEND_REMOTE_WRITE],
+        containers=otelcol_container,
+        model=MODEL,
+        config=FORWARD_ALERT_RULES,
+    )
+    blocked_state = ctx.run(ctx.on.update_status(), state=state)
+    assert blocked_state.unit_status.name == "blocked"
+    relation_after_invalid = blocked_state.get_relation(INVALID_ALERT_RULE_RELATION.id)
+
+    # WHEN the same relation updates its rules to become valid
+    now_valid_relation = dataclasses.replace(
+        relation_after_invalid,
+        remote_app_data={
+            **relation_after_invalid.remote_app_data,
+            "alert_rules": VALID_ALERT_RULE_RELATION.remote_app_data["alert_rules"],
+        },
+    )
+    recovered_state = ctx.run(
+        ctx.on.relation_changed(now_valid_relation),
+        dataclasses.replace(
+            blocked_state, relations=[now_valid_relation, SEND_REMOTE_WRITE]
+        ),
+    )
+
+    # THEN the charm is active again
+    assert recovered_state.unit_status.name == "active"

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -130,7 +130,7 @@ def test_invalid_alert_rule_relation_blocks(ctx, otelcol_container):
 
     # THEN the charm is blocked with a helpful message
     assert state_out.unit_status.name == "blocked"
-    assert state_out.unit_status.message == "Invalid alert rules. See debug-log"
+    assert state_out.unit_status.message == "Invalid Prometheus alerts. See debug-log"
 
 
 def test_invalid_alert_rule_relation_broken_recovers_to_active(ctx, otelcol_container):

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -152,7 +152,6 @@ def test_invalid_alert_rule_relation_broken_recovers_to_active(ctx, otelcol_cont
     # THEN the charm is active again
     assert state_out.unit_status.name == "active"
 
-
 def test_invalid_alert_rule_relation_becoming_valid_recovers_to_active(
     ctx, otelcol_container
 ):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #340.
Similar to #339.

## Solution
<!-- A summary of the solution addressing the above issue -->
When reconciling, check if there are any validation errors written to relation data. If there are, block this charm.
### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
For testing purposes, the charm with these changes is released to `dev/edge/pr341`.
Use this bundle for testing:
```yaml
bundle: kubernetes
applications:
  aval:
    charm: avalanche-k8s
    channel: 2/edge
    revision: 59
    resources:
      avalanche-image: 20
    scale: 1
    constraints: arch=amd64
    trust: true
  cos-config:
    charm: cos-configuration-k8s
    channel: dev/edge
    revision: 120
    base: ubuntu@26.04/stable
    resources:
      git-sync-image: 38
    scale: 1
    options:
      git_branch: main
      git_repo: https://github.com/sinapah/cos-config
      prometheus_alert_rules_path: prometheus_alert_rules
    constraints: arch=amd64
    storage:
      content-from-git: kubernetes,1,1024M
    trust: true
  otelcol:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 224
    base: ubuntu@26.04/stable
    resources:
      opentelemetry-collector-image: 11
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  prom:
    charm: prometheus-k8s
    channel: dev/edge
    revision: 316
    base: ubuntu@26.04/stable
    resources:
      prometheus-image: 155
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
relations:
- - otelcol:metrics-endpoint
  - cos-config:prometheus-config
- - prom:receive-remote-write
  - otelcol:send-remote-write
- - aval:metrics-endpoint
  - otelcol:metrics-endpoint

```
### After
1. Initially, all alert rules are valid. You can check that the alert rules from COS Config and Avalanche are correctly making it to Prometheus by running: `jsshc prometheus prom/0 ls /etc/prometheus/rules`. The result should be a file containing the alert rules from Avalanache, Otelcol, and COS Config in a file named according to Otelcol's topo. If you inspect that file, you should see the following alerts rules (among others for Otelcol itself):
- `PrometheusTargetDown`, provided by COS Config. The source of that rule is [here](https://github.com/sinapah/cos-config/blob/main/prometheus_alert_rules/valid-rule.yaml).
- test2_7401eb56_otelcol_test2_7401eb56_aval_AlwaysFiringDueToAbsentMetric_alerts_rules (from Avalanache)
- test2_7401eb56_otelcol_test2_7401eb56_aval_AlwaysFiringDueToNumericValue_alerts_rules (from Avalanche)
- test2_7401eb56_otelcol_test2_7401eb56_aval_HostHealth_alerts_rules (from Avalanche).
2. Now, configure COS Config to forward an invalid rule to Otelcol: `jc cos-config prometheus_alert_rules_path=staging/prometheus`
3. Notice that Otelcol's `prometheus_scrape` lib has written validation errors to app data with COS Config:
```
- relation-id: 6
    endpoint: prometheus-config
    related-endpoint: metrics-endpoint
    application-data:
      event: '{"errors": "error validating /tmp/tmpmjxkp0z_/validate_rule.yaml: [8:11:
        group \"invalid_promql_rule_2_rules\", rule 1, \"InvalidPromQLRule\": could
        not parse expression: 2:52: parse error: unterminated quoted string]"}'
    related-units:
      otelcol/0:

```
4. The invalid alert rule is named `InvalidPromQLRule` from [here](https://github.com/sinapah/cos-config/blob/main/staging/prometheus/invalid-rule.yaml).
5. Since this alert is valid and Otelcol drops it, it shouldn't be on Prom's FS either.
```
jsshc prometheus prom/0 cat /etc/prometheus/rules/juju_test2_7401eb56_otelcol.rules | grep invalid
<returns nothing>
```
6. Neither Prom, nor Otelcol becomes blocked.

### After
Let's refresh Otelcol to include the changes.
1. `juju refresh otelcol --channel dev/edge/pr341`.
2. Since there is an invalid rule coming over rel data from COS Config, Otelcol should become blocked with a message "Invalid alert rules. See debug-log"'
3. If you switch COS Config back to the valid rule.
4. Otelcol should become active.
5. The validation errors should be cleared from relation data with COS Config:
```
- relation-id: 6
    endpoint: prometheus-config
    related-endpoint: metrics-endpoint
    application-data:
      event: '{}'
    related-units:
      otelcol/0:
        in-scope: true

```
## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
