### PR TITLE
DO NOT MERGE: Performance analysis: instrumentation + script to run a stress test

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -23,6 +23,7 @@ from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import APIError, CheckDict, ExecDict, HttpDict, Layer
 
 import integrations
+import perf  # TEMPORARY: diagnostic instrumentation, do not merge
 from config_builder import Port
 from config_manager import ConfigManager
 from constants import (
@@ -142,6 +143,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
     loki_provider: LokiPushApiProvider
 
     def __init__(self, *args):
+        perf.install()  # TEMPORARY: diagnostic instrumentation, do not merge
         super().__init__(*args)
         if not self.unit.get_container(self._container_name).can_connect():
             self.unit.status = MaintenanceStatus("Waiting for otelcol to start")
@@ -149,7 +151,10 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
 
         self.external_configs: List[Dict[str, Any]] = []
         self.external_secret_files: Dict[str, str] = {}
-        self._reconcile()
+
+        # TEMPORARY: diagnostic instrumentation, do not merge
+        with perf.profiled(self, event=os.environ.get("JUJU_HOOK_NAME", "?")):
+            self._reconcile()
 
     def _reconcile(self):
         """Recreate the world state for the charm.
@@ -165,46 +170,56 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             initialization and the event emission.
         """
         container = self.unit.get_container(self._container_name)
-        self.resources_patch = KubernetesComputeResourcesPatch(
-            self,
-            container_name=self._container_name,
-            resource_reqs_func=self._resource_reqs_from_config,
-        )
-        resources_patch_status: StatusBase = self.resources_patch.get_status()
-        if not isinstance(resources_patch_status, ActiveStatus):
-            self.unit.status = resources_patch_status
-            return
+        with perf.phase("resources_patch"):
+            self.resources_patch = KubernetesComputeResourcesPatch(
+                self,
+                container_name=self._container_name,
+                resource_reqs_func=self._resource_reqs_from_config,
+            )
+            resources_patch_status: StatusBase = self.resources_patch.get_status()
+            if not isinstance(resources_patch_status, ActiveStatus):
+                self.unit.status = resources_patch_status
+                return
 
         insecure_skip_verify = cast(bool, self.config.get("tls_insecure_skip_verify"))
-        integrations.cleanup(self.charm_dir.absolute())
+        with perf.phase("cleanup_rule_dirs"):
+            integrations.cleanup(self.charm_dir.absolute())
 
         # Service mesh integration
-        integrations.setup_service_mesh(self)
+        with perf.phase("service_mesh"):
+            integrations.setup_service_mesh(self)
 
         # Ingress integration
-        traefik_tls = integrations.is_tls_ready(container)
-        traefik_ingress = integrations.setup_traefik_ingress(self, traefik_tls)
-        istio_ingress = integrations.setup_istio_ingress(self)
+        with perf.phase("ingress"):
+            traefik_tls = integrations.is_tls_ready(container)
+            traefik_ingress = integrations.setup_traefik_ingress(self, traefik_tls)
+            istio_ingress = integrations.setup_istio_ingress(self)
 
         # Integrate with TLS relations
-        receive_ca_certs_hash = integrations.receive_ca_cert(
-            self,
-            recv_ca_cert_folder_path=ContainerPath(RECV_CA_CERT_FOLDER_PATH, container=container),
-        )
-        server_cert_hash = integrations.receive_server_cert(
-            self,
-            server_cert_path=ContainerPath(SERVER_CERT_PATH, container=container),
-            private_key_path=ContainerPath(SERVER_CERT_PRIVATE_KEY_PATH, container=container),
-            root_ca_cert_path=ContainerPath(SERVER_CA_CERT_PATH, container=container),
-        )
+        with perf.phase("receive_ca_cert"):
+            receive_ca_certs_hash = integrations.receive_ca_cert(
+                self,
+                recv_ca_cert_folder_path=ContainerPath(
+                    RECV_CA_CERT_FOLDER_PATH, container=container
+                ),
+            )
+        with perf.phase("receive_server_cert"):
+            server_cert_hash = integrations.receive_server_cert(
+                self,
+                server_cert_path=ContainerPath(SERVER_CERT_PATH, container=container),
+                private_key_path=ContainerPath(SERVER_CERT_PRIVATE_KEY_PATH, container=container),
+                root_ca_cert_path=ContainerPath(SERVER_CA_CERT_PATH, container=container),
+            )
         # Refresh system certs
         # This must be run after receive_ca_cert and/or receive_server_cert because they update
         # certs in the /usr/local/share/ca-certificates directory
-        refresh_certs(container)
+        with perf.phase("refresh_certs"):
+            refresh_certs(container)
 
         # Address manager
         # NOTE: executed after ingress and TLS events
-        otelcol_address = charm_address(container, traefik_ingress, istio_ingress)
+        with perf.phase("address"):
+            otelcol_address = charm_address(container, traefik_ingress, istio_ingress)
         match otelcol_address:
             case integrations.MultipleIngressesConfigured():
                 self.unit.status = BlockedStatus(otelcol_address.message)
@@ -252,16 +267,24 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
 
         # OTLP setup
         traefik_ingress = integrations.traefik_ingress_ready(traefik_ingress)
-        otlp_provider = integrations.receive_otlp(self, otelcol_address, traefik_ingress)
+        with perf.phase("otlp_receive") as p:
+            otlp_provider = integrations.receive_otlp(self, otelcol_address, traefik_ingress)
+            p["n_relations"] = len(self.model.relations.get("receive-otlp", []))
         # See `stage_received_otlp_rules` for the ordering contract it depends on.
         # Ref: https://github.com/canonical/opentelemetry-collector-operator/issues/297
-        integrations.stage_received_otlp_rules(self, otlp_provider)
-        otlp_endpoints = integrations.send_otlp(self, otlp_provider)
+        with perf.phase("otlp_stage_rules"):
+            integrations.stage_received_otlp_rules(self, otlp_provider)
+        with perf.phase("otlp_send") as p:
+            otlp_endpoints = integrations.send_otlp(self, otlp_provider)
+            p["n_relations"] = len(self.model.relations.get("send-otlp", []))
         config_manager.add_otlp_forwarding(otlp_endpoints)
 
         # Logs setup
-        integrations.receive_loki_logs(self, otelcol_address)
-        loki_endpoints = integrations.send_loki_logs(self)
+        with perf.phase("logs_receive") as p:
+            integrations.receive_loki_logs(self, otelcol_address)
+            p["n_relations"] = len(self.model.relations.get("receive-loki-logs", []))
+        with perf.phase("logs_send"):
+            loki_endpoints = integrations.send_loki_logs(self)
         if self._incoming_logs:
             config_manager.add_log_ingestion()
         config_manager.add_log_forwarding(loki_endpoints, insecure_skip_verify)
@@ -275,63 +298,75 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             },
         )
         # For now, the only incoming and outgoing metrics relations are remote-write/scrape
-        metrics_consumer_jobs = integrations.scrape_metrics(self)
+        with perf.phase("metrics_scrape") as p:
+            metrics_consumer_jobs = integrations.scrape_metrics(self)
+            p["n_relations"] = len(self.model.relations.get("metrics-endpoint", []))
+            p["n_jobs"] = len(metrics_consumer_jobs)
         # Write CA certificates to disk and update job configurations
-        self._ensure_certs_dir(container)
-        cert_paths = self._write_ca_certificates_to_disk(metrics_consumer_jobs, container)
-        metrics_consumer_jobs = config_manager.update_jobs_with_ca_paths(
-            metrics_consumer_jobs, cert_paths
-        )
-        config_manager.add_prometheus_scrape_jobs(metrics_consumer_jobs)
-        remote_write_endpoints = integrations.send_remote_write(self)
+        with perf.phase("metrics_job_certs"):
+            self._ensure_certs_dir(container)
+            cert_paths = self._write_ca_certificates_to_disk(metrics_consumer_jobs, container)
+            metrics_consumer_jobs = config_manager.update_jobs_with_ca_paths(
+                metrics_consumer_jobs, cert_paths
+            )
+            config_manager.add_prometheus_scrape_jobs(metrics_consumer_jobs)
+        with perf.phase("remote_write_send") as p:
+            remote_write_endpoints = integrations.send_remote_write(self)
+            p["n_relations"] = len(self.model.relations.get("send-remote-write", []))
         config_manager.add_remote_write(remote_write_endpoints)
 
         # External-config setup
-        self.external_configs, self.external_secret_files = integrations.receive_external_configs(
-            self
-        )
-        self._write_secrets_to_disk(container, self.external_secret_files)
-        self._configure_external_configs(config_manager)
+        with perf.phase("external_configs"):
+            self.external_configs, self.external_secret_files = (
+                integrations.receive_external_configs(self)
+            )
+            self._write_secrets_to_disk(container, self.external_secret_files)
+            self._configure_external_configs(config_manager)
 
         # Profiling setup
-        if self._incoming_profiles:
-            config_manager.add_profile_ingestion()
-            integrations.receive_profiles(self, integrations.is_tls_ready(container))
-        if profiling_endpoints := integrations.send_profiles(self):
-            config_manager.add_profile_forwarding(profiling_endpoints)
-        if self._incoming_profiles or integrations.send_profiles(self):
-            feature_gates = "service.profilesSupport"
+        with perf.phase("profiles"):
+            if self._incoming_profiles:
+                config_manager.add_profile_ingestion()
+                integrations.receive_profiles(self, integrations.is_tls_ready(container))
+            if profiling_endpoints := integrations.send_profiles(self):
+                config_manager.add_profile_forwarding(profiling_endpoints)
+            if self._incoming_profiles or integrations.send_profiles(self):
+                feature_gates = "service.profilesSupport"
 
         # Tracing setup
-        requested_tracing_protocols = integrations.receive_traces(
-            self, integrations.is_tls_ready(container)
-        )
-        if self._incoming_traces:
-            config_manager.add_traces_ingestion(requested_tracing_protocols)
-            # Add default processors to traces
-            config_manager.add_traces_processing(
-                sampling_rate_charm=cast(bool, self.config.get("tracing_sampling_rate_charm")),
-                sampling_rate_workload=cast(
-                    bool, self.config.get("tracing_sampling_rate_workload")
-                ),
-                sampling_rate_error=cast(bool, self.config.get("tracing_sampling_rate_error")),
+        with perf.phase("traces"):
+            requested_tracing_protocols = integrations.receive_traces(
+                self, integrations.is_tls_ready(container)
             )
-        for idx, endpoint in enumerate(integrations.send_traces(self)):
-            config_manager.add_traces_forwarding(endpoint, identifier=str(idx))
-        integrations.send_charm_traces(self)
+            if self._incoming_traces:
+                config_manager.add_traces_ingestion(requested_tracing_protocols)
+                # Add default processors to traces
+                config_manager.add_traces_processing(
+                    sampling_rate_charm=cast(bool, self.config.get("tracing_sampling_rate_charm")),
+                    sampling_rate_workload=cast(
+                        bool, self.config.get("tracing_sampling_rate_workload")
+                    ),
+                    sampling_rate_error=cast(bool, self.config.get("tracing_sampling_rate_error")),
+                )
+            for idx, endpoint in enumerate(integrations.send_traces(self)):
+                config_manager.add_traces_forwarding(endpoint, identifier=str(idx))
+            integrations.send_charm_traces(self)
 
         # Dashboards setup
-        integrations.forward_dashboards(self)
+        with perf.phase("dashboards") as p:
+            integrations.forward_dashboards(self)
+            p["n_relations"] = len(self.model.relations.get("grafana-dashboards-consumer", []))
 
         # GrafanaCloudIntegrator setup
-        cloud_integrator_data = integrations.cloud_integrator(self)
-        config_manager.add_cloud_integrator(
-            username=cloud_integrator_data.username,
-            password=cloud_integrator_data.password,
-            prometheus_url=cloud_integrator_data.prometheus_url,
-            loki_url=cloud_integrator_data.loki_url,
-            tempo_url=cloud_integrator_data.tempo_url,
-        )
+        with perf.phase("cloud_integrator"):
+            cloud_integrator_data = integrations.cloud_integrator(self)
+            config_manager.add_cloud_integrator(
+                username=cloud_integrator_data.username,
+                password=cloud_integrator_data.password,
+                prometheus_url=cloud_integrator_data.prometheus_url,
+                loki_url=cloud_integrator_data.loki_url,
+                tempo_url=cloud_integrator_data.tempo_url,
+            )
 
         # Add debug exporters from Juju config
         config_manager.add_debug_exporters(
@@ -345,69 +380,81 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             config_manager.add_custom_processors(custom_processors)
 
         # Push the config and Push the config and deploy/update
-        container.push(CONFIG_PATH, config_manager.config.build(), make_dirs=True)
+        with perf.phase("config_build_and_push") as p:
+            rendered_config = config_manager.config.build()
+            p["config_bytes"] = len(rendered_config)
+            container.push(CONFIG_PATH, rendered_config, make_dirs=True)
 
-        # If the config file or any cert has changed, a change in this environment variable
-        # will trigger a restart
-        pebble_extra_env = {
-            "_reload": ",".join(
-                [
-                    config_manager.config.hash,
-                    receive_ca_certs_hash,
-                    server_cert_hash,
-                ]
+            # If the config file or any cert has changed, a change in this environment variable
+            # will trigger a restart
+            pebble_extra_env = {
+                "_reload": ",".join(
+                    [
+                        config_manager.config.hash,
+                        receive_ca_certs_hash,
+                        server_cert_hash,
+                    ]
+                )
+            }
+            container.add_layer(
+                self._container_name,
+                self._pebble_layer(environment=pebble_extra_env, feature_gates=feature_gates),
+                combine=True,
             )
-        }
-        container.add_layer(
-            self._container_name,
-            self._pebble_layer(environment=pebble_extra_env, feature_gates=feature_gates),
-            combine=True,
-        )
         # TODO: Conditionally open ports based on the otelcol config file rather than opening all ports
-        self.unit.set_ports(*[port.value for port in Port])
+        with perf.phase("set_ports"):
+            self.unit.set_ports(*[port.value for port in Port])
 
-        if self._has_server_cert_relation and not integrations.is_tls_ready(container):
-            # A tls relation to a CA was formed, but we didn't get the cert yet.
-            container.stop(SERVICE_NAME)
-            self.unit.status = WaitingStatus("CSR sent; otelcol down while waiting for a cert")
-        else:
-            container.replan()
-            self.unit.status = ActiveStatus()
-
-        # Mandatory relation pairs
-        missing_relations = _get_missing_mandatory_relations(self)
-        if missing_relations:
-            self.unit.status = BlockedStatus(missing_relations)
-
-        # Cyclic OTLP relations
-        if integrations.cyclic_otlp_relations_exist(self):
-            self.unit.status = BlockedStatus("cyclic OTLP relations exist")
-
-        # Ingress and scaling status
-        if self.model.unit.is_leader():
-            if self.app.planned_units() > 1 and not otelcol_address.ingress:
-                self.unit.status = BlockedStatus(
-                    "Ingress missing - routing only to leader; see debug-log"
+        with perf.phase("replan"):
+            if self._has_server_cert_relation and not integrations.is_tls_ready(container):
+                # A tls relation to a CA was formed, but we didn't get the cert yet.
+                container.stop(SERVICE_NAME)
+                self.unit.status = WaitingStatus(
+                    "CSR sent; otelcol down while waiting for a cert"
                 )
-                logger.warning(
-                    "without ingress and planned_units > 1, all data is forwarded to the leader "
-                    "unit, with nothing sent to non-leader units."
-                )
+            else:
+                container.replan()
+                self.unit.status = ActiveStatus()
+
+        with perf.phase("status_relation_pairs"):
+            # Mandatory relation pairs
+            missing_relations = _get_missing_mandatory_relations(self)
+            if missing_relations:
+                self.unit.status = BlockedStatus(missing_relations)
+
+            # Cyclic OTLP relations
+            if integrations.cyclic_otlp_relations_exist(self):
+                self.unit.status = BlockedStatus("cyclic OTLP relations exist")
+
+            # Ingress and scaling status
+            if self.model.unit.is_leader():
+                if self.app.planned_units() > 1 and not otelcol_address.ingress:
+                    self.unit.status = BlockedStatus(
+                        "Ingress missing - routing only to leader; see debug-log"
+                    )
+                    logger.warning(
+                        "without ingress and planned_units > 1, all data is forwarded to the "
+                        "leader unit, with nothing sent to non-leader units."
+                    )
 
         # Invalid alert rules
-        if self._has_invalid_prometheus_alerts():
-            self.unit.status = BlockedStatus("Invalid Prometheus alerts. See debug-log")
+        with perf.phase("status_invalid_prom_alerts"):
+            if self._has_invalid_prometheus_alerts():
+                self.unit.status = BlockedStatus("Invalid Prometheus alerts. See debug-log")
 
         # Invalid loki alert rules
-        if self._has_invalid_loki_alerts():
-            self.unit.status = BlockedStatus("Invalid Loki alerts. See debug-log")
+        with perf.phase("status_invalid_loki_alerts"):
+            if self._has_invalid_loki_alerts():
+                self.unit.status = BlockedStatus("Invalid Loki alerts. See debug-log")
 
         # Invalid scrape jobs
-        if self._has_invalid_scrape_job():
-            self.unit.status = BlockedStatus("Invalid scrape jobs. See debug-log")
+        with perf.phase("status_invalid_scrape_jobs"):
+            if self._has_invalid_scrape_job():
+                self.unit.status = BlockedStatus("Invalid scrape jobs. See debug-log")
 
         # Workload version
-        self.unit.set_workload_version(self._otelcol_version or "")
+        with perf.phase("workload_version"):
+            self.unit.set_workload_version(self._otelcol_version or "")
 
     def _pebble_layer(self, environment: Dict, feature_gates: Optional[str]) -> Layer:
         """Construct the Pebble layer configuration.

--- a/src/perf.py
+++ b/src/perf.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""TEMPORARY diagnostic instrumentation for the reconcile hot path. DO NOT MERGE.
+
+Answers "where does the reconcile time go?" with hard numbers, per phase of `_reconcile`:
+
+  * wall time
+  * cos-tool invocations, split into cache hits and misses (misses = real `subprocess`)
+  * every other subprocess (count + time)
+  * every Pebble HTTP request (count + time)
+  * every Juju hook command (count + time), with a per-command breakdown in the summary
+
+Three outputs per hook execution:
+
+  1. `juju-log` (INFO): one line per phase plus a summary line, greppable with `PERF`.
+  2. A JSON file per event under ``OUT_DIR`` (default ``/tmp/otelcol-perf``), consumed by
+     ``tests/stress/perf_report.py`` to build the report.
+  3. An OpenTelemetry span per phase, so with `send-charm-traces` related to Tempo the
+     phases show up nested under `ops.main`, alongside the spans that `ops` already emits
+     for every hook command (`ops/model.py:_wrap_hookcmd`) and every Pebble call.
+
+Why not only cProfile: it inflates the run ~2x (measured 4.68s -> 9.15s on a 100-relation
+reconcile) and its cumulative view is dominated by stdlib/urllib frames instead of charm
+phases. cProfile stays available (`OTELCOL_PERF_CPROFILE=1`) for ranking pure-Python hot
+spots by `tottime`, and it now dumps a full `.prof` to disk instead of a truncated dump in
+the log.
+
+Usage:
+    Enabled by default in this diagnostic branch. Toggle with env vars when running the
+    Scenario harness or unit tests:
+        OTELCOL_PERF=0              disable entirely
+        OTELCOL_PERF_CPROFILE=1     also dump a .prof per event
+        OTELCOL_PERF_DIR=/some/dir  where to write the JSON/.prof files
+
+    Collect from the unit:
+        juju ssh --container charm otelcol-agg/0 "tar cf - -C /tmp otelcol-perf" > perf.tar
+        # or: juju scp --container charm otelcol-agg/0:/tmp/otelcol-perf/'*.json' ./perf/
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import json
+import logging
+import os
+import subprocess
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _flag(name: str, default: str = "1") -> bool:
+    return os.environ.get(name, default).lower() not in ("", "0", "false", "no")
+
+
+ENABLED = _flag("OTELCOL_PERF")
+CPROFILE = _flag("OTELCOL_PERF_CPROFILE", default="0")
+OUT_DIR = Path(os.environ.get("OTELCOL_PERF_DIR", "/tmp/otelcol-perf"))  # noqa: S108
+
+# Wall clock at import time of this module, i.e. as early as possible in the hook.
+_IMPORT_TIME = time.monotonic()
+
+
+# --------------------------------------------------------------------------- counters
+@dataclass
+class _Counters:
+    """Process-wide counters, sampled at phase boundaries to compute deltas."""
+
+    subprocess_calls: int = 0
+    subprocess_seconds: float = 0.0
+    cos_tool_lookups: int = 0  # calls into cosl's memoized _exec (hit or miss)
+    cos_tool_misses: int = 0  # of those, the ones that spawned cos-tool
+    cos_tool_seconds: float = 0.0  # time spent inside cos-tool subprocesses
+    pebble_calls: int = 0
+    pebble_seconds: float = 0.0
+    hookcmd_calls: int = 0
+    hookcmd_seconds: float = 0.0
+    juju_log_calls: int = 0
+    juju_log_seconds: float = 0.0
+    subprocess_by_name: Counter = field(default_factory=Counter)
+
+    def snapshot(self) -> Dict[str, float]:
+        return {
+            "subprocess_calls": self.subprocess_calls,
+            "subprocess_ms": self.subprocess_seconds * 1000,
+            "cos_tool_lookups": self.cos_tool_lookups,
+            "cos_tool_misses": self.cos_tool_misses,
+            "cos_tool_ms": self.cos_tool_seconds * 1000,
+            "pebble_calls": self.pebble_calls,
+            "pebble_ms": self.pebble_seconds * 1000,
+            "hookcmd_calls": self.hookcmd_calls,
+            "hookcmd_ms": self.hookcmd_seconds * 1000,
+            "juju_log_calls": self.juju_log_calls,
+            "juju_log_ms": self.juju_log_seconds * 1000,
+        }
+
+
+COUNTERS = _Counters()
+
+
+@dataclass
+class PhaseRecord:
+    """Measurements for a single named phase of the reconcile."""
+
+    name: str
+    ms: float
+    counters: Dict[str, float]
+    attrs: Dict[str, Any] = field(default_factory=dict)
+
+
+PHASES: List[PhaseRecord] = []
+
+
+# --------------------------------------------------------------------------- patching
+_patched = False
+
+
+def _patch_subprocess() -> None:
+    """Count and time every subprocess, classified by argv[0].
+
+    This is the only reliable interception point: Juju hook commands are subprocesses
+    (`juju-log`, `relation-get`, ...), and `ops.hookcmds` binds its `run` helper by name
+    at import time, so patching the helper's module after import has no effect. Note that
+    every `logger.debug()` in charm or library code is one `juju-log` fork, which is
+    invisible to Scenario and is the reason this classification matters.
+    """
+    real_run = subprocess.run
+
+    @functools.wraps(real_run)
+    def run(*args: Any, **kwargs: Any):
+        cmd = args[0] if args else kwargs.get("args")
+        name = "?"
+        if isinstance(cmd, (list, tuple)) and cmd:
+            name = os.path.basename(str(cmd[0]))
+        elif isinstance(cmd, str):
+            name = os.path.basename(cmd.split()[0]) if cmd else "?"
+        t0 = time.monotonic()
+        try:
+            return real_run(*args, **kwargs)
+        finally:
+            dt = time.monotonic() - t0
+            COUNTERS.subprocess_calls += 1
+            COUNTERS.subprocess_seconds += dt
+            COUNTERS.subprocess_by_name[name] += 1
+            if "cos-tool" in name:
+                COUNTERS.cos_tool_misses += 1
+                COUNTERS.cos_tool_seconds += dt
+            elif name == "juju-log":
+                COUNTERS.juju_log_calls += 1
+                COUNTERS.juju_log_seconds += dt
+            else:
+                # Everything else a charm spawns is a Juju hook command.
+                COUNTERS.hookcmd_calls += 1
+                COUNTERS.hookcmd_seconds += dt
+
+    subprocess.run = run  # type: ignore[assignment]
+
+
+def _patch_cos_tool() -> None:
+    """Count every *lookup* into cosl's memoized cos-tool exec.
+
+    ``cos_tool_misses`` is counted by the subprocess patch, so
+    ``lookups - misses`` is the number of cache hits: exactly the metric needed to tell
+    "the cache is working" from "the cache is not the problem".
+    """
+    try:
+        from cosl import cos_tool  # type: ignore
+    except ImportError:  # pragma: no cover - only if cosl layout changes
+        logger.warning("PERF: could not patch cosl.cos_tool")
+        return
+
+    real_exec = cos_tool._exec
+
+    @functools.wraps(real_exec)
+    def counting_exec(*args: Any, **kwargs: Any):
+        COUNTERS.cos_tool_lookups += 1
+        return real_exec(*args, **kwargs)
+
+    cos_tool._exec = counting_exec
+    # `CosTool._exec` delegates to the module-level function, so instances pick this up.
+
+
+def _patch_pebble() -> None:
+    """Count and time every Pebble HTTP request."""
+    try:
+        from ops import pebble  # type: ignore
+    except ImportError:  # pragma: no cover
+        return
+
+    real_request_raw = pebble.Client._request_raw
+
+    @functools.wraps(real_request_raw)
+    def request_raw(self: Any, *args: Any, **kwargs: Any):
+        t0 = time.monotonic()
+        try:
+            return real_request_raw(self, *args, **kwargs)
+        finally:
+            COUNTERS.pebble_calls += 1
+            COUNTERS.pebble_seconds += time.monotonic() - t0
+
+    pebble.Client._request_raw = request_raw  # type: ignore[assignment]
+
+
+def install() -> None:
+    """Install all patches. Idempotent; safe to call from the charm constructor."""
+    global _patched
+    if not ENABLED or _patched:
+        return
+    _patched = True
+    _patch_subprocess()
+    _patch_cos_tool()
+    _patch_pebble()
+
+
+# ------------------------------------------------------------------------------ spans
+def _tracer():
+    try:
+        import opentelemetry.trace  # type: ignore
+
+        return opentelemetry.trace.get_tracer("otelcol.perf")
+    except ImportError:  # pragma: no cover
+        return None
+
+
+@contextlib.contextmanager
+def phase(name: str, **attrs: Any) -> Iterator[Dict[str, Any]]:
+    """Measure a named phase of the reconcile.
+
+    Yields a mutable dict; anything put in it is recorded as an attribute of the phase
+    (and of the span), which is how phases report domain facts such as the number of
+    relations or rules they processed::
+
+        with perf.phase("otlp_stage_rules") as p:
+            ...
+            p["n_rules"] = len(rules)
+    """
+    if not ENABLED:
+        yield {}
+        return
+
+    before = COUNTERS.snapshot()
+    t0 = time.monotonic()
+    tracer = _tracer()
+    span_cm = tracer.start_as_current_span(f"perf.{name}") if tracer else contextlib.nullcontext()
+    try:
+        with span_cm as span:
+            try:
+                yield attrs
+            finally:
+                ms = (time.monotonic() - t0) * 1000
+                after = COUNTERS.snapshot()
+                delta = {k: round(after[k] - before[k], 3) for k in after}
+                PHASES.append(PhaseRecord(name=name, ms=round(ms, 1), counters=delta, attrs=attrs))
+                if span is not None:
+                    with contextlib.suppress(Exception):
+                        for k, v in {**delta, **attrs}.items():
+                            span.set_attribute(f"perf.{k}", v)
+    except Exception:
+        raise
+
+
+def measure(name: str):
+    """Decorator form of `phase`, for whole functions."""
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any):
+            with phase(name):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+# ----------------------------------------------------------------------------- report
+def _process_age_ms() -> Optional[float]:
+    """Age of this process in ms, i.e. including Python/venv import time.
+
+    Import time of a large charm venv is invisible to any in-charm profiler but very
+    much visible to the operator waiting for convergence, so it is reported explicitly.
+    """
+    try:
+        with open("/proc/self/stat") as f:
+            starttime_ticks = int(f.read().split(") ", 1)[1].split()[19])
+        with open("/proc/uptime") as f:
+            uptime = float(f.read().split()[0])
+        hz = os.sysconf("SC_CLK_TCK")
+        return round((uptime - starttime_ticks / hz) * 1000, 1)
+    except Exception:  # pragma: no cover - /proc not available
+        return None
+
+
+def _loadavg() -> Optional[List[float]]:
+    """Host load average. A contaminated (CPU-starved) run must be discarded, not averaged."""
+    try:
+        return [round(x, 2) for x in os.getloadavg()]
+    except OSError:  # pragma: no cover
+        return None
+
+
+def report(charm: Any = None, event: str = "?", extra: Optional[Dict[str, Any]] = None) -> None:
+    """Emit the per-phase lines, the summary line, and the JSON artifact."""
+    if not ENABLED:
+        return
+
+    since_import_ms = round((time.monotonic() - _IMPORT_TIME) * 1000, 1)
+    totals = COUNTERS.snapshot()
+
+    relations: Dict[str, int] = {}
+    rule_files: Dict[str, int] = {}
+    if charm is not None:
+        with contextlib.suppress(Exception):
+            relations = {
+                name: len(rels) for name, rels in charm.model.relations.items() if rels
+            }
+        with contextlib.suppress(Exception):
+            root = Path(charm.charm_dir).absolute()
+            for label, rel in (
+                ("promql", "prometheus_alert_rules"),
+                ("logql", "loki_alert_rules"),
+                ("dashboards", "grafana_dashboards"),
+            ):
+                d = root / rel
+                rule_files[label] = len(list(d.rglob("*"))) if d.is_dir() else 0
+
+    payload = {
+        "event": event,
+        "timestamp": time.time(),
+        "unit": os.environ.get("JUJU_UNIT_NAME", "?"),
+        "process_age_ms": _process_age_ms(),
+        "loadavg": _loadavg(),
+        "cpu_count": os.cpu_count(),
+        "since_import_ms": since_import_ms,
+        "totals": totals,
+        "subprocess_by_name": dict(COUNTERS.subprocess_by_name),
+        "hookcmd_by_name": dict(COUNTERS.subprocess_by_name),
+        "relations": relations,
+        "staged_files": rule_files,
+        "phases": [
+            {"name": p.name, "ms": p.ms, **p.counters, **p.attrs} for p in PHASES
+        ],
+        **(extra or {}),
+    }
+
+    for p in sorted(PHASES, key=lambda p: -p.ms):
+        c = p.counters
+        logger.info(
+            "PERF phase=%-24s ms=%-9.1f cos_tool=%d/%d(miss/lookup) cos_tool_ms=%.0f "
+            "pebble=%d/%.0fms hookcmd=%d/%.0fms juju_log=%d/%.0fms subprocess=%d/%.0fms %s",
+            p.name,
+            p.ms,
+            c["cos_tool_misses"],
+            c["cos_tool_lookups"],
+            c["cos_tool_ms"],
+            c["pebble_calls"],
+            c["pebble_ms"],
+            c["hookcmd_calls"],
+            c["hookcmd_ms"],
+            c["juju_log_calls"],
+            c["juju_log_ms"],
+            c["subprocess_calls"],
+            c["subprocess_ms"],
+            " ".join(f"{k}={v}" for k, v in p.attrs.items()),
+        )
+
+    logger.info(
+        "PERF SUMMARY event=%s since_import_ms=%.0f process_age_ms=%s loadavg=%s "
+        "reconcile_ms=%s cos_tool_lookups=%d cos_tool_misses=%d cos_tool_ms=%.0f "
+        "pebble=%d/%.0fms hookcmd=%d/%.0fms juju_log=%d/%.0fms subprocess=%d/%.0fms "
+        "relations=%s staged=%s",
+        event,
+        since_import_ms,
+        payload["process_age_ms"],
+        payload["loadavg"],
+        payload.get("reconcile_ms", "?"),
+        totals["cos_tool_lookups"],
+        totals["cos_tool_misses"],
+        totals["cos_tool_ms"],
+        totals["pebble_calls"],
+        totals["pebble_ms"],
+        totals["hookcmd_calls"],
+        totals["hookcmd_ms"],
+        totals["juju_log_calls"],
+        totals["juju_log_ms"],
+        totals["subprocess_calls"],
+        totals["subprocess_ms"],
+        json.dumps(relations, sort_keys=True),
+        json.dumps(rule_files, sort_keys=True),
+    )
+    logger.info(
+        "PERF SUBPROCESSES %s", json.dumps(dict(COUNTERS.subprocess_by_name), sort_keys=True)
+    )
+
+    with contextlib.suppress(Exception):
+        OUT_DIR.mkdir(parents=True, exist_ok=True)
+        name = f"{time.strftime('%Y%m%dT%H%M%S')}-{event}-{os.getpid()}.json"
+        (OUT_DIR / name).write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+
+@contextlib.contextmanager
+def profiled(charm: Any, event: str) -> Iterator[None]:
+    """Wrap the whole reconcile: optional cProfile + guaranteed report on the way out."""
+    if not ENABLED:
+        yield
+        return
+
+    profiler = None
+    if CPROFILE:
+        import cProfile
+
+        profiler = cProfile.Profile()
+        profiler.enable()
+    t0 = time.monotonic()
+    try:
+        yield
+    finally:
+        reconcile_ms = round((time.monotonic() - t0) * 1000, 1)
+        if profiler is not None:
+            profiler.disable()
+            with contextlib.suppress(Exception):
+                import pstats
+
+                OUT_DIR.mkdir(parents=True, exist_ok=True)
+                stem = f"{time.strftime('%Y%m%dT%H%M%S')}-{event}-{os.getpid()}"
+                stats = pstats.Stats(profiler)
+                stats.dump_stats(str(OUT_DIR / f"{stem}.prof"))
+                # Log only own code, ranked by self time: that is where CPU actually goes.
+                import io
+
+                buf = io.StringIO()
+                pstats.Stats(profiler, stream=buf).sort_stats("tottime").print_stats(
+                    "charm.py|integrations.py|config_manager|config_builder|cosl|charmlibs|lib/charms",
+                    25,
+                )
+                for chunk in buf.getvalue().splitlines():
+                    logger.info("PERF CPROFILE %s", chunk)
+        report(charm=charm, event=event, extra={"reconcile_ms": reconcile_ms})

--- a/tests/stress/bench_reconcile.py
+++ b/tests/stress/bench_reconcile.py
@@ -1,0 +1,230 @@
+"""Benchmark a full otelcol-k8s reconcile with N receive-otlp + N dashboard relations.
+
+Run from the charm repo root:
+    /tmp/opencode/venv/bin/python /tmp/opencode/bench_reconcile.py <n_relations> <cold|warm>
+"""
+
+import collections
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from shutil import copytree
+from unittest.mock import MagicMock, patch
+
+CHARM_ROOT = Path("/home/ubuntu/repos/opentelemetry-collector-k8s-operator")
+sys.path.insert(0, str(CHARM_ROOT))
+sys.path.insert(0, str(CHARM_ROOT / "src"))
+sys.path.insert(0, str(CHARM_ROOT / "lib"))
+
+from cosl.utils import LZMABase64  # noqa: E402
+from ops import ActiveStatus  # noqa: E402
+from ops.testing import Container, Context, Exec, Model, PeerRelation, Relation, State  # noqa: E402
+
+N = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+MODE = sys.argv[2] if len(sys.argv) > 2 else "cold"
+RULES_PER_APP = 10
+DASHBOARDS_PER_APP = 2
+
+DASHBOARD = json.loads((CHARM_ROOT / "src/grafana_dashboards/overview-dashboard.json").read_text())
+
+# ---------------------------------------------------------------- instrumentation
+calls = collections.Counter()
+elapsed = collections.defaultdict(float)
+_real_run = subprocess.run
+
+
+INTEREST = {
+    "stage_received_otlp_rules", "send_otlp", "receive_loki_logs", "scrape_metrics",
+    "send_remote_write", "send_loki_logs", "forward_dashboards", "cloud_integrator",
+    "_upset_dashboards_on_relation", "load_dashboards_from_dir", "receive_otlp",
+}
+
+
+def _origin() -> str:
+    import inspect
+    names = [f.function for f in inspect.stack()[2:]]
+    hits = [n for n in names if n in INTEREST]
+    return hits[0] if hits else "?"
+
+
+def counting_run(*args, **kwargs):
+    cmd = args[0] if args else kwargs.get("args")
+    key = "other"
+    if isinstance(cmd, (list, tuple)) and cmd:
+        key = Path(str(cmd[0])).name
+        if "cos-tool" in key:
+            key = f"cos-tool:{cmd[cmd.index('--format') + 1] if '--format' in cmd else '?'}:" + (
+                "validate" if "validate" in cmd else "transform" if "transform" in cmd else "?"
+            )
+    key = f"{_origin():32s} {key}"
+    t = time.perf_counter()
+    try:
+        return _real_run(*args, **kwargs)
+    finally:
+        calls[key] += 1
+        elapsed[key] += time.perf_counter() - t
+
+
+subprocess.run = counting_run
+
+
+# ---------------------------------------------------------------- fixtures
+def promql_rules(i: int) -> dict:
+    return {
+        "groups": [
+            {
+                "name": f"zoo_group_{i}",
+                "rules": [
+                    {
+                        "alert": f"ZooAlert{j}",
+                        "expr": f'rate(zk_requests_total{{quantile="0.99"}}[5m]) > {j}',
+                        "for": "5m",
+                        "labels": {"severity": "critical"},
+                        "annotations": {"summary": "zk slow"},
+                    }
+                    for j in range(RULES_PER_APP)
+                ],
+            }
+        ]
+    }
+
+
+def logql_rules(i: int) -> dict:
+    return {
+        "groups": [
+            {
+                "name": f"zoo_logs_{i}",
+                "rules": [
+                    {
+                        "alert": f"ZooLogAlert{j}",
+                        "expr": 'count_over_time({job=~".+"} |= "ERROR" [5m]) > 10',
+                        "labels": {"severity": "warning"},
+                    }
+                    for j in range(2)
+                ],
+            }
+        ]
+    }
+
+
+def otlp_relation(i: int) -> Relation:
+    rules = {"promql": promql_rules(i), "logql": logql_rules(i)}
+    metadata = {
+        "model": f"test-{i}",
+        "model_uuid": f"00000000-0000-4000-8000-{i:012d}",
+        "application": "otelcol",
+        "unit": "otelcol/0",
+        "charm_name": "opentelemetry-collector",
+    }
+    return Relation(
+        "receive-otlp",
+        remote_app_name=f"otelcol-{i}",
+        remote_app_data={
+            "rules": json.dumps(LZMABase64.compress(json.dumps(rules))),
+            "metadata": json.dumps(metadata),
+        },
+    )
+
+
+def dashboard_relation(i: int, unique_titles: bool = True) -> Relation:
+    templates = {}
+    for d in range(DASHBOARDS_PER_APP):
+        title = f"zookeeper-{i}-{d}" if unique_titles else f"zookeeper-{d}"
+        templates[title] = {
+            "charm": "zookeeper",
+            "content": LZMABase64.compress(json.dumps(DASHBOARD)),
+            "juju_topology": {
+                "model": f"test-{i}",
+                "model_uuid": f"00000000-0000-4000-8000-{i:012d}",
+                "application": "zookeeper",
+                "unit": "zookeeper/0",
+            },
+        }
+    return Relation(
+        "grafana-dashboards-consumer",
+        remote_app_name=f"zoo-otelcol-{i}",
+        remote_app_data={"dashboards": json.dumps({"templates": templates})},
+    )
+
+
+def main():
+    from src.charm import OpenTelemetryCollectorK8sCharm
+
+    tmp = Path(f"/tmp/opencode/bench-root-{N}")
+    shutil.rmtree(tmp, ignore_errors=True)
+    for src_dir in ["grafana_dashboards", "loki_alert_rules", "prometheus_alert_rules"]:
+        copytree(CHARM_ROOT / "src" / src_dir, tmp / "src" / src_dir, dirs_exist_ok=True)
+
+    import cosl.cos_tool as _ct
+    cache_dir = f"/tmp/opencode/cache-N{N}"
+    if MODE == "cold":
+        shutil.rmtree(cache_dir, ignore_errors=True)
+    _ct.configure_cache(cache_dir)
+
+    ctx = Context(OpenTelemetryCollectorK8sCharm, charm_root=tmp)
+    container = Container(
+        name="otelcol",
+        can_connect=True,
+        execs={
+            Exec(["update-ca-certificates", "--fresh"], return_code=0, stdout=""),
+            Exec(["/usr/bin/otelcol", "--version"], return_code=0, stdout="otelcol version 0.0.0"),
+        },
+    )
+    relations = [otlp_relation(i) for i in range(N)]
+    relations += [dashboard_relation(i, unique_titles=os.environ.get("UNIQUE", "1") == "1") for i in range(N)]
+    relations += [
+        Relation("send-otlp", remote_app_data={"endpoints": json.dumps([
+            {"protocol": "grpc", "endpoint": "cos-otelcol:4317",
+             "telemetries": ["logs", "metrics", "traces"], "insecure": True}])}),
+        Relation("grafana-dashboards-provider"),
+    ]
+    if os.environ.get("RW"):
+        relations += [
+            Relation("send-remote-write", remote_app_data={}, remote_units_data={0: {"remote_write": json.dumps({"url": "http://prom:9090/api/v1/write"})}}),
+            Relation("send-loki-logs", remote_units_data={0: {"endpoint": json.dumps({"url": "http://loki:3100/loki/api/v1/push"})}}),
+        ]
+    relations += [
+        PeerRelation("peers"),
+    ]
+    state = State(
+        leader=True,
+        containers=[container],
+        relations=relations,
+        model=Model("agg", uuid="11111111-0000-4000-8000-000000000000"),
+    )
+
+    with patch.multiple(
+        "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch",
+        _namespace="test-namespace",
+        _patch=lambda *a, **kw: True,
+        is_ready=lambda *a, **kw: True,
+        get_status=lambda _: ActiveStatus(),
+    ), patch("lightkube.core.client.GenericSyncClient", new=MagicMock()):
+        prof = None
+        if os.environ.get("PROFILE"):
+            import cProfile
+            prof = cProfile.Profile()
+            prof.enable()
+        t0 = time.perf_counter()
+        ctx.run(ctx.on.update_status(), state)
+        total = time.perf_counter() - t0
+        if prof:
+            import pstats
+            prof.disable()
+            pstats.Stats(prof).sort_stats("cumulative").print_stats(35)
+
+    print(f"\n=== N={N} relations ({N} receive-otlp + {N} dashboards), mode={MODE} ===")
+    print(f"total reconcile: {total:.2f}s")
+    subs = sum(elapsed.values())
+    print(f"subprocess total: {subs:.2f}s in {sum(calls.values())} calls "
+          f"({subs / total * 100:.0f}% of reconcile)")
+    for k, v in sorted(calls.items(), key=lambda kv: -elapsed[kv[0]]):
+        print(f"  {k:35s} calls={v:6d}  time={elapsed[k]:7.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stress/perf_report.py
+++ b/tests/stress/perf_report.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Turn the JSON artifacts produced by `src/perf.py` into a report.
+
+Collect the artifacts from the unit first:
+
+    mkdir -p ./perf-data
+    juju ssh --container charm otelcol-agg/0 "tar cf - -C /tmp otelcol-perf" 2>/dev/null |
+        tar xf - -C ./perf-data
+    # or, if you only need the JSONs:
+    juju scp --container charm otelcol-agg/0:'/tmp/otelcol-perf/*.json' ./perf-data/
+
+Then:
+
+    python tests/stress/perf_report.py ./perf-data                 # ranking per event
+    python tests/stress/perf_report.py ./perf-data --md report.md  # markdown report
+    python tests/stress/perf_report.py ./perf-data --slope         # cost per relation
+
+`--slope` fits `ms = a + b * n_relations` per phase across all collected runs (least
+squares), which is what turns a 10-relation lab into a defensible statement about 300.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+COUNTER_KEYS = [
+    "cos_tool_lookups",
+    "cos_tool_misses",
+    "cos_tool_ms",
+    "pebble_calls",
+    "pebble_ms",
+    "hookcmd_calls",
+    "hookcmd_ms",
+    "subprocess_calls",
+    "subprocess_ms",
+]
+
+
+def load(path: Path) -> List[Dict[str, Any]]:
+    runs: List[Dict[str, Any]] = []
+    for f in sorted(path.rglob("*.json")):
+        try:
+            runs.append(json.loads(f.read_text()))
+        except json.JSONDecodeError:
+            print(f"skipping unparsable {f}")
+    return runs
+
+
+def _receive_otlp_relations(run: Dict[str, Any]) -> int:
+    return int(run.get("relations", {}).get("receive-otlp", 0))
+
+
+def regime(run: Dict[str, Any]) -> str:
+    """Classify a run by the state of the cos-tool cache.
+
+    A run with zero cos-tool misses never spawned the binary: the cache was warm. Mixing
+    the two regimes in one fit is meaningless (they differ by two orders of magnitude),
+    so every aggregation below is done per regime.
+    """
+    return "cold" if int(run.get("totals", {}).get("cos_tool_misses", 0)) > 0 else "warm"
+
+
+def summary_table(runs: List[Dict[str, Any]]) -> str:
+    rows = [
+        "| event | regime | relations (recv-otlp) | reconcile s | since import s | "
+        "process age s | load1 | cos-tool lookups | misses | cos-tool s | pebble | hookcmds |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for r in sorted(runs, key=lambda r: r.get("timestamp", 0)):
+        t = r.get("totals", {})
+        rows.append(
+            "| {event} | {regime} | {rel} | {rec} | {imp} | {age} | {load} | {lookups} "
+            "| {miss} | {ct} | {pc}/{pms}s | {hc}/{hms}s |".format(
+                event=r.get("event", "?"),
+                regime=regime(r),
+                load=(r.get("loadavg") or ["?"])[0],
+                rel=_receive_otlp_relations(r),
+                rec=_s(r.get("reconcile_ms")),
+                imp=_s(r.get("since_import_ms")),
+                age=_s(r.get("process_age_ms")),
+                lookups=int(t.get("cos_tool_lookups", 0)),
+                miss=int(t.get("cos_tool_misses", 0)),
+                ct=_s(t.get("cos_tool_ms")),
+                pc=int(t.get("pebble_calls", 0)),
+                pms=_s(t.get("pebble_ms")),
+                hc=int(t.get("hookcmd_calls", 0)),
+                hms=_s(t.get("hookcmd_ms")),
+            )
+        )
+    return "\n".join(rows)
+
+
+def _s(ms: Any) -> str:
+    if ms is None:
+        return "?"
+    return f"{float(ms) / 1000:.2f}"
+
+
+def phase_table(runs: List[Dict[str, Any]], top: int = 15) -> str:
+    """Rank phases by median wall time across runs of the same cache regime."""
+    per_phase: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for r in runs:
+        for ph in r.get("phases", []):
+            per_phase[ph["name"]].append(ph)
+
+    ranked = sorted(
+        per_phase.items(), key=lambda kv: -statistics.median(p["ms"] for p in kv[1])
+    )
+    total = sum(statistics.median(p["ms"] for p in v) for _, v in ranked) or 1.0
+
+    rows = [
+        "| phase | median s | max s | % | cos-tool lookups | misses | cos-tool s | "
+        "pebble | hookcmds | runs |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for name, samples in ranked[:top]:
+        med = statistics.median(s["ms"] for s in samples)
+        rows.append(
+            "| `{name}` | {med} | {mx} | {pct:.0f}% | {lookups} | {miss} | {ct} | "
+            "{pc}/{pms}s | {hc}/{hms}s | {n} |".format(
+                name=name,
+                med=_s(med),
+                mx=_s(max(s["ms"] for s in samples)),
+                pct=100 * med / total,
+                lookups=int(statistics.median(s.get("cos_tool_lookups", 0) for s in samples)),
+                miss=int(statistics.median(s.get("cos_tool_misses", 0) for s in samples)),
+                ct=_s(statistics.median(s.get("cos_tool_ms", 0) for s in samples)),
+                pc=int(statistics.median(s.get("pebble_calls", 0) for s in samples)),
+                pms=_s(statistics.median(s.get("pebble_ms", 0) for s in samples)),
+                hc=int(statistics.median(s.get("hookcmd_calls", 0) for s in samples)),
+                hms=_s(statistics.median(s.get("hookcmd_ms", 0) for s in samples)),
+                n=len(samples),
+            )
+        )
+    return "\n".join(rows)
+
+
+def _fit(points: List[Tuple[float, float]]) -> Tuple[float, float]:
+    """Least-squares fit of y = a + b*x. Returns (a, b)."""
+    n = len(points)
+    if n < 2:
+        return (points[0][1] if points else 0.0, 0.0)
+    sx = sum(x for x, _ in points)
+    sy = sum(y for _, y in points)
+    sxx = sum(x * x for x, _ in points)
+    sxy = sum(x * y for x, y in points)
+    denom = n * sxx - sx * sx
+    if denom == 0:
+        return (sy / n, 0.0)
+    b = (n * sxy - sx * sy) / denom
+    a = (sy - b * sx) / n
+    return a, b
+
+
+def slope_table(runs: List[Dict[str, Any]], extrapolate_to: int = 300) -> str:
+    """Fit per-phase cost as a function of the number of receive-otlp relations."""
+    per_phase: Dict[str, List[Tuple[float, float]]] = defaultdict(list)
+    for r in runs:
+        n = _receive_otlp_relations(r)
+        for ph in r.get("phases", []):
+            per_phase[ph["name"]].append((float(n), float(ph["ms"])))
+
+    rows = [
+        f"| phase | fixed cost s | cost per relation ms | projection @{extrapolate_to} s | points |",
+        "|---|---|---|---|---|",
+    ]
+    fits = []
+    for name, pts in per_phase.items():
+        xs = {x for x, _ in pts}
+        if len(xs) < 2:
+            continue
+        a, b = _fit(pts)
+        fits.append((a + b * extrapolate_to, name, a, b, len(pts)))
+    for proj, name, a, b, n in sorted(fits, reverse=True):
+        rows.append(
+            f"| `{name}` | {a / 1000:.2f} | {b:.1f} | {proj / 1000:.1f} | {n} |"
+        )
+    if len(rows) == 2:
+        rows.append("| _(need runs with at least two different relation counts)_ | | | | |")
+    return "\n".join(rows)
+
+
+def hookcmd_table(runs: List[Dict[str, Any]]) -> str:
+    agg: Dict[str, List[int]] = defaultdict(list)
+    for r in runs:
+        for cmd, count in r.get("hookcmd_by_name", {}).items():
+            agg[cmd].append(count)
+    if not agg:
+        return "_(no hook commands recorded; Scenario runs do not execute them)_"
+    rows = ["| hook command | median calls per event |", "|---|---|"]
+    for cmd, counts in sorted(agg.items(), key=lambda kv: -statistics.median(kv[1])):
+        rows.append(f"| `{cmd}` | {int(statistics.median(counts))} |")
+    return "\n".join(rows)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path", type=Path, help="directory with the perf JSON artifacts")
+    ap.add_argument("--md", type=Path, help="write a markdown report to this file")
+    ap.add_argument("--slope", action="store_true", help="fit cost per relation")
+    ap.add_argument("--to", type=int, default=300, help="relation count to extrapolate to")
+    ap.add_argument("--top", type=int, default=15, help="how many phases to show")
+    args = ap.parse_args()
+
+    runs = load(args.path)
+    if not runs:
+        raise SystemExit(f"no JSON artifacts found under {args.path}")
+
+    by_regime: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for r in runs:
+        by_regime[regime(r)].append(r)
+
+    parts = [
+        "# Reconcile performance report\n",
+        f"Runs analysed: **{len(runs)}** "
+        f"(cold cos-tool cache: {len(by_regime['cold'])}, warm: {len(by_regime['warm'])})\n",
+        "## Per event\n",
+        summary_table(runs),
+        "\n## Hook commands per event\n",
+        hookcmd_table(runs),
+    ]
+    for name in ("cold", "warm"):
+        if not by_regime[name]:
+            continue
+        parts += [
+            f"\n## Phases ranked by wall time — {name} cos-tool cache\n",
+            phase_table(by_regime[name], top=args.top),
+        ]
+        if args.slope:
+            parts += [
+                f"\n### Cost model per phase, {name} cache "
+                f"(projection to {args.to} relations)\n",
+                slope_table(by_regime[name], extrapolate_to=args.to),
+            ]
+    out = "\n".join(parts)
+    print(out)
+    if args.md:
+        args.md.write_text(out)
+        print(f"\nwritten to {args.md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stress/run_matrix.sh
+++ b/tests/stress/run_matrix.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Drive the reconcile performance matrix against a live deployment and collect the
+# artifacts produced by src/perf.py.
+#
+# Topology assumed (see informe-performance-reconcile.md):
+#   cos-config-i --prometheus_scrape--> otelcol-i (model: test, lxd)
+#   otelcol-i    --otlp-------------->  otelcol-agg (model: agg, k8s)
+#
+# For each relation count R the script:
+#   * relates/unrelates otelcol-i so that exactly R relations exist
+#   * waits for the models to settle
+#   * runs 1 cold-cache reconcile (cos-tool cache wiped) and N warm ones
+# Finally it optionally exercises the two real-world scenarios: adding a relation and
+# losing the pod (and with it the cos-tool cache).
+#
+# Usage:
+#   tests/stress/run_matrix.sh --dry-run
+#   tests/stress/run_matrix.sh --counts "1 3 5 10" --warm 3
+#   tests/stress/run_matrix.sh --collect-only
+set -euo pipefail
+
+AGG_MODEL="${AGG_MODEL:-agg}"
+AGG_APP="${AGG_APP:-otelcol-agg}"
+AGG_UNIT="${AGG_UNIT:-${AGG_APP}/0}"
+SRC_MODEL="${SRC_MODEL:-test}"
+SRC_APP_PREFIX="${SRC_APP_PREFIX:-otelcol-}"
+# Endpoint on the source (VM) side and the offer/endpoint on the aggregator side.
+SRC_ENDPOINT="${SRC_ENDPOINT:-send-otlp}"
+AGG_ENDPOINT="${AGG_ENDPOINT:-${AGG_MODEL}.${AGG_APP}:receive-otlp}"
+COUNTS="${COUNTS:-1 3 5 10}"
+WARM_RUNS="${WARM_RUNS:-3}"
+CACHE_DIR="${CACHE_DIR:-/tmp/cosl-cos-tool}"
+PERF_DIR="${PERF_DIR:-/tmp/otelcol-perf}"
+OUT_DIR="${OUT_DIR:-./perf-data}"
+SETTLE_TIMEOUT="${SETTLE_TIMEOUT:-2400}"
+DRY_RUN=0
+COLLECT_ONLY=0
+SKIP_SCENARIOS=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --counts) COUNTS="$2"; shift 2 ;;
+    --warm) WARM_RUNS="$2"; shift 2 ;;
+    --out) OUT_DIR="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --collect-only) COLLECT_ONLY=1; shift ;;
+    --skip-scenarios) SKIP_SCENARIOS=1; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+run() {
+  echo "+ $*" >&2
+  [[ $DRY_RUN -eq 1 ]] && return 0
+  "$@"
+}
+
+log() { echo -e "\n=== $* ===" >&2; }
+
+# ------------------------------------------------------------------ helpers
+related_apps() {
+  # Names of otelcol-i apps in SRC_MODEL currently related to the aggregator.
+  juju status -m "$SRC_MODEL" --format=json 2>/dev/null |
+    python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+prefix='${SRC_APP_PREFIX}'
+out=[]
+for name,app in data.get('applications',{}).items():
+    if not name.startswith(prefix):
+        continue
+    rels=app.get('relations',{}).get('${SRC_ENDPOINT}',[])
+    if rels:
+        out.append(name)
+print(' '.join(sorted(out)))
+"
+}
+
+all_source_apps() {
+  juju status -m "$SRC_MODEL" --format=json 2>/dev/null |
+    python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+prefix='${SRC_APP_PREFIX}'
+print(' '.join(sorted(n for n in data.get('applications',{}) if n.startswith(prefix))))
+"
+}
+
+settle() {
+  log "waiting for models to settle"
+  [[ $DRY_RUN -eq 1 ]] && return 0
+  # `juju wait-for` is not available on every client and `bc` may be missing, so poll
+  # status and count non-idle units in Python. Two consecutive clean samples are required,
+  # otherwise a hook that has not started yet reads as idle.
+  local deadline=$((SECONDS + SETTLE_TIMEOUT))
+  local clean=0
+  while (( SECONDS < deadline )); do
+    local busy=0 m n
+    for m in "$SRC_MODEL" "$AGG_MODEL"; do
+      n=$(juju status -m "$m" --format=json 2>/dev/null | python3 -c "
+import json,sys
+try:
+    data=json.load(sys.stdin)
+except Exception:
+    print(99); raise SystemExit
+busy=0
+for app in data.get('applications',{}).values():
+    for u in (app.get('units') or {}).values():
+        if u.get('juju-status',{}).get('current') != 'idle':
+            busy+=1
+        for sub in (u.get('subordinates') or {}).values():
+            if sub.get('juju-status',{}).get('current') != 'idle':
+                busy+=1
+print(busy)
+" 2>/dev/null) || n=99
+      busy=$((busy + ${n:-99}))
+    done
+    if (( busy == 0 )); then
+      clean=$((clean + 1))
+      (( clean >= 2 )) && { echo "settled after ${SECONDS}s" >&2; return 0; }
+    else
+      clean=0
+    fi
+    sleep 10
+  done
+  echo "WARNING: still not idle after ${SETTLE_TIMEOUT}s, continuing" >&2
+}
+
+set_relation_count() {
+  local target="$1"
+  local current_apps all
+  current_apps=$(related_apps || true)
+  all=$(all_source_apps || true)
+  local -a cur=($current_apps) every=($all)
+  log "relations: have ${#cur[@]}, want ${target} (available apps: ${#every[@]})"
+  if (( ${#every[@]} < target )); then
+    echo "ERROR: only ${#every[@]} ${SRC_APP_PREFIX}* apps deployed, need ${target}" >&2
+    exit 1
+  fi
+  # Remove extras.
+  for ((i = target; i < ${#cur[@]}; i++)); do
+    run juju remove-relation -m "$SRC_MODEL" "${cur[$i]}:${SRC_ENDPOINT}" "$AGG_ENDPOINT"
+  done
+  # Add missing, picking apps that are not related yet.
+  local have=${#cur[@]}
+  for app in "${every[@]}"; do
+    (( have >= target )) && break
+    if [[ " $current_apps " != *" $app "* ]]; then
+      run juju add-relation -m "$SRC_MODEL" "${app}:${SRC_ENDPOINT}" "$AGG_ENDPOINT"
+      have=$((have + 1))
+    fi
+  done
+  settle
+}
+
+count_artifacts() {
+  [[ $DRY_RUN -eq 1 ]] && { echo 0; return 0; }
+  juju ssh -m "$AGG_MODEL" --container charm "$AGG_UNIT" \
+    "ls -1 ${PERF_DIR}/*.json 2>/dev/null | wc -l" 2>/dev/null | tr -d '\r' | tail -1
+}
+
+fire() {
+  local label="$1"
+  echo "--- run: $label" >&2
+  local before after
+  before=$(count_artifacts)
+  # `jhack fire` exits 120 when stdout is not a TTY even though it does fire the event,
+  # so its exit code is ignored and progress is verified by the artifact count instead.
+  run jhack fire "$AGG_UNIT" update-status -m "$AGG_MODEL" || true
+  # Give the hook time to finish before the next one; Juju serialises hooks per unit.
+  settle
+  after=$(count_artifacts)
+  if [[ "${after:-0}" == "${before:-0}" ]]; then
+    echo "WARNING: no new perf artifact for '$label' (before=$before after=$after)" >&2
+  else
+    echo "    artifact ok ($before -> $after)" >&2
+  fi
+}
+
+wipe_cache() {
+  log "wiping cos-tool cache (cold run)"
+  run juju ssh -m "$AGG_MODEL" --container charm "$AGG_UNIT" rm -rf "$CACHE_DIR"
+}
+
+collect() {
+  log "collecting artifacts into $OUT_DIR"
+  mkdir -p "$OUT_DIR"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "+ juju ssh ... tar cf - -C /tmp otelcol-perf | tar xf - -C $OUT_DIR" >&2
+    return 0
+  fi
+  # `-C <dir> <operando>`: el directorio de trabajo y qué empaquetar son dos argumentos
+  # distintos. `2>/dev/null` evita que los mensajes de juju contaminen el stream de tar.
+  juju ssh -m "$AGG_MODEL" --container charm "$AGG_UNIT" \
+    "tar cf - -C $(dirname "$PERF_DIR") $(basename "$PERF_DIR")" 2>/dev/null |
+    tar xf - -C "$OUT_DIR"
+  local n
+  n=$(find "$OUT_DIR" -name '*.json' | wc -l)
+  echo "artifacts recolectados: $n" >&2
+  if [[ "$n" == "0" ]]; then
+    echo "ERROR: no se recolectó ningún artifact; revisar $PERF_DIR en la unidad" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------ main
+if [[ $COLLECT_ONLY -eq 1 ]]; then
+  collect
+  exit 0
+fi
+
+log "matrix: counts=[$COUNTS] warm_runs=$WARM_RUNS unit=$AGG_UNIT"
+echo "reminder: set 'update-status-hook-interval=60m' on both models first" >&2
+
+for r in $COUNTS; do
+  set_relation_count "$r"
+  wipe_cache
+  fire "R=${r} cold"
+  for ((w = 1; w <= WARM_RUNS; w++)); do
+    fire "R=${r} warm#${w}"
+  done
+done
+
+if [[ $SKIP_SCENARIOS -eq 0 ]]; then
+  log "scenario: add one relation on top of the current count (the 30-minute case)"
+  current=$(related_apps || true)
+  read -r -a cur <<<"$current"
+  set_relation_count $(( ${#cur[@]} + 1 ))
+
+  log "scenario: pod recreation (loses the cos-tool cache in /tmp)"
+  run juju ssh -m "$AGG_MODEL" --container charm "$AGG_UNIT" ls "$PERF_DIR" >/dev/null || true
+  echo "NOTE: recreate the pod manually if desired:" >&2
+  echo "  kubectl -n $AGG_MODEL delete pod ${AGG_APP}-0" >&2
+fi
+
+collect
+log "now build the report"
+echo "python tests/stress/perf_report.py $OUT_DIR --slope --to 300 --md informe-cuellos-de-botella.md" >&2


### PR DESCRIPTION
<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
**Table of Contents**

- [Solution](#solution)
- [Deployment to run the stress tests](#deployment-to-run-the-stress-tests)
- [How to measure](#how-to-measure)
  - [Step by step execution:](#step-by-step-execution)
- [Let's measure](#lets-measure)
  - [First run (Baseline)](#first-run-baseline)
    - [Reconcile: time per phase — cold cache](#reconcile-time-per-phase--cold-cache)
    - [Reconcile: time per phase — warm cache](#reconcile-time-per-phase--warm-cache)
    - [Subprocesses per event](#subprocesses-per-event)
  - [Second run (First improvement)](#second-run-first-improvement)
    - [Reconcile: time per phase — cold cache](#reconcile-time-per-phase--cold-cache-1)
    - [Reconcile: time per phase — warm cache](#reconcile-time-per-phase--warm-cache-1)
    - [Subprocesses per event](#subprocesses-per-event-1)
  - [Third run (Second improvement)](#third-run-second-improvement)
    - [Reconcile: time per phase — cold cache](#reconcile-time-per-phase--cold-cache-2)
    - [Reconcile: time per phase — warm cache](#reconcile-time-per-phase--warm-cache-2)
    - [Subprocesses per event](#subprocesses-per-event-2)
- [Conclusions](#conclusions)
  - [First improvement](#first-improvement)
  - [Second improvement](#second-improvement)
  - [What the improvements did NOT touch](#what-the-improvements-did-not-touch)
  - [Extra notes](#extra-notes)

<!-- markdown-toc end -->



## Solution
<!-- A summary of the solution addressing the above issue -->

In order to analyse the bottlenecks in the charm code a custom temporal instrumentation of `cProfile` was done.

The instrumentation of `src/charm.py` was done with a temporary helper module, `src/perf.py`. In `__init__`, `perf.install()` is called, which at runtime patches `subprocess.run` and Pebble's `Client._request_ra`w to count and time every subprocess (classified by argv[0]: juju-log, cos-tool-amd64, hook commands, etc.) and every Pebble request, using process-wide counters sampled at each phase boundary. Then `_reconcile` was wrapped in with `perf.profiled(...)`, which times the whole event and optionally enables cProfile (`OTELCOL_PERF_CPROFILE=1`) that dumps a `.prof` per event.

Inside, the ~30 operations of the reconcile are delimited `with with perf.phase("name")` (e.g. `otlp_send`, `refresh_certs`, `config_build_and_push`): each measures its wall time and the counter deltas (cos-tool lookups/misses, forks, pebble). At the end of the event, `perf` emits three outputs: a `PERF` log line per phase via `juju-log`, a JSON per event under `/tmp/otelcol-perf` (consumed by `tests/stress/perf_report.py`), and an OpenTelemetry span per phase (visible in Tempo nested under `ops.main`). All of it is diagnostic and marked DO NOT MERGE.


## Deployment to run the stress tests


There are two models on two different controllers for the stress tests. On a Kubernetes controller there is an `agg` model, which holds the aggregator under test: the `otelcol-agg` application (unit `otelcol-agg/0`), built with the K8s charm from this repo and instrumented with `src/perf.py` in the charm container. It is the one receiving the 10 `otlp` relations and writing the artifacts under `/tmp/otelcol-perf`.


On a `lxd` controller there is a `test` model, which is the load generator: 10 pairs of `postgresql` (pg1..pg10, `14/stable`) + `opentelemetry-collector` (otelcol1..otelcol10, dev/edge rev 404, subordinate charm), related 1:1; each pair relates to `otelcol-agg` via `otlp`, contributing ~67 alert rules each (670 total).

We believe that with this deployment, we can extrapolate with a fair degree of certainty what is happening in the IS deployment, where they have ~300 clients that provide a similar number of alert rules and dashboards.

There is also a third model in the Kubernetes controller running `otelcol` and `prometheus` to which `otelcol-agg` is related to through the `otlp` interface. The sole purpose of this is to let `otelcol-agg` to be in `active/idle`


```mermaid
flowchart TB
    subgraph CK8S["Controller ck8s (Kubernetes)"]
        subgraph AGG["Model agg"]
            AGG_APP["otelcol-agg</br><i>unit otelcol-agg/0</i>"]
            AGG_CHARM["charm container</br>instrumented with src/perf.py</br>artifacts → /tmp/otelcol-perf"]
            AGG_APP --- AGG_CHARM
        end
        subgraph COS["Model cos (cos-lite)"]
            COS_OT["otelcol"]
            COS_PROM["prometheus"]
            COS_OT --- COS_PROM
        end
    end

    subgraph LXD["Controller lxd (VMs)"]
        subgraph TEST["Model test (load generator)"]
            PG1["postgresql</br>pg1 (14/stable)"] --- OT1["opentelemetry-collector</br>otelcol1 (subordinate, dev/edge rev 404)"]
            PG2["postgresql</br>pg2"] --- OT2["opentelemetry-collector</br>otelcol2"]
            DOTS["... 10 pares 1:1 ..."]
            PG10["postgresql</br>pg10"] --- OT10["opentelemetry-collector</br>otelcol10"]
        end
    end

    OT1 -->|"otlp: ~67 rules"| AGG_APP
    OT2 -->|"otlp: ~67 rules"| AGG_APP
    OT10 -->|"otlp: ~67 rules"| AGG_APP
    DOTS -.->|"10 relations receive-otlp / 670 rules total"| AGG_APP

    AGG_APP -->|"send-otlp → receive-otlp (SAAS admin/cos.otelcol)"| COS_OT

    CK8S -.-> AGG
    CK8S -.-> COS
    LXD -.-> TEST
```


## How to measure


What `run_matrix.sh` does: it runs reconcile measurements against the live deployment with whatever relations are currently in place, in two regimes: one `cold` run where the `cos-tool` result cache is wiped first (equivalent to a recreated pod, a charm upgrade, or alert rules never seen before), followed by N `warm` runs that reuse the cache built by the cold run. The difference between the two isolates the cost of the cos-tool subprocesses; what is common to both is the cost no cache can remove. For each run it fires an `update-status` event on the unit under test via `jhack fire`, waits for both models to become idle, verifies that a new `JSON` artifact actually appeared in `/tmp/otelcol-perf` (the directory where `src/perf.py` writes one file per hook event), and finally collects the JSON artifacts from the charm container (base64-encoded tar, robust against the juju snap quirks) into `OUT_DIR` so the report can be generated.


### Step by step execution:

**Before you start**

- Make sure the charm under test is already instrumented (`src/charm.py` and `src/perf.py) and that `update-status-hook-interval` is set to `600m` on both `agg` and `test` models.
- Do not touch the models while it runs, any extra hook fired during the measurement contaminates it.



1. Run the benchmark:
   ```shell
   OUT_DIR=./perf-data ./tests/stress/run_matrix.sh --repeat 3
   ```
   Flags: `--repeat N` (1 cold + N warm)


2. Generate the report
   ```shell
    python3 tests/stress/perf_report.py ./perf-data --md report.md
    ```


## Let's measure

### First run (Baseline)

Runs analyzed: **4** (cold cos-tool cache: 1, warm: 3)

| run | event | relations | reconcile s | load1 | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools |
|---|---|---|---|---|---|---|---|---|---|---|
| cold | (update-status) | 10 | 23.54 | 7.01 | 3381 | 691 | 5.64 | 2749/11.30s | 22/3.45s | 63/0.35s |
| warm | (update-status) | 10 | 20.45 | 7.81 | 3381 | 0 | 0.00 | 3440/13.97s | 22/3.41s | 63/0.37s |
| warm | (update-status) | 10 | 20.50 | 7.27 | 3381 | 0 | 0.00 | 3440/14.03s | 22/3.42s | 63/0.35s |
| warm | (update-status) | 10 | 20.18 | 7.04 | 3381 | 0 | 0.00 | 3440/13.75s | 22/3.40s | 63/0.36s |

#### Reconcile: time per phase — cold cache

| phase | s | % | ms per relation | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools | runs |
|---|---|---|---|---|---|---|---|---|---|---|
| `otlp_send` | 9.78 | 42% | 978 | 2031 | 11 | 0.09 | 2024/8.37s | 0/0.00s | 6/0.03s | 1 |
| `otlp_stage_rules` | 9.74 | 41% | 974 | 1350 | 680 | 5.55 | 681/2.75s | 0/0.00s | 10/0.06s | 1 |
| `refresh_certs` | 3.16 | 13% | 316 | 0 | 0 | 0.00 | 0/0.00s | 2/3.12s | 0/0.00s | 1 |
| `replan` | 0.20 | 1% | 20 | 0 | 0 | 0.00 | 0/0.00s | 2/0.18s | 1/0.01s | 1 |
| `resources_patch` | 0.18 | 1% | 18 | 0 | 0 | 0.00 | 38/0.15s | 0/0.00s | 1/0.01s | 1 |
| `workload_version` | 0.17 | 1% | 17 | 0 | 0 | 0.00 | 0/0.00s | 2/0.12s | 1/0.01s | 1 |
| `otlp_receive` | 0.11 | 0% | 11 | 0 | 0 | 0.00 | 0/0.00s | 0/0.00s | 21/0.11s | 1 |
| _rest (22 phases)_ | 0.21 | 1% | | | | | | | | |

Total of the medians: **23.54 s**. `ms per relation` is the phase median divided by the 10 `receive-otlp` relations in the deployment: useful to compare phases against each other, not as a projection (part of the cost scales with rules, not with relations).


#### Reconcile: time per phase — warm cache

| phase | s | % | ms per relation | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools | runs |
|---|---|---|---|---|---|---|---|---|---|---|
| `otlp_send` | 9.56 | 47% | 956 | 2031 | 0 | 0.00 | 2035/8.26s | 0/0.00s | 6/0.03s | 3 |
| `otlp_stage_rules` | 6.77 | 33% | 677 | 1350 | 0 | 0.00 | 1361/5.46s | 0/0.00s | 10/0.07s | 3 |
| `refresh_certs` | 3.16 | 16% | 316 | 0 | 0 | 0.00 | 0/0.00s | 2/3.10s | 0/0.00s | 3 |
| `resources_patch` | 0.20 | 1% | 20 | 0 | 0 | 0.00 | 38/0.16s | 0/0.00s | 1/0.01s | 3 |
| `workload_version` | 0.18 | 1% | 18 | 0 | 0 | 0.00 | 0/0.00s | 2/0.13s | 1/0.01s | 3 |
| `replan` | 0.18 | 1% | 18 | 0 | 0 | 0.00 | 0/0.00s | 2/0.16s | 1/0.01s | 3 |
| `otlp_receive` | 0.11 | 1% | 11 | 0 | 0 | 0.00 | 0/0.00s | 0/0.00s | 21/0.10s | 3 |
| _rest (22 phases)_ | 0.19 | 1% | | | | | | | | |

Total of the medians: **20.35 s**. `ms per relation` is the phase median divided by the 10 `receive-otlp` relations in the deployment: useful to compare phases against each other, not as a projection (part of the cost scales with rules, not with relations).

#### Subprocesses per event

| command | forks per event (median) |
|---|---|
| `juju-log` | 3440 |
| `cos-tool-amd64` | 691 |
| `relation-ids` | 23 |
| `relation-get` | 22 |
| `relation-list` | 12 |
| `application-version-set` | 1 |
| `config-get` | 1 |
| `goal-state` | 1 |
| `is-leader` | 1 |
| `opened-ports` | 1 |
| `status-set` | 1 |


### Second run (First improvement)

After applying [this fix to coslib](https://github.com/canonical/cos-lib/pull/204) that tries to improve the execution times of the two major offenders: `otlp_send` and `otlp_stage_rules` we re-ran the benchmark:


Runs analysed: **4** (cold cos-tool cache: 1, warm: 3)

| run | event | relations | reconcile s | load1 | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools |
|---|---|---|---|---|---|---|---|---|---|---|
| cold | (update-status) | 10 | 11.84 | 1.36 | 3381 | 691 | 5.83 | 59/0.23s | 22/3.38s | 63/0.34s |
| warm | (update-status) | 10 | 5.63 | 1.47 | 3381 | 0 | 0.00 | 59/0.24s | 22/3.30s | 63/0.36s |
| warm | (update-status) | 10 | 5.80 | 2.53 | 3381 | 0 | 0.00 | 59/0.24s | 22/3.45s | 63/0.37s |
| warm | (update-status) | 10 | 5.74 | 2.69 | 3381 | 0 | 0.00 | 59/0.26s | 22/3.39s | 63/0.37s |


#### Reconcile: time per phase — cold cache

| phase | s | % | ms per relation | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools | runs |
|---|---|---|---|---|---|---|---|---|---|---|
| `otlp_stage_rules` | 7.08 | 60% | 708 | 1350 | 680 | 5.74 | 11/0.05s | 0/0.00s | 10/0.07s | 1 |
| `refresh_certs` | 3.10 | 26% | 310 | 0 | 0 | 0.00 | 0/0.00s | 2/3.06s | 0/0.00s | 1 |
| `otlp_send` | 0.83 | 7% | 83 | 2031 | 11 | 0.10 | 4/0.02s | 0/0.00s | 6/0.03s | 1 |
| `replan` | 0.20 | 2% | 20 | 0 | 0 | 0.00 | 0/0.00s | 2/0.18s | 1/0.02s | 1 |
| `resources_patch` | 0.18 | 1% | 18 | 0 | 0 | 0.00 | 38/0.14s | 0/0.00s | 1/0.01s | 1 |
| `workload_version` | 0.17 | 1% | 17 | 0 | 0 | 0.00 | 0/0.00s | 2/0.12s | 1/0.01s | 1 |
| _rest (23 phases)_ | 0.29 | 2% | | | | | | | | |

Total of the medians: **11.84 s**. `ms per relation` is the phase median divided by the 10 `receive-otlp` relations in the deployment: useful to compare phases against each other, not as a projection (part of the cost scales with rules, not with relations).


#### Reconcile: time per phase — warm cache

| phase | s | % | ms per relation | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools | runs |
|---|---|---|---|---|---|---|---|---|---|---|
| `refresh_certs` | 3.15 | 55% | 315 | 0 | 0 | 0.00 | 0/0.00s | 2/3.08s | 0/0.00s | 3 |
| `otlp_stage_rules` | 0.97 | 17% | 97 | 1350 | 0 | 0.00 | 11/0.05s | 0/0.00s | 10/0.07s | 3 |
| `otlp_send` | 0.77 | 14% | 77 | 2031 | 0 | 0.00 | 4/0.02s | 0/0.00s | 6/0.03s | 3 |
| `workload_version` | 0.18 | 3% | 18 | 0 | 0 | 0.00 | 0/0.00s | 2/0.14s | 1/0.01s | 3 |
| `resources_patch` | 0.18 | 3% | 18 | 0 | 0 | 0.00 | 38/0.15s | 0/0.00s | 1/0.01s | 3 |
| `replan` | 0.17 | 3% | 17 | 0 | 0 | 0.00 | 0/0.00s | 2/0.16s | 1/0.02s | 3 |
| `otlp_receive` | 0.13 | 2% | 13 | 0 | 0 | 0.00 | 0/0.00s | 0/0.00s | 21/0.13s | 3 |
| _rest (22 phases)_ | 0.18 | 3% | | | | | | | | |

Total of the medians: **5.73 s**. `ms per relation` is the phase median divided by the 10 `receive-otlp` relations in the deployment: useful to compare phases against each other, not as a projection (part of the cost scales with rules, not with relations).


#### Subprocesses per event

| command | forks per event (median) |
|---|---|
| `cos-tool-amd64` | 691 |
| `juju-log` | 59 |
| `relation-ids` | 23 |
| `relation-get` | 22 |
| `relation-list` | 12 |
| `application-version-set` | 1 |
| `config-get` | 1 |
| `goal-state` | 1 |
| `is-leader` | 1 |
| `opened-ports` | 1 |
| `status-set` | 1 |


### Third run (Second improvement)

On top of the first improvement, the idea now is to try to reduce the execution time of the third offender: `refresh_certs`, for that in `charm.py` we modify the `refresh_certs` function like this:


```diff
-def refresh_certs(container: Container):
-    """Run `update-ca-certificates` to refresh the trusted system certs."""
+def refresh_certs(container: Container, trust_hash: str):
+    """Refresh the trusted system certs, but only when they actually changed.
+
+    `update-ca-certificates --fresh` rehashes the whole bundle and costs several seconds,
+    yet the vast majority of reconciles do not touch any certificate. The hash of the certs
+    written under the system trust dir is therefore stamped on disk (in the workload
+    container, next to the trust store) and the command is skipped when it is unchanged
+
+    Args:
+        container: the workload container whose trust store is refreshed.
+        trust_hash: a hash summarising every cert that feeds the trust store. When it
+            matches the stamp from a previous run, the refresh is skipped.
+    """
+    stamp = ContainerPath(CA_TRUST_STAMP_PATH, container=container)
+    try:
+        if stamp.read_text() == trust_hash:
+            logger.debug("System trust store unchanged; skipping update-ca-certificates")
+            return
+    except FileNotFoundError:
+        pass
+
     container.exec(["update-ca-certificates", "--fresh"]).wait()
+    # Only stamp after a successful refresh, so a failed run is retried next reconcile.
+    container.push(
+        CA_TRUST_STAMP_PATH,
+        trust_hash.encode("utf-8"),
+        make_dirs=True,
+    )
```


Runs analysed: **4** (cold cos-tool cache: 1, warm: 3)

| run | event | relations | reconcile s | load1 | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools |
|---|---|---|---|---|---|---|---|---|---|---|
| cold | (update-status) | 10 | 12.07 | 1.32 | 3381 | 691 | 5.86 | 59/0.26s | 24/3.47s | 63/0.37s |
| warm | (update-status) | 10 | 2.56 | 1.55 | 3381 | 0 | 0.00 | 60/0.24s | 21/0.29s | 63/0.35s |
| warm | (update-status) | 10 | 2.71 | 1.51 | 3381 | 0 | 0.00 | 60/0.27s | 21/0.32s | 63/0.37s |
| warm | (update-status) | 10 | 2.52 | 1.6 | 3381 | 0 | 0.00 | 60/0.24s | 21/0.30s | 63/0.37s |


#### Reconcile: time per phase — cold cache

| phase | s | % | ms per relation | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools | runs |
|---|---|---|---|---|---|---|---|---|---|---|
| `otlp_stage_rules` | 7.14 | 59% | 714 | 1350 | 680 | 5.77 | 11/0.04s | 0/0.00s | 10/0.09s | 1 |
| `refresh_certs` | 3.17 | 26% | 317 | 0 | 0 | 0.00 | 0/0.00s | 4/3.14s | 0/0.00s | 1 |
| `otlp_send` | 0.86 | 7% | 86 | 2031 | 11 | 0.09 | 4/0.02s | 0/0.00s | 6/0.03s | 1 |
| `resources_patch` | 0.22 | 2% | 22 | 0 | 0 | 0.00 | 38/0.18s | 0/0.00s | 1/0.01s | 1 |
| `replan` | 0.19 | 2% | 19 | 0 | 0 | 0.00 | 0/0.00s | 2/0.17s | 1/0.01s | 1 |
| `workload_version` | 0.18 | 1% | 18 | 0 | 0 | 0.00 | 0/0.00s | 2/0.13s | 1/0.01s | 1 |
| `otlp_receive` | 0.12 | 1% | 12 | 0 | 0 | 0.00 | 0/0.00s | 0/0.00s | 21/0.12s | 1 |
| _rest (22 phases)_ | 0.18 | 1% | | | | | | | | |

Total of the medians: **12.07 s**. `ms per relation` is the phase median divided by the 10 `receive-otlp` relations in the deployment: useful to compare phases against each other, not as a projection (part of the cost scales with rules, not with relations).

#### Reconcile: time per phase — warm cache

| phase | s | % | ms per relation | cos-tool lookups | misses | cos-tool s | juju-log | pebble | other hook tools | runs |
|---|---|---|---|---|---|---|---|---|---|---|
| `otlp_stage_rules` | 0.97 | 38% | 97 | 1350 | 0 | 0.00 | 11/0.05s | 0/0.00s | 10/0.07s | 3 |
| `otlp_send` | 0.74 | 29% | 74 | 2031 | 0 | 0.00 | 4/0.02s | 0/0.00s | 6/0.03s | 3 |
| `resources_patch` | 0.18 | 7% | 18 | 0 | 0 | 0.00 | 38/0.15s | 0/0.00s | 1/0.01s | 3 |
| `replan` | 0.18 | 7% | 18 | 0 | 0 | 0.00 | 0/0.00s | 2/0.16s | 1/0.01s | 3 |
| `workload_version` | 0.17 | 7% | 17 | 0 | 0 | 0.00 | 0/0.00s | 2/0.12s | 1/0.01s | 3 |
| `otlp_receive` | 0.12 | 5% | 12 | 0 | 0 | 0.00 | 0/0.00s | 0/0.00s | 21/0.12s | 3 |
| `dashboards` | 0.03 | 1% | 3 | 0 | 0 | 0.00 | 1/0.00s | 0/0.00s | 2/0.01s | 3 |
| _rest (22 phases)_ | 0.17 | 7% | | | | | | | | |

Total of the medians: **2.56 s**. `ms per relation` is the phase median divided by the 10 `receive-otlp` relations in the deployment: useful to compare phases against each other, not as a projection (part of the cost scales with rules, not with relations).


#### Subprocesses per event

| command | forks per event (median) |
|---|---|
| `cos-tool-amd64` | 691 |
| `juju-log` | 60 |
| `relation-ids` | 23 |
| `relation-get` | 22 |
| `relation-list` | 12 |
| `application-version-set` | 1 |
| `config-get` | 1 |
| `goal-state` | 1 |
| `is-leader` | 1 |
| `opened-ports` | 1 |
| `status-set` | 1 |


## Conclusions

With just two easy improvements in the code we managed to reduce the subsequent execution times by **78%**.

<img width="1123" height="661" alt="image" src="https://github.com/user-attachments/assets/a46cbff2-4338-4a9c-b0dc-98b442a06c11" />



### First improvement

Removing a `logger.debug` on every cos-tool cache hit in cos-lib [#204](https://github.com/canonical/cos-lib/pull/204). Every logger.* call spawns a juju-log subprocess (~4–5 ms each). With 3,381 cos-tool lookups per event and almost all of them cache hits, each hit was logging a debug line → 3,400 wasted forks (14 s) per reconcile. The fix does exactly the same work — the lookups/misses are identical (3,381 / 691) — it just stops paying for the forks.

- Cold execution time has been reduced by **50%** compared with the Baseline
- Warm execution time has been reduced by another **50%** compared with cold execution time

### Second improvement

Stamping the trust-store hash and skipping `update-ca-certificates --fresh` when it is unchanged. The command rehashes the whole trust bundle (~2.6 s of Pebble) on every reconcile even though no certificate changed. With the stamp it only runs when the certs actually change: Pebble per event drops from 3.4 s to 0.29 s and `refresh_certs` disappears from the warm per-phase tables.

- Cold execution time remains the same compared with First improvement
- Warm execution time has bee reduced by **78%** compared with cold execution time


### What the improvements did NOT touch

- **Cold cache (~12 s)**: barely moved across runs 2 and 3 (11.84 → 12.07 s, single cold samples at different loads). It is dominated by the 691 cos-tool misses (~5.8 s of cos-tool time) plus the first update-ca-certificates after a deploy (~3.1 s) — which the stamp cannot skip because there is no stamp yet. Both are inherent to a fresh cache / fresh trust store.
- **Rule processing**: at warm 2.56 s, ~1.7 s is still `otlp_stage_rules` (0.97 s) + `otlp_send` (0.74 s) doing 3,381 cos-tool lookups (all cache hits) with double topology injection. That is the next bottleneck, memoizing OtlpProvider.rules and avoiding the re-injection in Rules.add() would project warm to ~1 s.


### Extra notes

- Both fixes are behavioural no-ops: lookups/misses are identical across all runs (3,381 / 691), so the same rules are produced and published — only wasted work was removed.
- Absolute times depend on host load: the baseline was measured at load1 7.0–7.8 vs 1.3–2.7 for the other two, which might inflates the warm deltas. The deterministic counters (juju-log forks, Pebble calls) and the per-phase medians are the reliable comparators.
