### PR TITLE
feat: blocked on invalid alert rules over `loki_push_api`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -10,6 +10,7 @@ import socket
 from typing import Any, Dict, List, Optional, cast
 
 from charmlibs.pathops import ContainerPath
+from charms.loki_k8s.v1.loki_push_api import LokiPushApiProvider
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     KubernetesComputeResourcesPatch,
     adjust_resource_requirements,
@@ -138,6 +139,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
 
     _container_name = "otelcol"
     metrics_consumer: MetricsEndpointConsumer
+    loki_provider: LokiPushApiProvider
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -396,6 +398,10 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         if self._has_invalid_prometheus_alerts():
             self.unit.status = BlockedStatus("Invalid Prometheus alerts. See debug-log")
 
+        # Invalid loki alert rules
+        if self._has_invalid_loki_alerts():
+            self.unit.status = BlockedStatus("Invalid Loki alerts. See debug-log")
+
         # Invalid scrape jobs
         if self._has_invalid_scrape_job():
             self.unit.status = BlockedStatus("Invalid scrape jobs. See debug-log")
@@ -559,6 +565,10 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
     def _has_invalid_prometheus_alerts(self) -> bool:
         """Check if any metrics-endpoint relation reported invalid alert rules."""
         return self.metrics_consumer.has_invalid_alert_rules()
+
+    def _has_invalid_loki_alerts(self) -> bool:
+        """Check if any receive-loki-logs relation reported invalid alert rules."""
+        return self.loki_provider.has_invalid_alert_rules()
 
     def _has_invalid_scrape_job(self) -> bool:
         """Check if any metrics-endpoint relation reported invalid scrape jobs."""

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -1,13 +1,14 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
-"""Feature: block when a metrics-endpoint relation reports invalid alert rules.
+"""Feature: block when a relation reports invalid alert rules.
 
-The charm consumes alert rules over the `metrics-endpoint` relation. The
-`prometheus_scrape` lib validates each rule set with cos-tool and records any
-validation failures in the leader's relation app data (under `event.errors`).
-An invalid rule set is excluded from the resulting alerts, so the only way to
-detect it is to inspect that same relation data. The charm should set `blocked`
-when any such error is present, and return to `active` once the errors are cleared.
+The charm consumes alert rules over the `metrics-endpoint` and `receive-loki-logs`
+relations. The `prometheus_scrape`/`loki_push_api` libs validate each rule set with
+cos-tool and record any validation failures in the leader's relation app data (under
+`event.errors`). An invalid rule set is excluded from the resulting alerts, so the
+only way to detect it is to inspect that same relation data. The charm should set
+`blocked` when any such error is present, and return to `active` once the errors are
+cleared.
 """
 
 import dataclasses
@@ -98,6 +99,58 @@ SEND_REMOTE_WRITE = Relation(
 FORWARD_ALERT_RULES: dict[str, str | int | float | bool] = {"forward_alert_rules": True}
 
 
+def _loki_alert_rules(group_name: str, valid: bool) -> str:
+    invalid_expr = 'sum(rate({job="invalid"}[5m])) > INVALID'
+    return json.dumps(
+        {
+            "groups": [
+                {
+                    "name": group_name,
+                    "rules": [
+                        {
+                            "alert": f"{group_name}Valid",
+                            "expr": 'sum(rate({job="valid"}[5m])) > 0',
+                            "for": "1m",
+                            "labels": {"severity": "warning"},
+                            "annotations": {"summary": "valid-a"},
+                        },
+                        {
+                            "alert": f"{group_name}Rule",
+                            "expr": 'sum(rate({job="valid"}[5m])) > 0'
+                            if valid
+                            else invalid_expr,
+                            "for": "1m",
+                            "labels": {"severity": "warning"},
+                            "annotations": {"summary": "b"},
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+
+VALID_LOKI_ALERT_RULE_RELATION = Relation(
+    "receive-loki-logs",
+    remote_app_name="loki-alert-rule-valid",
+    remote_app_data={"alert_rules": _loki_alert_rules("valid-group", valid=True)},
+)
+
+INVALID_LOKI_ALERT_RULE_RELATION = Relation(
+    "receive-loki-logs",
+    remote_app_name="loki-alert-rule-invalid",
+    remote_app_data={"alert_rules": _loki_alert_rules("invalid-group", valid=False)},
+)
+
+# `receive-loki-logs` must be paired with a logs sink (see `_get_missing_mandatory_relations`),
+# otherwise the charm blocks on missing relations rather than on alert rule validity.
+SEND_LOKI_LOGS = Relation(
+    "send-loki-logs",
+    interface="loki_push_api",
+    remote_app_name="loki",
+)
+
+
 def test_valid_alert_rule_relation_remains_active(ctx, otelcol_container):
     # GIVEN a relation with valid alert rules
     state = State(
@@ -179,6 +232,97 @@ def test_invalid_alert_rule_relation_becoming_valid_recovers_to_active(
         ctx.on.relation_changed(now_valid_relation),
         dataclasses.replace(
             blocked_state, relations=[now_valid_relation, SEND_REMOTE_WRITE]
+        ),
+    )
+
+    # THEN the charm is active again
+    assert recovered_state.unit_status.name == "active"
+
+
+def test_valid_loki_alert_rule_relation_remains_active(ctx, otelcol_container):
+    # GIVEN a relation with valid loki alert rules
+    state = State(
+        leader=True,
+        relations=[VALID_LOKI_ALERT_RULE_RELATION, SEND_LOKI_LOGS],
+        containers=otelcol_container,
+        model=MODEL,
+        config=FORWARD_ALERT_RULES,
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the charm stays active
+    assert state_out.unit_status.name == "active"
+
+
+def test_invalid_loki_alert_rule_relation_blocks(ctx, otelcol_container):
+    # GIVEN a relation with invalid loki alert rules
+    state = State(
+        leader=True,
+        relations=[INVALID_LOKI_ALERT_RULE_RELATION, SEND_LOKI_LOGS],
+        containers=otelcol_container,
+        model=MODEL,
+        config=FORWARD_ALERT_RULES,
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the charm is blocked with a helpful message
+    assert state_out.unit_status.name == "blocked"
+    assert state_out.unit_status.message == "Invalid Loki alerts. See debug-log"
+
+
+def test_invalid_loki_alert_rule_relation_broken_recovers_to_active(
+    ctx, otelcol_container
+):
+    # GIVEN a loki alert rule relation with invalid rules has already blocked the charm
+    state = State(
+        leader=True,
+        relations=[INVALID_LOKI_ALERT_RULE_RELATION, SEND_LOKI_LOGS],
+        containers=otelcol_container,
+        model=MODEL,
+        config=FORWARD_ALERT_RULES,
+    )
+    blocked_state = ctx.run(ctx.on.update_status(), state=state)
+    assert blocked_state.unit_status.name == "blocked"
+
+    # WHEN the invalid relation is removed
+    removed_relation = blocked_state.get_relation(INVALID_LOKI_ALERT_RULE_RELATION.id)
+    state_out = ctx.run(ctx.on.relation_broken(removed_relation), blocked_state)
+
+    # THEN the charm is active again
+    assert state_out.unit_status.name == "active"
+
+
+def test_invalid_loki_alert_rule_relation_becoming_valid_recovers_to_active(
+    ctx, otelcol_container
+):
+    # GIVEN a loki alert rule relation with invalid rules has already blocked the charm
+    state = State(
+        leader=True,
+        relations=[INVALID_LOKI_ALERT_RULE_RELATION, SEND_LOKI_LOGS],
+        containers=otelcol_container,
+        model=MODEL,
+        config=FORWARD_ALERT_RULES,
+    )
+    blocked_state = ctx.run(ctx.on.update_status(), state=state)
+    assert blocked_state.unit_status.name == "blocked"
+    relation_after_invalid = blocked_state.get_relation(INVALID_LOKI_ALERT_RULE_RELATION.id)
+
+    # WHEN the same relation updates its rules to become valid
+    now_valid_relation = dataclasses.replace(
+        relation_after_invalid,
+        remote_app_data={
+            **relation_after_invalid.remote_app_data,
+            "alert_rules": VALID_LOKI_ALERT_RULE_RELATION.remote_app_data["alert_rules"],
+        },
+    )
+    recovered_state = ctx.run(
+        ctx.on.relation_changed(now_valid_relation),
+        dataclasses.replace(
+            blocked_state, relations=[now_valid_relation, SEND_LOKI_LOGS]
         ),
     )
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Similar to https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/341 but for Loki alerts.
Fixes #345.
Based on the original impl in Loki K8s: https://github.com/canonical/loki-k8s-operator/pull/622

## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
For testing purposes, the charm with these changes is released to `dev/edge/pr346`.
Use this bundle for testing:
```yaml
bundle: kubernetes
applications:
  cos-config:
    charm: cos-configuration-k8s
    channel: dev/edge
    revision: 120
    resources:
      git-sync-image: 38
    scale: 1
    options:
      git_branch: main
      git_repo: https://github.com/sinapah/cos-config
      loki_alert_rules_path: loki_alert_rules
      prometheus_alert_rules_path: prometheus_alert_rules
    constraints: arch=amd64
    storage:
      content-from-git: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: dev/edge
    revision: 249
    resources:
      loki-image: 105
      node-exporter-image: 4
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  otelcol:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 229
    resources:
      opentelemetry-collector-image: 11
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
relations:
- - otelcol:metrics-endpoint
  - cos-config:prometheus-config
- - otelcol:send-loki-logs
  - loki:logging
- - otelcol:receive-loki-logs
  - cos-config:loki-config

```

### Before
1. Initially, all alert rules are valid. You can check that the alert rules from COS Config (and any other related logging charm) are correctly making it to Loki by running: `jsshc loki loki/0 <ls path to Loki rules>`. The result should be a file containing the alert rules from COS Config. If you inspect that file, you should see the following alert rules:
```
jsshc loki loki/0 cat /loki/rules/fake/observability_e9f39fb5_prometheus-k8s_alert.rules                                                                                     1 ↵
groups:
- name: test2_d25da20e_otelcol_loki_alerts_rules
  rules:
  - alert: PrometheusErrorLogs
    annotations:
      description: Error logs detected for application {{ $labels.juju_application
        }}
      summary: Prometheus error logs detected
    expr: (sum by(juju_application)(rate({juju_application="prometheus-k8s", juju_model="observability",
      juju_model_uuid="e9f39fb5-e6ff-4e0c-82a5-712bdd7e1912"} | json | level="ERROR"[15m]))
      > 0)
    for: 15m
    labels:
      juju_application: prometheus-k8s
      juju_charm: opentelemetry-collector-k8s
      juju_model: observability
      juju_model_uuid: e9f39fb5-e6ff-4e0c-82a5-712bdd7e1912
      severity: critical
      team: observability

```
2. Now, configure COS Config to forward an invalid rule to Otelcol: `jc cos-config loki_alert_rules_path=staging/loki`
3. Notice that Otelcol's `loki_push_api` lib has written validation errors to app data with COS Config:
```
- relation-id: 10
    endpoint: loki-config
    related-endpoint: receive-loki-logs
    application-data:
      event: '{"errors": "error validating /tmp/tmpvnyx9yql/validate_rule.yaml: [parse
        error at line 6, col 15: literal not terminated"}'

```
4. The invalid alert rule is named `InvalidRule` from [here](https://github.com/sinapah/cos-config/blob/main/staging/loki/invalid-rule.yaml).
5. Since this alert is invalid and Otelcol drops it, it shouldn't be on Loki's FS either.
```
jsshc loki loki/0 cat /loki/rules/fake/observability_e9f39fb5_prometheus-k8s_alert.rules
cat: /loki/rules/fake/observability_e9f39fb5_prometheus-k8s_alert.rules: No such file or directory
ERROR command terminated with exit code 1

```
6. Neither Loki, nor Otelcol becomes blocked.

### After
Let's refresh Otelcol to include the changes.
1. `juju refresh otelcol --channel dev/edge/pr346`.
2. Since there is an invalid rule coming over relation data from COS Config, Otelcol should become blocked with the message "Invalid Loki alerts. See debug-log".
3. If you switch COS Config back to the valid rule.
4. Otelcol should become active.
5. The validation errors should be cleared from relation data with COS Config:

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->

