### PR TITLE
perf: avoid unnecessary update-ca-certs excecutions

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -23,9 +23,10 @@ from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import APIError, CheckDict, ExecDict, HttpDict, Layer
 
 import integrations
-from config_builder import Port
+from config_builder import Port, sha256
 from config_manager import ConfigManager
 from constants import (
+    CA_TRUST_STAMP_PATH,
     CERTS_DIR,
     CONFIG_PATH,
     EXTERNAL_CONFIG_SECRETS_DIR,
@@ -80,9 +81,34 @@ def charm_address(
     )
 
 
-def refresh_certs(container: Container):
-    """Run `update-ca-certificates` to refresh the trusted system certs."""
+def refresh_certs(container: Container, trust_hash: str):
+    """Refresh the trusted system certs, but only when they actually changed.
+
+    `update-ca-certificates --fresh` rehashes the whole bundle and costs several seconds,
+    yet the vast majority of reconciles do not touch any certificate. The hash of the certs
+    written under the system trust dir is therefore stamped on disk (in the workload
+    container, next to the trust store) and the command is skipped when it is unchanged
+
+    Args:
+        container: the workload container whose trust store is refreshed.
+        trust_hash: a hash summarising every cert that feeds the trust store. When it
+            matches the stamp from a previous run, the refresh is skipped.
+    """
+    stamp = ContainerPath(CA_TRUST_STAMP_PATH, container=container)
+    try:
+        if stamp.read_text() == trust_hash:
+            logger.debug("System trust store unchanged; skipping update-ca-certificates")
+            return
+    except FileNotFoundError:
+        pass
+
     container.exec(["update-ca-certificates", "--fresh"]).wait()
+    # Only stamp after a successful refresh, so a failed run is retried next reconcile.
+    container.push(
+        CA_TRUST_STAMP_PATH,
+        trust_hash.encode("utf-8"),
+        make_dirs=True,
+    )
 
 
 def _get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
@@ -200,7 +226,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         # Refresh system certs
         # This must be run after receive_ca_cert and/or receive_server_cert because they update
         # certs in the /usr/local/share/ca-certificates directory
-        refresh_certs(container)
+        refresh_certs(container, sha256(receive_ca_certs_hash + server_cert_hash))
 
         # Address manager
         # NOTE: executed after ingress and TLS events

--- a/src/constants.py
+++ b/src/constants.py
@@ -11,6 +11,11 @@ SERVER_CA_CERT_PATH: Final[str] = (
 SERVER_CERT_PATH: Final[str] = "/etc/otelcol/otelcol-server-cert.crt"
 SERVER_CERT_PRIVATE_KEY_PATH: Final[str] = "/etc/otelcol/otelcol-private-key.key"
 CONFIG_PATH: Final[str] = "/etc/otelcol/config.yaml"
+# Records the hash of the certs last applied to the system trust store, so that
+# `update-ca-certificates` (which costs several seconds) is only run when they change.
+# Kept in the workload container, alongside the trust store it guards, so a recreated
+# container drops the stamp and the trust store is rebuilt on the next reconcile.
+CA_TRUST_STAMP_PATH: Final[str] = "/etc/otelcol/.ca-trust-hash"
 METRICS_RULES_SRC_PATH: Final[str] = "src/prometheus_alert_rules"
 METRICS_RULES_DEST_PATH: Final[str] = "prometheus_alert_rules"
 LOKI_RULES_SRC_PATH: Final[str] = "src/loki_alert_rules"

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -670,7 +670,8 @@ def receive_server_cert(
     workload container.
 
     Returns:
-        Hash of server cert and private key, to be used as reload trigger if it changed.
+        Hash of server cert, private key and CA cert, to be used as reload trigger if it
+        changed.
     """
     # Common name length must be >= 1 and <= 64, so fqdn is too long.
     common_name = charm.unit.name.replace("/", "-")
@@ -717,7 +718,9 @@ def receive_server_cert(
 
     # NOTE: we run `update-ca-certificates` in charm code
 
-    return sha256(str(provider_certificate.certificate) + str(private_key))
+    return sha256(
+        str(provider_certificate.certificate) + str(private_key) + str(provider_certificate.ca)
+    )
 
 
 def receive_ca_cert(charm: CharmBase, recv_ca_cert_folder_path: PathProtocol) -> str:

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -2,8 +2,16 @@
 # See LICENSE file for licensing details.
 
 
+from unittest.mock import patch
+
 import yaml
+from charms.tls_certificates_interface.v4.tls_certificates import (
+    Certificate,
+    TLSCertificatesRequiresV4,
+)
 from ops.testing import Context, State
+
+from constants import CA_TRUST_STAMP_PATH
 
 
 def get_otelcol_file(state_out: State, ctx: Context, file_path: str) -> dict:
@@ -14,3 +22,30 @@ def get_otelcol_file(state_out: State, ctx: Context, file_path: str) -> dict:
     assert otelcol_file.exists(), "file does not exist"
     cfg = yaml.safe_load(otelcol_file.read_text())
     return cfg
+
+
+def trust_stamp_after_reconcile(ctx: Context, state_in: State, cert_obj, private_key: str) -> str:
+    """Run a reconcile with a stubbed assigned server cert and return the trust-store stamp.
+
+    `_reconcile` fetches the server cert, key and CA from the `receive-server-cert` relation
+    via `TLSCertificatesRequiresV4`; here `get_assigned_certificate` is stubbed to return
+    `cert_obj` (which must expose `.certificate.raw` and `.ca.raw`) together with
+    `private_key`. The returned stamp (`CA_TRUST_STAMP_PATH`) reflects what `refresh_certs`
+    wrote for that cert, so comparing two runs isolates the trust-store inputs that changed.
+    """
+    with (
+        patch.object(TLSCertificatesRequiresV4, "_find_available_certificates", return_value=None),
+        patch.object(
+            TLSCertificatesRequiresV4,
+            "get_assigned_certificate",
+            return_value=(cert_obj, private_key),
+        ),
+        patch.object(Certificate, "from_string", return_value=cert_obj),
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state=state_in)
+    otelcol = state_out.get_container("otelcol")
+    fs = otelcol.get_filesystem(ctx)
+
+    stamp = fs.joinpath(*CA_TRUST_STAMP_PATH.strip("/").split("/"))
+    assert stamp.exists(), "trust store stamp was not written"
+    return stamp.read_text()

--- a/tests/unit/test_tls_certificates.py
+++ b/tests/unit/test_tls_certificates.py
@@ -11,7 +11,8 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     Certificate,
     TLSCertificatesRequiresV4,
 )
-from helpers import get_otelcol_file
+from conftest import MockCertificate
+from helpers import get_otelcol_file, trust_stamp_after_reconcile
 from ops.testing import Relation, State
 
 from constants import (
@@ -117,6 +118,28 @@ def test_transitioned_from_http_to_https_to_http(
         get_otelcol_file(state_out, ctx, SERVER_CA_CERT_PATH)
     with pytest.raises(AssertionError, match="file does not exist"):
         get_otelcol_file(state_out, ctx, SERVER_CERT_PRIVATE_KEY_PATH)
+
+
+def test_ca_only_rotation_refreshes_trust_stamp(
+    ctx, otelcol_container, cert_obj, private_key, server_cert
+):
+    """Scenario: the issuing CA rotates while the server cert and private key stay the same."""
+    # GIVEN a tls-certificates relation with an assigned cert, key and CA
+    ssc = Relation(
+        endpoint="receive-server-cert",
+        interface="tls-certificate",
+    )
+    state_in = State(relations=[ssc], containers=otelcol_container)
+
+    # WHEN a reconcile refreshes the trust store with the current CA
+    stamp_before = trust_stamp_after_reconcile(ctx, state_in, cert_obj, private_key)
+    # AND nothing changes, the trust store is left untouched
+    assert trust_stamp_after_reconcile(ctx, state_in, cert_obj, private_key) == stamp_before
+    # WHEN only the CA rotates (same server cert and private key)
+    rotated = MockCertificate(server_cert, "rotated_ca_certificate")
+    stamp_after = trust_stamp_after_reconcile(ctx, state_in, rotated, private_key)
+    # THEN the trust store is refreshed again
+    assert stamp_after != stamp_before
 
 
 @pytest.mark.skip(reason="https://github.com/canonical/operator/issues/1858")

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.10.2"
+version = "1.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -355,9 +355,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/18/9199c798915b667c9516ce664152dbc1f14d80aed963c22f640a0400c253/cosl-1.10.2.tar.gz", hash = "sha256:911981f89a3447dd3f26e1f69f8cdd44b5935fb1e2cfdbd60e75c28d86a17e6d", size = 157045, upload-time = "2026-07-17T21:32:13.709Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/dd/ca7a3873653d9d28b3ad99c3cd87c1daa3e2053d16800343768c4f6c6194/cosl-1.10.3.tar.gz", hash = "sha256:95ac498d3820a7d1f4096e6662b22de639911d7f77e1a25b0cfad963f83836bc", size = 157021, upload-time = "2026-08-14T18:17:08.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/53/26902ea5662f0016282c672214bdfbf99251135eeec35ace6875f7784c8d/cosl-1.10.2-py3-none-any.whl", hash = "sha256:ff4aa756ab084def1f49fe31b49781aa584176ac7eec107dd192ae0c87899fc0", size = 41117, upload-time = "2026-07-17T21:32:12.535Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cc/4a797249e1f253c9a9ab29fd8e7466ddd882f973ba55f655f041c38fd44a/cosl-1.10.3-py3-none-any.whl", hash = "sha256:7e514b161ca3d227a23c88377138176e16f23aff92bf218837bc3551dba1ebf7", size = 41094, upload-time = "2026-08-14T18:17:07.87Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Every reconcile runs `update-ca-certificates --fresh`, which rehashes the whole system trust bundle and costs ~2.6 s, even though the certificates almost never change. This makes the ["third offender" measured in the reconcile profiling](https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/347): with a warm cache it is ~54% of the event time.


## Solution
<!-- A summary of the solution addressing the above issue -->

Stamp the trust store with a hash of everything that feeds it, and skip `update-ca-certificates --fresh` when that hash is unchanged:

- `refresh_certs` reads the stamp and only runs the command when the input hash differs; the stamp is written only after a successful run, so a failed refresh is retried.
- `receive_server_cert` now includes the CA cert in its returned hash, so a CA-only rotation is detected too (and triggers the `_reload` restart).
- Unit test covering the CA-only rotation scenario.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

`update-ca-certificates --fresh` rebuilds the entire `/etc/ssl/certs` bundle; on a warm reconcile it accounts for ~2.6 s of Pebble time. The stamp lives in the workload container, so a recreated pod drops it and the trust store is rebuilt on the next reconcile. The input hash covers every cert that feeds the trust store: the `receive-ca-cert` CAs and the server cert, key and CA.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

```shell
tox -e unit -- tests/unit/test_tls_certificates.py
```

Manual: deploy the charm, run a couple of reconciles and confirm `update-ca-certificates --fresh` only executes when the receive-ca-cert/server-cert relations actually change.

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->

The stamp does not exist before this change, so the first reconcile after upgrade runs `update-ca-certificates` once; afterwards it only runs when the certs change. No user-visible behaviour change.