### PR TITLE
fix: skip unreadable relations when forwarding dashboards

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -482,16 +482,21 @@ def _add_dashboards(dashboards: List[Dict[str, str]], dest_path: Path):
             logger.debug("updated dashboard file %s", f.name)
 
 
-def _safe_relations(charm: CharmBase, endpoint: str) -> List[Relation]:
-    """Return the relations of an endpoint, or an empty list if they cannot be listed.
+def _safe_relations(charm: CharmBase, endpoint: str) -> Optional[List[Relation]]:
+    """Return the relations of an endpoint, or None if they cannot be listed.
 
     Constructing the Relation objects of an endpoint can fail with a
     "permission denied" ModelError if one of the relations is gone (e.g. a
     cross-model relation removed while this unit was running a hook): ops
     calls `relation-list` from `Relation.__init__`, and Juju denies access
-    to the gone relation instead of reporting it as missing. Degrade to no
-    relations until the next event, which re-reconciles once the relation is
-    fully removed.
+    to the gone relation instead of reporting it as missing. Since ops builds
+    every relation of the endpoint in one go, a single dangling relation makes
+    the whole endpoint unreadable.
+
+    ``None`` means "unknown", which callers must not confuse with "no
+    relations": the data received over the healthy relations of the endpoint
+    is still valid, so it must be left untouched rather than recomputed from
+    an empty list.
 
     TODO: remove once canonical/operator#2709 is resolved.
     """
@@ -500,12 +505,9 @@ def _safe_relations(charm: CharmBase, endpoint: str) -> List[Relation]:
     except ModelError as e:
         if not (msg := _permission_denied_message(e)):
             raise
-        logger.warning(
-            "skipping the %s relations this run: %s",
-            endpoint,
-            msg.strip(),
-        )
-        return []
+
+        logger.warning("cannot list the %s relations: %s", endpoint, msg.strip())
+        return None
 
 
 def forward_dashboards(charm: CharmBase):
@@ -521,9 +523,18 @@ def forward_dashboards(charm: CharmBase):
     if not charm.unit.is_leader():
         return
 
+    consumer_relations = _safe_relations(charm, "grafana-dashboards-consumer")
+    if consumer_relations is None:
+        # The received dashboards are unknown this run, which is not the same as
+        # "there are no dashboards": rewriting the databag now would delete from
+        # Grafana the dashboards of the healthy relations, which are still valid.
+        # Leave the previously published dashboards in place instead.
+        logger.warning("skipping the dashboards sync this run: no dashboards were deleted")
+        return
+
     shutil.copytree(src_path, dest_path, dirs_exist_ok=True)
     _add_dashboards(
-        dashboards=_get_dashboards(_safe_relations(charm, "grafana-dashboards-consumer")),
+        dashboards=_get_dashboards(consumer_relations),
         dest_path=dest_path,
     )
 

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -404,6 +404,19 @@ def send_charm_traces(charm: CharmBase) -> Optional[str]:
     charm.__setattr__("charm_tracing_requirer", charm_tracing_requirer)
 
 
+def _permission_denied_message(e: ModelError) -> Optional[str]:
+    """Return the error message if it is a Juju permission-denied error, else None.
+
+    Workaround for https://github.com/canonical/operator/issues/2709: ops maps the
+    "relation not found" flavor to RelationNotFoundError, but accessing a relation
+    that is gone from state fails with a plain ModelError("permission denied").
+    This helper and the guards that use it can be removed once that issue is
+    resolved and ops maps this flavor to a typed exception.
+    """
+    msg = str(e.args[0]) if e.args else ""
+    return msg if "permission denied" in msg else None
+
+
 def _get_dashboards(relations: List[Relation]) -> List[Dict[str, Any]]:
     """Returns a deduplicated list of all dashboards received by this otelcol."""
     aggregate = {}
@@ -413,18 +426,15 @@ def _get_dashboards(relations: List[Relation]) -> List[Dict[str, Any]]:
         try:
             dashboards = json.loads(rel.data[rel.app].get("dashboards", "{}"))  # type: ignore
         except ModelError as e:
-            # Reading the remote application databag fails with "permission denied"
-            # if the relation is gone or dangling (e.g. a cross-model relation that
-            # was removed while this unit was running a hook), in which case Juju
-            # denies access instead of returning the (stale) data.
-            msg = e.args[0] if e.args else e
-            if isinstance(msg, bytes):
-                msg = msg.decode("utf-8", errors="replace")
-            if "permission denied" in str(msg):
+            # The remote application databag is unreadable ("permission denied") if
+            # the relation is gone or dangling: skip it and let the next event
+            # re-reconcile once it is fully removed.
+            # TODO: remove once canonical/operator#2709 is resolved.
+            if msg := _permission_denied_message(e):
                 logger.warning(
                     "skipping relation %s: remote application data is not readable (%s)",
                     rel.id,
-                    str(msg).strip(),
+                    msg.strip(),
                 )
                 continue
             raise
@@ -472,6 +482,32 @@ def _add_dashboards(dashboards: List[Dict[str, str]], dest_path: Path):
             logger.debug("updated dashboard file %s", f.name)
 
 
+def _safe_relations(charm: CharmBase, endpoint: str) -> List[Relation]:
+    """Return the relations of an endpoint, or an empty list if they cannot be listed.
+
+    Constructing the Relation objects of an endpoint can fail with a
+    "permission denied" ModelError if one of the relations is gone (e.g. a
+    cross-model relation removed while this unit was running a hook): ops
+    calls `relation-list` from `Relation.__init__`, and Juju denies access
+    to the gone relation instead of reporting it as missing. Degrade to no
+    relations until the next event, which re-reconciles once the relation is
+    fully removed.
+
+    TODO: remove once canonical/operator#2709 is resolved.
+    """
+    try:
+        return charm.model.relations[endpoint]
+    except ModelError as e:
+        if not (msg := _permission_denied_message(e)):
+            raise
+        logger.warning(
+            "skipping the %s relations this run (%s); they will be retried on the next event",
+            endpoint,
+            msg.strip(),
+        )
+        return []
+
+
 def forward_dashboards(charm: CharmBase):
     """Instantiate the GrafanaDashboardProvider and update the dashboards in the relation databag.
 
@@ -487,7 +523,7 @@ def forward_dashboards(charm: CharmBase):
 
     shutil.copytree(src_path, dest_path, dirs_exist_ok=True)
     _add_dashboards(
-        dashboards=_get_dashboards(charm.model.relations["grafana-dashboards-consumer"]),
+        dashboards=_get_dashboards(_safe_relations(charm, "grafana-dashboards-consumer")),
         dest_path=dest_path,
     )
 

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -63,7 +63,7 @@ from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
 from cosl.rules import JujuTopology
 from cosl.utils import LZMABase64
 from ops import CharmBase, Container, tracing
-from ops.model import Relation
+from ops.model import ModelError, Relation
 
 from config_builder import Port, sha256
 from constants import (
@@ -408,7 +408,26 @@ def _get_dashboards(relations: List[Relation]) -> List[Dict[str, Any]]:
     """Returns a deduplicated list of all dashboards received by this otelcol."""
     aggregate = {}
     for rel in relations:
-        dashboards = json.loads(rel.data[rel.app].get("dashboards", "{}"))  # type: ignore
+        if not rel.app:
+            continue
+        try:
+            dashboards = json.loads(rel.data[rel.app].get("dashboards", "{}"))  # type: ignore
+        except ModelError as e:
+            # Reading the remote application databag fails with "permission denied"
+            # if the relation is gone or dangling (e.g. a cross-model relation that
+            # was removed while this unit was running a hook), in which case Juju
+            # denies access instead of returning the (stale) data.
+            msg = e.args[0] if e.args else e
+            if isinstance(msg, bytes):
+                msg = msg.decode("utf-8", errors="replace")
+            if "permission denied" in str(msg):
+                logger.warning(
+                    "skipping relation %s: remote application data is not readable (%s)",
+                    rel.id,
+                    str(msg).strip(),
+                )
+                continue
+            raise
         if "templates" not in dashboards:
             continue
         for template in dashboards["templates"]:

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -501,7 +501,7 @@ def _safe_relations(charm: CharmBase, endpoint: str) -> List[Relation]:
         if not (msg := _permission_denied_message(e)):
             raise
         logger.warning(
-            "skipping the %s relations this run (%s); they will be retried on the next event",
+            "skipping the %s relations this run: %s",
             endpoint,
             msg.strip(),
         )

--- a/tests/unit/test_dashboard_transfer.py
+++ b/tests/unit/test_dashboard_transfer.py
@@ -4,9 +4,16 @@
 """Feature: Dashboard forwarding to Grafana."""
 
 import json
+from unittest.mock import MagicMock, patch
 
+import pytest
 from cosl import LZMABase64
+from ops.model import ModelError
 from ops.testing import Container, Relation, State
+from scenario.errors import UncaughtCharmError
+from scenario.mocking import _MockModelBackend
+
+from src.integrations import _get_dashboards
 
 
 def encode_as_dashboard(dct: dict):
@@ -58,3 +65,148 @@ def test_dashboard_propagation(ctx, execs):
                 assert "file:juju_file:dashboard-0-some-charm-100" in dashboard_str
                 assert "file:juju_file:dashboard-1-some-charm-101" in dashboard_str
                 assert "file:overview-dashboard" in dashboard_str
+
+
+DANGLING_RELATION_ID = 453
+
+# Captured at import time, before any patching, so the patched method can delegate
+# healthy reads to the original implementation.
+_original_relation_get = _MockModelBackend.relation_get
+
+
+def _good_relation(rel_id: int) -> MagicMock:
+    content = encode_as_dashboard({"whoami": str(rel_id)})
+    rel = MagicMock()
+    rel.id = rel_id
+    rel.app.name = "some-charm"
+    rel.data = {rel.app: {"dashboards": json.dumps(
+        {"templates": {f"file:dashboard-{rel_id}": {"charm": "some-charm", "content": content}}}
+    )}}
+    return rel
+
+def _unreadable_remote_databag(error: Exception):
+    """Build a _MockModelBackend.relation_get patch simulating a dangling relation.
+
+    In Juju, reading the remote application databag of a relation that is gone
+    (e.g. a removed cross-model relation) fails with "permission denied" instead
+    of returning the (stale) data.
+    """
+
+    def relation_get(
+        self: _MockModelBackend,
+        relation_id: int,
+        member_name: str,
+        is_app: bool,
+        *,
+        relation_name: str | None = None,
+    ):
+        if relation_id == DANGLING_RELATION_ID and is_app:
+            raise error
+        return _original_relation_get(
+            self, relation_id, member_name, is_app, relation_name=relation_name
+        )
+
+    return relation_get
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ModelError("ERROR permission denied "),
+        ModelError(b"ERROR permission denied\n"),
+    ],
+)
+def test_dashboard_propagation_with_dangling_relation(ctx, execs, error):
+    """Scenario: Dashboards are forwarded even if a dangling relation's remote databag is unreadable."""
+    # GIVEN a healthy remote charm with a dashboard
+    data = {
+        idx: {
+            "templates": {
+                f"file:dashboard-{idx}": {
+                    "charm": "some-charm",
+                    "content": encode_as_dashboard({"whoami": str(idx)}),
+                }
+            }
+        }
+        for idx in (0, 1)
+    }
+    consumer_healthy = Relation(
+        "grafana-dashboards-consumer",
+        remote_app_data={"dashboards": json.dumps(data[0])},
+        id=100,
+    )
+    # AND a dangling cross-model relation: still listed by Juju, but its remote
+    # application databag cannot be read (e.g. it was removed while this unit
+    # was running a hook)
+    consumer_dangling = Relation(
+        "grafana-dashboards-consumer",
+        remote_app_name="remote-8cdadb5a13d943d9868d3ed7ccc330ad",
+        remote_app_data={"dashboards": json.dumps(data[1])},
+        id=DANGLING_RELATION_ID,
+    )
+    # AND otelcol is related to a Grafana instance
+    provider = Relation("grafana-dashboards-provider")
+
+    state = State(
+        relations=[consumer_healthy, consumer_dangling, provider],
+        leader=True,
+        containers=[Container("otelcol", can_connect=True, execs=execs)],
+    )
+    # WHEN any event executes the reconciler
+    with patch.object(_MockModelBackend, "relation_get", _unreadable_remote_databag(error)):
+        with ctx(ctx.on.update_status(), state=state) as mgr:
+            state_out = mgr.run()
+    # THEN Grafana receives otelcol's bundled dashboard and the healthy relation's dashboard
+    for rel in state_out.relations:
+        if "-provider" in rel.endpoint:
+            dashboard_str = rel.local_app_data["dashboards"]
+            assert "file:juju_file:dashboard-0-some-charm-100" in dashboard_str
+            assert "file:overview-dashboard" in dashboard_str
+            # AND the dangling relation's dashboard is not forwarded
+            assert "dashboard-1" not in dashboard_str
+
+
+def test_unexpected_model_error_fails_the_hook(ctx, execs):
+    """Scenario: Unexpected ModelErrors while reading dashboards fail the hook."""
+    # GIVEN a dangling relation whose remote application databag read fails
+    # with an unexpected error (not "permission denied")
+    consumer_dangling = Relation(
+        "grafana-dashboards-consumer",
+        remote_app_name="remote-8cdadb5a13d943d9868d3ed7ccc330ad",
+        id=DANGLING_RELATION_ID,
+    )
+
+    state = State(
+        relations=[consumer_dangling, Relation("grafana-dashboards-provider")],
+        leader=True,
+        containers=[Container("otelcol", can_connect=True, execs=execs)],
+    )
+    # WHEN any event executes the reconciler
+    with patch.object(
+        _MockModelBackend,
+        "relation_get",
+        _unreadable_remote_databag(ModelError("something else")),
+    ):
+        # THEN the hook fails with an uncaught charm error
+        # (this charm reconciles in __init__, so the error surfaces on context entry)
+        with pytest.raises(UncaughtCharmError):
+            with ctx(ctx.on.update_status(), state=state) as mgr:
+                mgr.run()
+
+
+def test_unreadable_remote_databag_without_app_is_skipped():
+    """A relation without a remote app (e.g. breaking) is skipped, not fatal.
+
+    Kept as a direct test because Scenario cannot represent a relation whose
+    remote application is unknown.
+    """
+    # GIVEN a relation whose remote app is gone (e.g. while breaking)
+    gone = MagicMock()
+    gone.app = None
+    # AND a healthy relation with a dashboard
+    healthy = _good_relation(100)
+    # WHEN the dashboards are collected
+    dashboards = _get_dashboards([gone, healthy])
+    # THEN the app-less relation is skipped and the healthy dashboard is returned
+    assert [dash["title"] for dash in dashboards] == ["file:dashboard-100"]
+

--- a/tests/unit/test_dashboard_transfer.py
+++ b/tests/unit/test_dashboard_transfer.py
@@ -9,11 +9,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 from cosl import LZMABase64
 from ops.model import ModelError
-from ops.testing import Container, Relation, State
+from ops.testing import Container, Exec, Relation, State
 from scenario.errors import UncaughtCharmError
 from scenario.mocking import _MockModelBackend
 
 from src.integrations import _get_dashboards
+
+DANGLING_RELATION_ID = 453
+
+# The error Juju returns for hook commands on a relation that is gone from state.
+PERMISSION_DENIED_ERROR = ModelError("ERROR permission denied ")
+
+# Captured at import time, before any patching, so the patched methods can
+# delegate healthy calls to the original implementation.
+_original_relation_get = _MockModelBackend.relation_get
+_original_relation_list = _MockModelBackend.relation_list
 
 
 def encode_as_dashboard(dct: dict):
@@ -67,13 +77,6 @@ def test_dashboard_propagation(ctx, execs):
                 assert "file:overview-dashboard" in dashboard_str
 
 
-DANGLING_RELATION_ID = 453
-
-# Captured at import time, before any patching, so the patched method can delegate
-# healthy reads to the original implementation.
-_original_relation_get = _MockModelBackend.relation_get
-
-
 def _good_relation(rel_id: int) -> MagicMock:
     content = encode_as_dashboard({"whoami": str(rel_id)})
     rel = MagicMock()
@@ -84,41 +87,68 @@ def _good_relation(rel_id: int) -> MagicMock:
     )}}
     return rel
 
-def _unreadable_remote_databag(error: Exception):
-    """Build a _MockModelBackend.relation_get patch simulating a dangling relation.
+
+def _permission_denied_relation_get(
+    self: _MockModelBackend,
+    relation_id: int,
+    member_name: str,
+    is_app: bool,
+    *,
+    relation_name: str | None = None,
+):
+    """Simulate a dangling relation whose remote application databag is unreadable.
 
     In Juju, reading the remote application databag of a relation that is gone
     (e.g. a removed cross-model relation) fails with "permission denied" instead
     of returning the (stale) data.
     """
-
-    def relation_get(
-        self: _MockModelBackend,
-        relation_id: int,
-        member_name: str,
-        is_app: bool,
-        *,
-        relation_name: str | None = None,
-    ):
-        if relation_id == DANGLING_RELATION_ID and is_app:
-            raise error
-        return _original_relation_get(
-            self, relation_id, member_name, is_app, relation_name=relation_name
-        )
-
-    return relation_get
+    if relation_id == DANGLING_RELATION_ID and is_app:
+        raise PERMISSION_DENIED_ERROR
+    return _original_relation_get(self, relation_id, member_name, is_app, relation_name=relation_name)
 
 
-@pytest.mark.parametrize(
-    "error",
-    [
-        ModelError("ERROR permission denied "),
-        ModelError(b"ERROR permission denied\n"),
-    ],
-)
-def test_dashboard_propagation_with_dangling_relation(ctx, execs, error):
-    """Scenario: Dashboards are forwarded even if a dangling relation's remote databag is unreadable."""
-    # GIVEN a healthy remote charm with a dashboard
+def _permission_denied_relation_list(
+    self: _MockModelBackend,
+    relation_id: int,
+    *,
+    relation_name: str | None = None,
+):
+    """Simulate a dangling relation whose units cannot even be listed.
+
+    In Juju, listing the units of a relation that is gone can also fail with
+    "permission denied", which makes the construction of the Relation object
+    itself fail: ops calls `relation-list` from `Relation.__init__` when the
+    charm first accesses `model.relations` for the endpoint.
+    """
+    if relation_id == DANGLING_RELATION_ID:
+        raise PERMISSION_DENIED_ERROR
+    return _original_relation_list(self, relation_id, relation_name=relation_name)
+
+
+def _unexpected_error_relation_get(
+    self: _MockModelBackend,
+    relation_id: int,
+    member_name: str,
+    is_app: bool,
+    *,
+    relation_name: str | None = None,
+):
+    """Simulate a dangling relation whose databag read fails unexpectedly.
+
+    The error is a ModelError, but not the "permission denied" flavor.
+    """
+    if relation_id == DANGLING_RELATION_ID and is_app:
+        raise ModelError("something else")
+    return _original_relation_get(self, relation_id, member_name, is_app, relation_name=relation_name)
+
+
+def _state_with_dangling_relation(execs: set[Exec]) -> State:
+    """Return a state with a healthy and a dangling dashboard relation.
+
+    A leader unit receiving a dashboard over a healthy relation and a dangling
+    cross-model relation, related to a Grafana instance. The dangling relation
+    carries a dashboard too, to prove that it is never forwarded.
+    """
     data = {
         idx: {
             "templates": {
@@ -135,25 +165,29 @@ def test_dashboard_propagation_with_dangling_relation(ctx, execs, error):
         remote_app_data={"dashboards": json.dumps(data[0])},
         id=100,
     )
-    # AND a dangling cross-model relation: still listed by Juju, but its remote
-    # application databag cannot be read (e.g. it was removed while this unit
-    # was running a hook)
     consumer_dangling = Relation(
         "grafana-dashboards-consumer",
         remote_app_name="remote-8cdadb5a13d943d9868d3ed7ccc330ad",
         remote_app_data={"dashboards": json.dumps(data[1])},
         id=DANGLING_RELATION_ID,
     )
-    # AND otelcol is related to a Grafana instance
     provider = Relation("grafana-dashboards-provider")
-
-    state = State(
+    return State(
         relations=[consumer_healthy, consumer_dangling, provider],
         leader=True,
         containers=[Container("otelcol", can_connect=True, execs=execs)],
     )
-    # WHEN any event executes the reconciler
-    with patch.object(_MockModelBackend, "relation_get", _unreadable_remote_databag(error)):
+
+
+def test_dashboard_propagation_with_dangling_relation(ctx, execs):
+    """Scenario: Dashboards are forwarded even if a dangling relation's remote databag is unreadable."""
+    # GIVEN a healthy relation with a dashboard, a dangling cross-model relation
+    # (which also carries a dashboard), and a Grafana instance to forward them to
+    state = _state_with_dangling_relation(execs)
+    # WHEN any event executes the reconciler while the dangling relation's remote
+    # application databag cannot be read (e.g. it was removed while this unit
+    # was running a hook)
+    with patch.object(_MockModelBackend, "relation_get", _permission_denied_relation_get):
         with ctx(ctx.on.update_status(), state=state) as mgr:
             state_out = mgr.run()
     # THEN Grafana receives otelcol's bundled dashboard and the healthy relation's dashboard
@@ -163,6 +197,33 @@ def test_dashboard_propagation_with_dangling_relation(ctx, execs, error):
             assert "file:juju_file:dashboard-0-some-charm-100" in dashboard_str
             assert "file:overview-dashboard" in dashboard_str
             # AND the dangling relation's dashboard is not forwarded
+            assert "dashboard-1" not in dashboard_str
+
+
+def test_hook_survives_when_listing_the_dangling_relation_fails(ctx, execs):
+    """Scenario: The hook survives even if listing a dangling relation's units fails.
+
+    A dangling relation can be in a state where even `relation-list` is
+    denied ("permission denied"), so the construction of the endpoint's
+    Relation objects fails when the charm first accesses `model.relations`.
+    The endpoint is then treated as empty for this run; dashboards flow
+    again on the next event, once the relation is fully removed.
+    """
+    # GIVEN a healthy relation with a dashboard, a dangling cross-model relation
+    # (which also carries a dashboard), and a Grafana instance to forward them to
+    state = _state_with_dangling_relation(execs)
+    # WHEN any event executes the reconciler while the dangling relation's units
+    # cannot even be listed (e.g. `relation-list` denied during its teardown)
+    with patch.object(_MockModelBackend, "relation_list", _permission_denied_relation_list):
+        with ctx(ctx.on.update_status(), state=state) as mgr:
+            state_out = mgr.run()
+    # THEN the hook does not fail and Grafana receives otelcol's bundled dashboard
+    for rel in state_out.relations:
+        if "-provider" in rel.endpoint:
+            dashboard_str = rel.local_app_data["dashboards"]
+            assert "file:overview-dashboard" in dashboard_str
+            # AND no dashboard from this endpoint is forwarded until the next event
+            assert "dashboard-0" not in dashboard_str
             assert "dashboard-1" not in dashboard_str
 
 
@@ -182,11 +243,7 @@ def test_unexpected_model_error_fails_the_hook(ctx, execs):
         containers=[Container("otelcol", can_connect=True, execs=execs)],
     )
     # WHEN any event executes the reconciler
-    with patch.object(
-        _MockModelBackend,
-        "relation_get",
-        _unreadable_remote_databag(ModelError("something else")),
-    ):
+    with patch.object(_MockModelBackend, "relation_get", _unexpected_error_relation_get):
         # THEN the hook fails with an uncaught charm error
         # (this charm reconciles in __init__, so the error surfaces on context entry)
         with pytest.raises(UncaughtCharmError):

--- a/tests/unit/test_dashboard_transfer.py
+++ b/tests/unit/test_dashboard_transfer.py
@@ -4,6 +4,7 @@
 """Feature: Dashboard forwarding to Grafana."""
 
 import json
+from typing import Dict, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -142,12 +143,18 @@ def _unexpected_error_relation_get(
     return _original_relation_get(self, relation_id, member_name, is_app, relation_name=relation_name)
 
 
-def _state_with_dangling_relation(execs: set[Exec]) -> State:
+def _state_with_dangling_relation(
+    execs: set[Exec], provider_app_data: Optional[Dict[str, str]] = None
+) -> State:
     """Return a state with a healthy and a dangling dashboard relation.
 
     A leader unit receiving a dashboard over a healthy relation and a dangling
     cross-model relation, related to a Grafana instance. The dangling relation
     carries a dashboard too, to prove that it is never forwarded.
+
+    Args:
+        execs: the container execs the charm is allowed to run.
+        provider_app_data: the dashboards already published to Grafana, if any.
     """
     data = {
         idx: {
@@ -171,7 +178,7 @@ def _state_with_dangling_relation(execs: set[Exec]) -> State:
         remote_app_data={"dashboards": json.dumps(data[1])},
         id=DANGLING_RELATION_ID,
     )
-    provider = Relation("grafana-dashboards-provider")
+    provider = Relation("grafana-dashboards-provider", local_app_data=provider_app_data or {})
     return State(
         relations=[consumer_healthy, consumer_dangling, provider],
         leader=True,
@@ -200,31 +207,61 @@ def test_dashboard_propagation_with_dangling_relation(ctx, execs):
             assert "dashboard-1" not in dashboard_str
 
 
-def test_hook_survives_when_listing_the_dangling_relation_fails(ctx, execs):
-    """Scenario: The hook survives even if listing a dangling relation's units fails.
+def test_already_forwarded_dashboards_survive_when_listing_relations_fails(ctx, execs):
+    """Scenario: A dangling relation does not delete the dashboards already sent to Grafana.
 
-    A dangling relation can be in a state where even `relation-list` is
-    denied ("permission denied"), so the construction of the endpoint's
-    Relation objects fails when the charm first accesses `model.relations`.
-    The endpoint is then treated as empty for this run; dashboards flow
-    again on the next event, once the relation is fully removed.
+    A dangling relation can be in a state where even `relation-list` is denied
+    ("permission denied"), so the construction of the endpoint's Relation
+    objects fails when the charm first accesses `model.relations`. Since ops
+    builds the whole endpoint at once, the received dashboards are unknown for
+    this run, which is not the same as "there are no dashboards": republishing
+    an empty set would delete from Grafana the dashboards of the healthy
+    relations, which are still valid. The previously published dashboards are
+    left untouched instead.
     """
-    # GIVEN a healthy relation with a dashboard, a dangling cross-model relation
-    # (which also carries a dashboard), and a Grafana instance to forward them to
+    # GIVEN dashboards already published to Grafana
+    already_published = {
+        "templates": {
+            "file:juju_file:dashboard-0-some-charm-100": {
+                "charm": "some-charm",
+                "content": encode_as_dashboard({"whoami": "0"}),
+            },
+            "file:overview-dashboard": {
+                "charm": "opentelemetry-collector-k8s",
+                "content": encode_as_dashboard({"whoami": "overview"}),
+            },
+        },
+        "uuid": "some-uuid",
+    }
+    provider_app_data = {"dashboards": json.dumps(already_published)}
+    # AND a healthy relation with a dashboard and a dangling cross-model relation
+    state = _state_with_dangling_relation(execs, provider_app_data=provider_app_data)
+    # WHEN any event executes the reconciler while the dangling relation's units
+    # cannot even be listed (e.g. `relation-list` denied during its teardown)
+    with patch.object(_MockModelBackend, "relation_list", _permission_denied_relation_list):
+        with ctx(ctx.on.update_status(), state=state) as mgr:
+            state_out = mgr.run()
+    # THEN the hook does not fail and the published dashboards are left untouched
+    for rel in state_out.relations:
+        if "-provider" in rel.endpoint:
+            assert rel.local_app_data == provider_app_data
+
+
+def test_hook_survives_when_listing_the_dangling_relation_fails(ctx, execs):
+    """Scenario: The hook survives even if listing a dangling relation's units fails."""
+    # GIVEN nothing has been forwarded to Grafana yet
     state = _state_with_dangling_relation(execs)
     # WHEN any event executes the reconciler while the dangling relation's units
     # cannot even be listed (e.g. `relation-list` denied during its teardown)
     with patch.object(_MockModelBackend, "relation_list", _permission_denied_relation_list):
         with ctx(ctx.on.update_status(), state=state) as mgr:
             state_out = mgr.run()
-    # THEN the hook does not fail and Grafana receives otelcol's bundled dashboard
+    # THEN the hook does not fail and nothing is published for this endpoint,
+    # not even otelcol's bundled dashboards: they are forwarded on the next
+    # event, once the dangling relation is fully removed
     for rel in state_out.relations:
         if "-provider" in rel.endpoint:
-            dashboard_str = rel.local_app_data["dashboards"]
-            assert "file:overview-dashboard" in dashboard_str
-            # AND no dashboard from this endpoint is forwarded until the next event
-            assert "dashboard-0" not in dashboard_str
-            assert "dashboard-1" not in dashboard_str
+            assert "dashboards" not in rel.local_app_data
 
 
 def test_unexpected_model_error_fails_the_hook(ctx, execs):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Fixes #355
Related to https://github.com/canonical/operator/issues/2575

`_get_dashboards()` reads the remote application databag (`rel.data[rel.app]`) of every relation on `grafana-dashboards-consumer` on every hook. When one of those relations is gone or dangling (e.g. a cross-model relation in teardown), Juju's `relation-get --app` fails with `permission denied`, which crashes the whole reconcile and leaves the unit in `error` status.

## Solution
<!-- A summary of the solution addressing the above issue -->

Make `_get_dashboards()` resilient to unreadable relations:

- Skip relations with no known remote app.
- Catch `ModelError` and, if the message is a Juju `permission denied` (str or bytes), log a warning and skip that relation; dashboards from the remaining relations are still forwarded. Any other error is re-raised. This follows the same pattern already used by the vendored `tempo_coordinator_k8s/v0/tracing.py`.
- Scenario regression tests simulate the dangling relation by patching `_MockModelBackend.relation_get` and run a real reconcile through the charm.


### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

- Juju returns `permission denied` (not `not found`) from `relation-get --app <remote-app>` when the relation no longer exists in state (see [`getRemoteRelationAppSettings` in `apiserver/facades/agent/uniter/uniter.go`](https://github.com/juju/juju/blob/8f61c6be244b734bf669819351ff7601d0425876/apiserver/facades/agent/uniter/uniter.go#L1802) in juju/juju). This happens with dangling relations: a cross-model relation being torn down, `remove-saas`/`remove-relation --force`, or an application removed with `--force`.
- Reading the remote app databag of a live relation that simply has no data yet returns `{}`, so this error really means "the relation is gone". The `remote-<uuid>` remote app name in the traceback is the local view of a cross-model relation.
- Scenario cannot represent a relation whose databag read fails (databags are plain dicts in `State`), hence the `_MockModelBackend.relation_get` patch in the tests.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

```shell
tox -e unit -- tests/unit/test_dashboard_transfer.py
```

Manual: relate a dashboard provider over a cross-model offer, remove the SAAS while the unit
is running hooks, and confirm the unit stays `active` and other dashboards keep flowing to
Grafana.

