### PR TITLE
fix: distribute incoming telemetry across units instead of duplicating it

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,6 @@
 import logging
 import os
 import re
-import socket
 from typing import Any, Dict, List, Optional, cast
 
 from charmlibs.pathops import ContainerPath
@@ -41,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 def charm_address(
+    charm: CharmBase,
     container: Container,
     traefik_ingress: integrations.TraefikRouteRequirer,
     istio_ingress: integrations.IstioIngressRouteRequirer,
@@ -48,6 +48,7 @@ def charm_address(
     """Return the Address dataclass from charm context.
 
     Args:
+        charm: the otel-collector charm object
         container: An ops.Container where the TLS certificates exist
         traefik_ingress: A TraefikRouteRequirer containing ingress context
         istio_ingress: An IstioIngressRouteRequirer containing ingress context
@@ -71,7 +72,7 @@ def charm_address(
         external_tls = False
         external_host = None
 
-    internal_host = socket.getfqdn()
+    internal_host = integrations.internal_host(charm, container)
     internal_tls = integrations.is_tls_ready(container)
     resolved_host = external_host if external_host else internal_host
     return integrations.Address(
@@ -230,7 +231,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
 
         # Address manager
         # NOTE: executed after ingress and TLS events
-        otelcol_address = charm_address(container, traefik_ingress, istio_ingress)
+        otelcol_address = charm_address(self, container, traefik_ingress, istio_ingress)
         match otelcol_address:
             case integrations.MultipleIngressesConfigured():
                 self.unit.status = BlockedStatus(otelcol_address.message)
@@ -267,7 +268,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             queue_size=cast(int, self.config.get("queue_size")),
             max_elapsed_time_min=cast(int, self.config.get("max_elapsed_time_min")),
             unit_name=self.unit.name,
-            internal_host=socket.getfqdn(),
+            self_telemetry_host=integrations.unit_fqdn(),
             topology_labels=topology_labels,
         )
 
@@ -322,16 +323,14 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         # Profiling setup
         if self._incoming_profiles:
             config_manager.add_profile_ingestion()
-            integrations.receive_profiles(self, integrations.is_tls_ready(container))
+            integrations.receive_profiles(self, otelcol_address)
         if profiling_endpoints := integrations.send_profiles(self):
             config_manager.add_profile_forwarding(profiling_endpoints)
         if self._incoming_profiles or integrations.send_profiles(self):
             feature_gates = "service.profilesSupport"
 
         # Tracing setup
-        requested_tracing_protocols = integrations.receive_traces(
-            self, integrations.is_tls_ready(container)
-        )
+        requested_tracing_protocols = integrations.receive_traces(self, otelcol_address)
         if self._incoming_traces:
             config_manager.add_traces_ingestion(requested_tracing_protocols)
             # Add default processors to traces
@@ -409,16 +408,25 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         if integrations.cyclic_otlp_relations_exist(self):
             self.unit.status = BlockedStatus("cyclic OTLP relations exist")
 
-        # Ingress and scaling status
-        if self.model.unit.is_leader():
-            if self.app.planned_units() > 1 and not otelcol_address.ingress:
-                self.unit.status = BlockedStatus(
-                    "Ingress missing - routing only to leader; see debug-log"
-                )
-                logger.warning(
-                    "without ingress and planned_units > 1, all data is forwarded to the leader "
-                    "unit, with nothing sent to non-leader units."
-                )
+        # Scaling status
+        # Traffic is normally addressed to the Kubernetes Service, which load-balances over
+        # all units. The exception is a TLS deployment whose certificate does not list the
+        # Service name yet: until the CA issues the widened certificate we must keep
+        # advertising this pod, so all traffic lands on the leader.
+        if (
+            self.app.planned_units() > 1
+            and not otelcol_address.ingress
+            and otelcol_address.resolved_host != integrations.service_fqdn(self)
+        ):
+            self.unit.status = WaitingStatus(
+                "Waiting for a certificate valid for the Kubernetes Service name"
+            )
+            logger.warning(
+                "The server certificate does not list %s as a SAN, so the pod address is "
+                "advertised instead and all data is routed to the leader unit. This resolves "
+                "itself once the CA issues a certificate for the Kubernetes Service name.",
+                integrations.service_fqdn(self),
+            )
 
         # Invalid alert rules
         if self._has_invalid_prometheus_alerts():

--- a/src/charm.py
+++ b/src/charm.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 def charm_address(
-    charm: CharmBase,
+    charm: "OpenTelemetryCollectorK8sCharm",
     container: Container,
     traefik_ingress: integrations.TraefikRouteRequirer,
     istio_ingress: integrations.IstioIngressRouteRequirer,
@@ -72,7 +72,7 @@ def charm_address(
         external_tls = False
         external_host = None
 
-    internal_host = integrations.internal_host(charm, container)
+    internal_host = charm.internal_host(container)
     internal_tls = integrations.is_tls_ready(container)
     resolved_host = external_host if external_host else internal_host
     return integrations.Address(
@@ -178,6 +178,47 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         self.external_secret_files: Dict[str, str] = {}
         self._reconcile()
 
+    @property
+    def unit_fqdn(self) -> str:
+        """Return the DNS name of this unit's pod.
+
+        On Kubernetes this resolves to the headless-service address of a single pod, e.g.
+        ``otelcol-0.otelcol-endpoints.mymodel.svc.cluster.local``. It addresses exactly one
+        unit, so it must only be used for unit-local concerns such as the collector's own
+        internal telemetry.
+        """
+        return integrations.unit_fqdn()
+
+    @property
+    def service_fqdn(self) -> str:
+        """Return the DNS name of the Kubernetes Service fronting all units of this app.
+
+        Juju creates a ClusterIP service named after the application, which load-balances
+        across all ready pods. This is the address that must be advertised to remote charms,
+        so that telemetry is distributed over the units instead of being duplicated to each
+        of them (or pinned to the leader).
+        """
+        return f"{self.app.name}.{self.model.name}.svc.cluster.local"
+
+    def internal_host(self, container: Container) -> str:
+        """Return the in-cluster address that remote charms should use to reach this app.
+
+        This is the Kubernetes Service FQDN, so that traffic is load-balanced across units
+        instead of being duplicated to every unit or pinned to the leader.
+
+        When the server is serving TLS, the Service FQDN is only advertised once the
+        certificate on disk actually lists it as a SAN; otherwise clients would fail hostname
+        verification. Until then we keep advertising the pod FQDN, and switch over
+        automatically on the reconcile that follows the arrival of the widened certificate.
+        """
+        if not integrations.is_tls_ready(container):
+            return self.service_fqdn
+        return (
+            self.service_fqdn
+            if self.service_fqdn in integrations.server_cert_sans_dns(container)
+            else self.unit_fqdn
+        )
+
     def _reconcile(self):
         """Recreate the world state for the charm.
 
@@ -210,7 +251,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
 
         # Ingress integration
         traefik_tls = integrations.is_tls_ready(container)
-        traefik_ingress = integrations.setup_traefik_ingress(self, traefik_tls)
+        traefik_ingress = integrations.setup_traefik_ingress(self, self.service_fqdn, traefik_tls)
         istio_ingress = integrations.setup_istio_ingress(self)
 
         # Integrate with TLS relations
@@ -220,6 +261,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         )
         server_cert_hash = integrations.receive_server_cert(
             self,
+            service_fqdn=self.service_fqdn,
             server_cert_path=ContainerPath(SERVER_CERT_PATH, container=container),
             private_key_path=ContainerPath(SERVER_CERT_PRIVATE_KEY_PATH, container=container),
             root_ca_cert_path=ContainerPath(SERVER_CA_CERT_PATH, container=container),
@@ -268,7 +310,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
             queue_size=cast(int, self.config.get("queue_size")),
             max_elapsed_time_min=cast(int, self.config.get("max_elapsed_time_min")),
             unit_name=self.unit.name,
-            self_telemetry_host=integrations.unit_fqdn(),
+            self_telemetry_host=self.unit_fqdn,
             topology_labels=topology_labels,
         )
 
@@ -416,7 +458,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
         if (
             self.app.planned_units() > 1
             and not otelcol_address.ingress
-            and otelcol_address.resolved_host != integrations.service_fqdn(self)
+            and otelcol_address.resolved_host != self.service_fqdn
         ):
             self.unit.status = WaitingStatus(
                 "Waiting for a certificate valid for the Kubernetes Service name"
@@ -425,7 +467,7 @@ class OpenTelemetryCollectorK8sCharm(CharmBase):
                 "The server certificate does not list %s as a SAN, so the pod address is "
                 "advertised instead and all data is routed to the leader unit. This resolves "
                 "itself once the CA issues a certificate for the Kubernetes Service name.",
-                integrations.service_fqdn(self),
+                self.service_fqdn,
             )
 
         # Invalid alert rules

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -98,7 +98,7 @@ class ConfigBuilder:
         global_scrape_timeout: str,
         receiver_tls: bool = False,
         exporter_skip_verify: bool = False,
-        internal_host: str = "localhost",
+        self_telemetry_host: str = "localhost",
         topology_labels: Optional[Dict[str, str]] = None,
     ):
         """Generate an empty OpenTelemetry collector config.
@@ -109,7 +109,10 @@ class ConfigBuilder:
             global_scrape_timeout: value for `scrape_timeout` in all prometheus receivers
             receiver_tls: whether to inject TLS config in all receivers on build
             exporter_skip_verify: value for `insecure_skip_verify` in all exporters
-            internal_host: the unit FQDN the OTLP receiver's server cert is valid for
+            self_telemetry_host: the FQDN of THIS pod, used to loop the collector's own
+                telemetry back into its own OTLP receiver. Must not be the Kubernetes
+                Service FQDN, or a unit's internal telemetry would be load-balanced away
+                to a different unit.
             topology_labels: this collector's own deployment topology. Attached to the collector's
                 internal telemetry so logs from multiple otelcol apps/units are distinguishable.
         """
@@ -129,7 +132,7 @@ class ConfigBuilder:
         self._topology_labels = dict(topology_labels or {})
         self._receiver_tls = receiver_tls
         self._exporter_skip_verify = exporter_skip_verify
-        self._internal_host = internal_host
+        self._self_telemetry_host = self_telemetry_host
         self._scrape_interval = global_scrape_interval
         self._scrape_timeout = global_scrape_timeout
 
@@ -259,7 +262,7 @@ class ConfigBuilder:
         internal_logs_otlp_exporter: Dict[str, Any] = {
             "protocol": "http/protobuf",
             "endpoint": (
-                f"https://{self._internal_host}:{Port.otlp_http.value}"
+                f"https://{self._self_telemetry_host}:{Port.otlp_http.value}"
                 if self._receiver_tls
                 else f"http://localhost:{Port.otlp_http.value}"
             ),

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -114,7 +114,7 @@ class ConfigManager:
         insecure_skip_verify: bool = False,
         queue_size: int = 1000,
         max_elapsed_time_min: int = 5,
-        internal_host: str = "localhost",
+        self_telemetry_host: str = "localhost",
         topology_labels: Optional[Dict[str, str]] = None,
     ):
         """Generate a default OpenTelemetry collector ConfigManager.
@@ -129,7 +129,8 @@ class ConfigManager:
             insecure_skip_verify: value for `insecure_skip_verify` in all exporters
             queue_size: size of the sending queue for exporters
             max_elapsed_time_min: maximum elapsed time for retrying failed requests in minutes
-            internal_host: the unit FQDN the OTLP receiver's server cert is valid for
+            self_telemetry_host: the FQDN of THIS pod, used to loop the collector's own
+                telemetry back into its own OTLP receiver
             topology_labels: this collector's own Juju topology labels, attached to its internal
                 telemetry so logs from multiple otelcol apps/units are distinguishable in Loki
         """
@@ -143,7 +144,7 @@ class ConfigManager:
             global_scrape_timeout=global_scrape_timeout,
             receiver_tls=receiver_tls,
             exporter_skip_verify=insecure_skip_verify,
-            internal_host=internal_host,
+            self_telemetry_host=self_telemetry_host,
             topology_labels=topology_labels,
         )
         self.config.add_default_config()

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -55,6 +55,7 @@ from charms.tempo_coordinator_k8s.v0.tracing import (
     receiver_protocol_to_transport_protocol,
 )
 from charms.tls_certificates_interface.v4.tls_certificates import (
+    Certificate,
     CertificateRequestAttributes,
     Mode,
     TLSCertificatesRequiresV4,
@@ -276,34 +277,33 @@ def send_remote_write(charm: CharmBase) -> List[Dict[str, str]]:
     return sorted(remote_write.endpoints, key=lambda endpoint: endpoint["url"])
 
 
-def _get_tracing_receiver_url(protocol: ReceiverProtocol, tls_enabled: bool) -> str:
+def _get_tracing_receiver_url(protocol: ReceiverProtocol, address: "Address") -> str:
     """Build the endpoint URL for a tracing receiver.
 
     Args:
         protocol: The tracing protocol to build the URL for.
-        tls_enabled: Whether to use HTTPS (True) or HTTP (False) for the URL.
-
+        address: a dataclass for determining network addressing.
 
     Returns:
         str: The complete URL for the tracing receiver endpoint.
 
     Note:
-        The method assumes the receiver is in the same model since the charm
-        doesn't have ingress support. The FQDN is used as the hostname.
+        Without ingress the host is the Kubernetes Service FQDN, so that traces are
+        load-balanced across all units rather than sent to every one of them.
     """
-    scheme = "http"
-    if tls_enabled:
-        scheme = "https"
-
     # The correct transport protocol is specified in the tracing library, and it's always
     # either http or grpc.
     if receiver_protocol_to_transport_protocol[protocol] == TransportProtocolType.grpc:
-        return f"{socket.getfqdn()}:{Port.otlp_grpc.value}"
-    return f"{scheme}://{socket.getfqdn()}:{Port.otlp_http.value}"
+        return f"{address.grpc_resolved_url}:{Port.otlp_grpc.value}"
+    return f"{address.http_resolved_url}:{Port.otlp_http.value}"
 
 
-def receive_traces(charm: CharmBase, tls: bool) -> Set:
+def receive_traces(charm: CharmBase, address: "Address") -> Set:
     """Integrate with other charms via the receive-traces relation endpoint.
+
+    Args:
+        charm: the otel-collector charm object
+        address: a dataclass for determining network addressing
 
     Returns:
         All receiver protocols that have been requested.
@@ -326,10 +326,7 @@ def receive_traces(charm: CharmBase, tls: bool) -> Set:
             tuple(
                 (
                     protocol,
-                    _get_tracing_receiver_url(
-                        protocol=protocol,
-                        tls_enabled=tls,
-                    ),
+                    _get_tracing_receiver_url(protocol=protocol, address=address),
                 )
                 for protocol in sorted(requested_tracing_protocols)
             )
@@ -337,18 +334,17 @@ def receive_traces(charm: CharmBase, tls: bool) -> Set:
     return requested_tracing_protocols
 
 
-def receive_profiles(charm: CharmBase, tls: bool) -> None:
+def receive_profiles(charm: CharmBase, address: "Address") -> None:
     """Integrate with other charms over the receive-profiles relation endpoint."""
     if not charm.unit.is_leader():
         # TODO: leader-only because of
         #  https://github.com/canonical/opentelemetry-collector-operator/issues/71
         return
-    fqdn = socket.getfqdn()
-    grpc_endpoint = f"{fqdn}:{Port.otlp_grpc.value}"
+    grpc_endpoint = f"{address.grpc_resolved_url}:{Port.otlp_grpc.value}"
     # this charm lib exposes a holistic API, so we don't need to bind the instance
     ProfilingEndpointProvider(
         charm.model.relations["receive-profiles"], app=charm.app
-    ).publish_endpoint(otlp_grpc_endpoint=grpc_endpoint, insecure=not tls)
+    ).publish_endpoint(otlp_grpc_endpoint=grpc_endpoint, insecure=not address.resolved_tls)
 
 
 def send_profiles(charm: CharmBase) -> List[ProfilingEndpoint]:
@@ -675,8 +671,14 @@ def receive_server_cert(
     """
     # Common name length must be >= 1 and <= 64, so fqdn is too long.
     common_name = charm.unit.name.replace("/", "-")
-    domain = socket.getfqdn()
-    csr_attrs = CertificateRequestAttributes(common_name=common_name, sans_dns=frozenset({domain}))
+    # Every unit gets its own certificate (Mode.UNIT), but each of those certificates must be
+    # valid for BOTH the pod FQDN and the Kubernetes Service FQDN: remote charms are given the
+    # Service FQDN so that traffic is load-balanced, and any unit may end up terminating that
+    # connection.
+    csr_attrs = CertificateRequestAttributes(
+        common_name=common_name,
+        sans_dns=frozenset({unit_fqdn(), service_fqdn(charm)}),
+    )
     certificates = TLSCertificatesRequiresV4(
         charm=charm,
         relationship_name="receive-server-cert",
@@ -796,12 +798,13 @@ def _static_ingress_config() -> dict:
     return {"entryPoints": entry_points}
 
 
-def _build_lb_server_config(scheme: str, port: int) -> List[Dict[str, str]]:
+def _build_lb_server_config(charm: CharmBase, scheme: str, port: int) -> List[Dict[str, str]]:
     """Build the server portion of the loadbalancer config of Traefik ingress.
 
-    The leader provides the kubernetes service address to Traefik to serve as ingress.
+    The leader provides the kubernetes service address to Traefik, so that Traefik
+    balances ingressed traffic across all units instead of pinning it to the leader's pod.
     """
-    return [{"url": f"{scheme}://{socket.getfqdn()}:{port}"}]
+    return [{"url": f"{scheme}://{service_fqdn(charm)}:{port}"}]
 
 
 def is_tls_ready(container: Container) -> bool:
@@ -809,6 +812,58 @@ def is_tls_ready(container: Container) -> bool:
     return container.exists(path=SERVER_CERT_PATH) and container.exists(
         path=SERVER_CERT_PRIVATE_KEY_PATH
     )
+
+
+def unit_fqdn() -> str:
+    """Return the DNS name of this unit's pod.
+
+    On Kubernetes this resolves to the headless-service address of a single pod, e.g.
+    ``otelcol-0.otelcol-endpoints.mymodel.svc.cluster.local``. It addresses exactly one
+    unit, so it must only be used for unit-local concerns such as the collector's own
+    internal telemetry.
+    """
+    return socket.getfqdn()
+
+
+def service_fqdn(charm: CharmBase) -> str:
+    """Return the DNS name of the Kubernetes Service fronting all units of this app.
+
+    Juju creates a ClusterIP service named after the application, which load-balances
+    across all ready pods. This is the address that must be advertised to remote charms,
+    so that telemetry is distributed over the units instead of being duplicated to each
+    of them (or pinned to the leader).
+    """
+    return f"{charm.app.name}.{charm.model.name}.svc.cluster.local"
+
+
+def _server_cert_sans_dns(container: Container) -> Set[str]:
+    """Return the DNS SANs of the server certificate currently on disk.
+
+    Returns an empty set when there is no readable, parsable certificate.
+    """
+    try:
+        raw = cast(str, container.pull(SERVER_CERT_PATH).read())
+        return set(Certificate(raw).sans_dns or set())
+    except Exception:
+        logger.warning("Could not read the SANs of the server certificate on disk")
+        return set()
+
+
+def internal_host(charm: CharmBase, container: Container) -> str:
+    """Return the in-cluster address that remote charms should use to reach this app.
+
+    This is the Kubernetes Service FQDN, so that traffic is load-balanced across units
+    instead of being duplicated to every unit or pinned to the leader.
+
+    When the server is serving TLS, the Service FQDN is only advertised once the
+    certificate on disk actually lists it as a SAN; otherwise clients would fail hostname
+    verification. Until then we keep advertising the pod FQDN, and switch over
+    automatically on the reconcile that follows the arrival of the widened certificate.
+    """
+    service = service_fqdn(charm)
+    if not is_tls_ready(container):
+        return service
+    return service if service in _server_cert_sans_dns(container) else unit_fqdn()
 
 
 class MultipleIngressesConfigured:
@@ -913,7 +968,9 @@ def _traefik_ingress_config(charm: CharmBase, ingress: TraefikRouteRequirer, tls
             f"juju-{charm.model.name}-{charm.model.app.name}-service-{sanitized_protocol}"
         ] = {
             "loadBalancer": {
-                "servers": _build_lb_server_config("http" if not tls else "https", port.value)
+                "servers": _build_lb_server_config(
+                    charm, "http" if not tls else "https", port.value
+                )
             }
         }
 

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -656,6 +656,7 @@ def cloud_integrator(charm: CharmBase) -> CloudIntegratorData:
 
 def receive_server_cert(
     charm: CharmBase,
+    service_fqdn: str,
     server_cert_path: PathProtocol,
     private_key_path: PathProtocol,
     root_ca_cert_path: PathProtocol,
@@ -664,6 +665,14 @@ def receive_server_cert(
 
     Thes key and certs are obtained via the tls_certificates(v4) library, and pushed to the
     workload container.
+
+    Args:
+        charm: the otel-collector charm object
+        service_fqdn: the Kubernetes Service name this app is reachable at, included in the
+            CSR alongside this unit's own pod name
+        server_cert_path: where to write the signed server certificate
+        private_key_path: where to write the private key
+        root_ca_cert_path: where to write the issuing CA certificate
 
     Returns:
         Hash of server cert, private key and CA cert, to be used as reload trigger if it
@@ -677,7 +686,7 @@ def receive_server_cert(
     # connection.
     csr_attrs = CertificateRequestAttributes(
         common_name=common_name,
-        sans_dns=frozenset({unit_fqdn(), service_fqdn(charm)}),
+        sans_dns=frozenset({unit_fqdn(), service_fqdn}),
     )
     certificates = TLSCertificatesRequiresV4(
         charm=charm,
@@ -798,13 +807,13 @@ def _static_ingress_config() -> dict:
     return {"entryPoints": entry_points}
 
 
-def _build_lb_server_config(charm: CharmBase, scheme: str, port: int) -> List[Dict[str, str]]:
+def _build_lb_server_config(service_fqdn: str, scheme: str, port: int) -> List[Dict[str, str]]:
     """Build the server portion of the loadbalancer config of Traefik ingress.
 
     The leader provides the kubernetes service address to Traefik, so that Traefik
     balances ingressed traffic across all units instead of pinning it to the leader's pod.
     """
-    return [{"url": f"{scheme}://{service_fqdn(charm)}:{port}"}]
+    return [{"url": f"{scheme}://{service_fqdn}:{port}"}]
 
 
 def is_tls_ready(container: Container) -> bool:
@@ -825,21 +834,10 @@ def unit_fqdn() -> str:
     return socket.getfqdn()
 
 
-def service_fqdn(charm: CharmBase) -> str:
-    """Return the DNS name of the Kubernetes Service fronting all units of this app.
+def server_cert_sans_dns(container: Container) -> Set[str]:
+    """Return the DNS SANs of the server certificate received over `receive-server-cert`.
 
-    Juju creates a ClusterIP service named after the application, which load-balances
-    across all ready pods. This is the address that must be advertised to remote charms,
-    so that telemetry is distributed over the units instead of being duplicated to each
-    of them (or pinned to the leader).
-    """
-    return f"{charm.app.name}.{charm.model.name}.svc.cluster.local"
-
-
-def _server_cert_sans_dns(container: Container) -> Set[str]:
-    """Return the DNS SANs of the server certificate currently on disk.
-
-    Returns an empty set when there is no readable, parsable certificate.
+    Returns an empty set when there is no readable, parsable certificate on disk.
     """
     try:
         raw = cast(str, container.pull(SERVER_CERT_PATH).read())
@@ -847,23 +845,6 @@ def _server_cert_sans_dns(container: Container) -> Set[str]:
     except Exception:
         logger.warning("Could not read the SANs of the server certificate on disk")
         return set()
-
-
-def internal_host(charm: CharmBase, container: Container) -> str:
-    """Return the in-cluster address that remote charms should use to reach this app.
-
-    This is the Kubernetes Service FQDN, so that traffic is load-balanced across units
-    instead of being duplicated to every unit or pinned to the leader.
-
-    When the server is serving TLS, the Service FQDN is only advertised once the
-    certificate on disk actually lists it as a SAN; otherwise clients would fail hostname
-    verification. Until then we keep advertising the pod FQDN, and switch over
-    automatically on the reconcile that follows the arrival of the widened certificate.
-    """
-    service = service_fqdn(charm)
-    if not is_tls_ready(container):
-        return service
-    return service if service in _server_cert_sans_dns(container) else unit_fqdn()
 
 
 class MultipleIngressesConfigured:
@@ -934,7 +915,9 @@ def _istio_ingress_config(charm: CharmBase) -> IstioIngressRouteConfig:
     )
 
 
-def _traefik_ingress_config(charm: CharmBase, ingress: TraefikRouteRequirer, tls: bool) -> dict:
+def _traefik_ingress_config(
+    charm: CharmBase, ingress: TraefikRouteRequirer, service_fqdn: str, tls: bool
+) -> dict:
     """Build a raw ingress configuration for Traefik."""
     http_routers = {}
     http_services = {}
@@ -969,7 +952,7 @@ def _traefik_ingress_config(charm: CharmBase, ingress: TraefikRouteRequirer, tls
         ] = {
             "loadBalancer": {
                 "servers": _build_lb_server_config(
-                    charm, "http" if not tls else "https", port.value
+                    service_fqdn, "http" if not tls else "https", port.value
                 )
             }
         }
@@ -990,15 +973,20 @@ def _update_ingress_relation(
     charm: CharmBase,
     ingress: TraefikRouteRequirer | IstioIngressRouteRequirer,
     tls: Optional[bool],
+    service_fqdn: Optional[str] = None,
 ) -> None:
-    """Make sure the ingress routes are up-to-date."""
+    """Make sure the ingress routes are up-to-date.
+
+    `service_fqdn` is only needed by Traefik, which is told the backend address
+    explicitly. Istio derives it from the application name instead.
+    """
     if not charm.unit.is_leader():
         return
 
     match ingress:
         case TraefikRouteRequirer():
-            if ingress.is_ready() and tls is not None:
-                config = _traefik_ingress_config(charm, ingress, tls)
+            if ingress.is_ready() and tls is not None and service_fqdn is not None:
+                config = _traefik_ingress_config(charm, ingress, service_fqdn, tls)
                 ingress.submit_to_traefik(config, static=_static_ingress_config())
         case IstioIngressRouteRequirer():
             if ingress.is_ready():
@@ -1015,8 +1003,14 @@ def istio_ingress_ready(ingress: IstioIngressRouteRequirer) -> bool:
     return bool(ingress.is_ready() and ingress.external_host)
 
 
-def setup_traefik_ingress(charm: CharmBase, tls: bool) -> TraefikRouteRequirer:
+def setup_traefik_ingress(charm: CharmBase, service_fqdn: str, tls: bool) -> TraefikRouteRequirer:
     """Integrate with Traefik to enable ingress.
+
+    Args:
+        charm: the otel-collector charm object
+        service_fqdn: the Kubernetes Service name Traefik should route to, so that
+            ingressed traffic is balanced across all units
+        tls: whether the collector's receivers are serving TLS
 
     Returns:
         A TraefikRouteRequirer instance.
@@ -1027,7 +1021,7 @@ def setup_traefik_ingress(charm: CharmBase, tls: bool) -> TraefikRouteRequirer:
         "ingress",
     )
     charm.__setattr__("ingress", ingress)
-    _update_ingress_relation(charm, ingress, tls)
+    _update_ingress_relation(charm, ingress, tls, service_fqdn=service_fqdn)
     return ingress
 
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Feature: A scaled otelcol shares incoming telemetry instead of duplicating it."""
+"""Feature: A scaled up otelcol shares incoming telemetry."""
 
 import logging
 from typing import Dict, List

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -56,7 +56,7 @@ def _assert_single_load_balanced_exporter(
     )
 
 
-def test_scaling_does_not_duplicate_telemetry(
+def test_scaling_without_ingress_does_not_duplicate_telemetry(
     juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
 ):
     """Scenario: scaling the receiver must not multiply what the sender transmits."""

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -52,7 +52,7 @@ def _assert_single_load_balanced_exporter(
         f"expected the K8s Service name in {endpoints[0]!r}, got a per-unit address"
     )
     assert "-endpoints." not in endpoints[0], (
-        f"{endpoints[0]!r} is a per-pod headless address, not the K8s Service"
+        f"{endpoints[0]!r} is a per-pod headless address, expected the K8s Service"
     )
 
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -63,10 +63,14 @@ def test_scaling_does_not_duplicate_telemetry(
     # GIVEN a single-unit otelcol receiving OTLP from another otelcol
     juju.deploy(charm, "otelcol", resources=charm_resources, trust=True)
     juju.deploy(charm, "sender", resources=charm_resources, trust=True)
+    juju.deploy(charm, "sink", resources=charm_resources, trust=True)
     juju.integrate("sender:send-otlp", "otelcol:receive-otlp")
+    # An incoming relation must be paired with an outgoing one, or the charm blocks on
+    # missing mandatory relations; give otelcol somewhere to forward what it receives.
+    juju.integrate("otelcol:send-otlp", "sink:receive-otlp")
     juju.wait(
-        lambda status: jubilant.all_active(status, "sender"),
-        timeout=600,
+        lambda status: jubilant.all_active(status, "otelcol", "sender"),
+        timeout=900,
         error=jubilant.any_error,
     )
     juju.wait(jubilant.all_agents_idle, timeout=600, error=jubilant.any_error)

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -4,7 +4,7 @@
 """Feature: A scaled up otelcol shares incoming telemetry."""
 
 import logging
-from typing import Dict, List
+from typing import Dict
 
 import jubilant
 import yaml
@@ -17,42 +17,33 @@ logger = logging.getLogger(__name__)
 # pyright: reportAttributeAccessIssue = false
 
 
-def _otlp_exporter_endpoints(juju: jubilant.Juju, sender: str) -> List[str]:
-    """Return the OTLP exporter endpoints in the sender's rendered collector config.
+@RETRY
+def otlp_exporter_endpoint(juju: jubilant.Juju, sender: str) -> str:
+    """Return the single OTLP exporter endpoint in the sender's rendered collector config.
 
     This is the ground truth for the duplication bug: one exporter per destination means
     each payload is sent once, whereas one exporter per receiving unit means the same
-    payload is sent N times.
+    payload is sent N times. Retried because the config is rewritten asynchronously.
     """
     config_raw = juju.ssh(f"{sender}/leader", command=f"cat {CONFIG_PATH}", container="otelcol")
     exporters = yaml.safe_load(config_raw).get("exporters") or {}
-    return [
+    endpoints = {
         exporter["endpoint"]
         for name, exporter in exporters.items()
         if name.startswith("otlp/") and "endpoint" in exporter
-    ]
+    }
+    assert len(endpoints) == 1, (
+        f"expected {sender} to target exactly one endpoint, got {sorted(endpoints)}"
+    )
+    return endpoints.pop()
 
 
 @RETRY
-def _assert_single_load_balanced_exporter(
-    juju: jubilant.Juju, receiver: str, sender: str
-) -> None:
-    """Assert the sender targets the receiver's K8s Service exactly once."""
-    endpoints = _otlp_exporter_endpoints(juju, sender)
-    assert endpoints, f"{sender} configured no OTLP exporters"
-
-    service_fqdn = f"{receiver}.{juju.model}.svc.cluster.local"
-    assert len(set(endpoints)) == 1, (
-        f"{sender} targets {len(set(endpoints))} distinct endpoints, so telemetry is "
-        f"duplicated rather than load-balanced: {sorted(set(endpoints))}"
-    )
-    # A per-pod headless address (`<app>-0.<app>-endpoints...`) is published once per unit,
-    # which is exactly what made a scaled otelcol receive every payload N times.
-    assert service_fqdn in endpoints[0], (
-        f"expected the K8s Service name in {endpoints[0]!r}, got a per-unit address"
-    )
-    assert "-endpoints." not in endpoints[0], (
-        f"{endpoints[0]!r} is a per-pod headless address, expected the K8s Service"
+def assert_no_tls_verification_errors(juju: jubilant.Juju, sender: str) -> None:
+    """Assert the sender's collector logs contain no certificate verification failures."""
+    logs = juju.ssh(f"{sender}/leader", command="pebble logs -n 1000", container="otelcol")
+    assert "tls: failed to verify certificate" not in logs, (
+        f"{sender} could not verify the receiver's certificate for the K8s Service name"
     )
 
 
@@ -63,10 +54,11 @@ def test_scaling_without_ingress_does_not_duplicate_telemetry(
     # GIVEN a single-unit otelcol receiving OTLP from another otelcol
     juju.deploy(charm, "otelcol", resources=charm_resources, trust=True)
     juju.deploy(charm, "sender", resources=charm_resources, trust=True)
+    # `sink` is a stand-in backend and is not part of what we assert on. It exists only
+    # because an incoming relation must be paired with an outgoing one, otherwise otelcol
+    # blocks on missing mandatory relations and never reaches an active status.
     juju.deploy(charm, "sink", resources=charm_resources, trust=True)
     juju.integrate("sender:send-otlp", "otelcol:receive-otlp")
-    # An incoming relation must be paired with an outgoing one, or the charm blocks on
-    # missing mandatory relations; give otelcol somewhere to forward what it receives.
     juju.integrate("otelcol:send-otlp", "sink:receive-otlp")
     juju.wait(
         lambda status: jubilant.all_active(status, "otelcol", "sender"),
@@ -75,9 +67,17 @@ def test_scaling_without_ingress_does_not_duplicate_telemetry(
     )
     juju.wait(jubilant.all_agents_idle, timeout=600, error=jubilant.any_error)
 
-    # THEN the sender targets the Kubernetes Service
-    _assert_single_load_balanced_exporter(juju, receiver="otelcol", sender="sender")
-    endpoints_at_one_unit = set(_otlp_exporter_endpoints(juju, "sender"))
+    # THEN the sender targets otelcol's Kubernetes Service
+    service_fqdn = f"otelcol.{juju.model}.svc.cluster.local"
+    endpoint_at_one_unit = otlp_exporter_endpoint(juju, "sender")
+    assert service_fqdn in endpoint_at_one_unit, (
+        f"expected the K8s Service name in {endpoint_at_one_unit!r}, got a per-unit address"
+    )
+    # A per-pod headless address (`<app>-0.<app>-endpoints...`) is published once per unit,
+    # which is exactly what made a scaled otelcol receive every payload N times.
+    assert "-endpoints." not in endpoint_at_one_unit, (
+        f"{endpoint_at_one_unit!r} is a per-pod headless address, expected the K8s Service"
+    )
 
     # AND WHEN otelcol is scaled out
     juju.add_unit("otelcol", num_units=2)
@@ -88,10 +88,9 @@ def test_scaling_without_ingress_does_not_duplicate_telemetry(
     )
     juju.wait(jubilant.all_agents_idle, timeout=600, error=jubilant.any_error)
 
-    # THEN the sender's config is unchanged: still one endpoint, so each payload is sent
-    # once and Kubernetes spreads it over the units instead of it being duplicated
-    _assert_single_load_balanced_exporter(juju, receiver="otelcol", sender="sender")
-    assert set(_otlp_exporter_endpoints(juju, "sender")) == endpoints_at_one_unit
+    # THEN the sender's config is unchanged: still that one endpoint, so each payload is
+    # sent once and Kubernetes spreads it over the units instead of it being duplicated
+    assert otlp_exporter_endpoint(juju, "sender") == endpoint_at_one_unit
 
     # AND scaling without ingress no longer blocks the charm
     assert jubilant.all_active(juju.status(), "otelcol")
@@ -117,17 +116,10 @@ def test_every_unit_serves_tls_for_the_shared_address(
     juju.wait(jubilant.all_agents_idle, timeout=600, error=jubilant.any_error)
 
     # THEN the sender still targets the Service name, now over TLS
-    _assert_single_load_balanced_exporter(juju, receiver="otelcol", sender="sender")
+    endpoint = otlp_exporter_endpoint(juju, "sender")
+    assert f"otelcol.{juju.model}.svc.cluster.local" in endpoint
 
     # AND the sender reaches it without certificate errors, whichever unit it lands on.
     # Without the widened SANs this fails hostname verification, since the certificate
     # would only be valid for the pod that happened to serve the request.
-    _assert_no_tls_verification_errors(juju, "sender")
-
-
-@RETRY
-def _assert_no_tls_verification_errors(juju: jubilant.Juju, sender: str) -> None:
-    logs = juju.ssh(f"{sender}/leader", command="pebble logs -n 1000", container="otelcol")
-    assert "tls: failed to verify certificate" not in logs, (
-        f"{sender} could not verify the receiver's certificate for the K8s Service name"
-    )
+    assert_no_tls_verification_errors(juju, "sender")

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Feature: A scaled otelcol shares incoming telemetry instead of duplicating it."""
+
+import logging
+from typing import Dict, List
+
+import jubilant
+import yaml
+from helpers import RETRY
+
+from src.constants import CONFIG_PATH
+
+logger = logging.getLogger(__name__)
+
+# pyright: reportAttributeAccessIssue = false
+
+
+def _otlp_exporter_endpoints(juju: jubilant.Juju, sender: str) -> List[str]:
+    """Return the OTLP exporter endpoints in the sender's rendered collector config.
+
+    This is the ground truth for the duplication bug: one exporter per destination means
+    each payload is sent once, whereas one exporter per receiving unit means the same
+    payload is sent N times.
+    """
+    config_raw = juju.ssh(f"{sender}/leader", command=f"cat {CONFIG_PATH}", container="otelcol")
+    exporters = yaml.safe_load(config_raw).get("exporters") or {}
+    return [
+        exporter["endpoint"]
+        for name, exporter in exporters.items()
+        if name.startswith("otlp/") and "endpoint" in exporter
+    ]
+
+
+@RETRY
+def _assert_single_load_balanced_exporter(
+    juju: jubilant.Juju, receiver: str, sender: str
+) -> None:
+    """Assert the sender targets the receiver's K8s Service exactly once."""
+    endpoints = _otlp_exporter_endpoints(juju, sender)
+    assert endpoints, f"{sender} configured no OTLP exporters"
+
+    service_fqdn = f"{receiver}.{juju.model}.svc.cluster.local"
+    assert len(set(endpoints)) == 1, (
+        f"{sender} targets {len(set(endpoints))} distinct endpoints, so telemetry is "
+        f"duplicated rather than load-balanced: {sorted(set(endpoints))}"
+    )
+    # A per-pod headless address (`<app>-0.<app>-endpoints...`) is published once per unit,
+    # which is exactly what made a scaled otelcol receive every payload N times.
+    assert service_fqdn in endpoints[0], (
+        f"expected the K8s Service name in {endpoints[0]!r}, got a per-unit address"
+    )
+    assert "-endpoints." not in endpoints[0], (
+        f"{endpoints[0]!r} is a per-pod headless address, not the K8s Service"
+    )
+
+
+def test_scaling_does_not_duplicate_telemetry(
+    juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
+):
+    """Scenario: scaling the receiver must not multiply what the sender transmits."""
+    # GIVEN a single-unit otelcol receiving OTLP from another otelcol
+    juju.deploy(charm, "otelcol", resources=charm_resources, trust=True)
+    juju.deploy(charm, "sender", resources=charm_resources, trust=True)
+    juju.integrate("sender:send-otlp", "otelcol:receive-otlp")
+    juju.wait(
+        lambda status: jubilant.all_active(status, "sender"),
+        timeout=600,
+        error=jubilant.any_error,
+    )
+    juju.wait(jubilant.all_agents_idle, timeout=600, error=jubilant.any_error)
+
+    # THEN the sender targets the Kubernetes Service
+    _assert_single_load_balanced_exporter(juju, receiver="otelcol", sender="sender")
+    endpoints_at_one_unit = set(_otlp_exporter_endpoints(juju, "sender"))
+
+    # AND WHEN otelcol is scaled out
+    juju.add_unit("otelcol", num_units=2)
+    juju.wait(
+        lambda status: jubilant.all_active(status, "otelcol"),
+        timeout=900,
+        error=jubilant.any_error,
+    )
+    juju.wait(jubilant.all_agents_idle, timeout=600, error=jubilant.any_error)
+
+    # THEN the sender's config is unchanged: still one endpoint, so each payload is sent
+    # once and Kubernetes spreads it over the units instead of it being duplicated
+    _assert_single_load_balanced_exporter(juju, receiver="otelcol", sender="sender")
+    assert set(_otlp_exporter_endpoints(juju, "sender")) == endpoints_at_one_unit
+
+    # AND scaling without ingress no longer blocks the charm
+    assert jubilant.all_active(juju.status(), "otelcol")
+
+
+def test_every_unit_serves_tls_for_the_shared_address(
+    juju: jubilant.Juju, charm: str, charm_resources: Dict[str, str]
+):
+    """Scenario: any unit may terminate a connection made to the K8s Service.
+
+    Requests to the Service land on an arbitrary unit, so each unit's certificate must
+    cover the Service name or verification fails intermittently once scaled.
+    """
+    # GIVEN the scaled otelcol from the previous test, now serving TLS
+    juju.deploy("self-signed-certificates", "ssc")
+    juju.integrate("otelcol:receive-server-cert", "ssc:certificates")
+    juju.integrate("sender:receive-ca-cert", "ssc:send-ca-cert")
+    juju.wait(
+        lambda status: jubilant.all_active(status, "otelcol", "ssc", "sender"),
+        timeout=900,
+        error=jubilant.any_error,
+    )
+    juju.wait(jubilant.all_agents_idle, timeout=600, error=jubilant.any_error)
+
+    # THEN the sender still targets the Service name, now over TLS
+    _assert_single_load_balanced_exporter(juju, receiver="otelcol", sender="sender")
+
+    # AND the sender reaches it without certificate errors, whichever unit it lands on.
+    # Without the widened SANs this fails hostname verification, since the certificate
+    # would only be valid for the pod that happened to serve the request.
+    _assert_no_tls_verification_errors(juju, "sender")
+
+
+@RETRY
+def _assert_no_tls_verification_errors(juju: jubilant.Juju, sender: str) -> None:
+    logs = juju.ssh(f"{sender}/leader", command="pebble logs -n 1000", container="otelcol")
+    assert "tls: failed to verify certificate" not in logs, (
+        f"{sender} could not verify the receiver's certificate for the K8s Service name"
+    )

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -2,16 +2,40 @@
 # See LICENSE file for licensing details.
 
 
+from datetime import timedelta
 from unittest.mock import patch
 
 import yaml
 from charms.tls_certificates_interface.v4.tls_certificates import (
     Certificate,
+    PrivateKey,
     TLSCertificatesRequiresV4,
+    generate_ca,
+    generate_certificate,
+    generate_csr,
 )
 from ops.testing import Context, State
 
 from constants import CA_TRUST_STAMP_PATH
+
+
+class IssuedCertificate:
+    """A real, parsable server certificate plus its CA, for tests that inspect SANs.
+
+    `MockCertificate` carries opaque strings, which is enough for most tests but not for the
+    ones that assert on which names otelcol's certificate is valid for.
+    """
+
+    def __init__(self, common_name: str, sans_dns: frozenset[str]):
+        ca_key = PrivateKey.generate()
+        ca = generate_ca(private_key=ca_key, validity=timedelta(days=1), common_name="test-ca")
+        key = PrivateKey.generate()
+        csr = generate_csr(private_key=key, common_name=common_name, sans_dns=sans_dns)
+        self.private_key = key
+        self.certificate = generate_certificate(
+            csr=csr, ca=ca, ca_private_key=ca_key, validity=timedelta(days=1)
+        )
+        self.ca = ca
 
 
 def get_otelcol_file(state_out: State, ctx: Context, file_path: str) -> dict:

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -193,20 +193,22 @@ def test_internal_logs_without_topology_labels_are_unchanged():
 
 
 def test_default_internal_logs_self_export_tls():
-    # GIVEN a default config WITH receiver TLS and the unit FQDN the server cert is valid for
+    # GIVEN a default config WITH receiver TLS and the pod FQDN this unit's cert is valid for
     config = ConfigBuilder(
         unit_name="fake/0",
         global_scrape_interval="",
         global_scrape_timeout="",
         receiver_tls=True,
-        internal_host="otelcol-0.otelcol-endpoints.o11y.svc.cluster.local",
+        self_telemetry_host="otelcol-0.otelcol-endpoints.o11y.svc.cluster.local",
     )
     config.add_default_config()
     otlp = config._config["service"]["telemetry"]["logs"]["processors"][0]["batch"]["exporter"][
         "otlp"
     ]
-    # THEN the loopback endpoint targets the FQDN (a name present in the cert SANs) over HTTPS, so
-    # verification succeeds -- NOT `localhost`, which would fail ("valid for <fqdn>, not localhost")
+    # THEN the loopback endpoint targets THIS pod's FQDN (a name present in the cert SANs) over
+    # HTTPS, so verification succeeds -- NOT `localhost`, which would fail ("valid for <fqdn>, not
+    # localhost"), and NOT the K8s Service FQDN, which would route this unit's own telemetry to a
+    # different unit
     assert (
         otlp["endpoint"]
         == "https://otelcol-0.otelcol-endpoints.o11y.svc.cluster.local:4318"

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -8,7 +8,6 @@ from typing import Any, List
 from unittest.mock import patch
 
 import pytest
-
 import yaml
 from ops.testing import Relation, State
 
@@ -16,9 +15,16 @@ from src.config_builder import Port
 from src.constants import INGRESS_IP_MATCHER
 
 FQDN = "otelcol-0.otelcol-endpoints.otel.svc.cluster.local"
+CHARM_NAME = "opentelemetry-collector-k8s"
 
 
-def test_blocked_status_when_scaled_without_ingress(ctx, otelcol_container):
+def service_fqdn(state) -> str:
+    """Return the Kubernetes Service FQDN otelcol advertises for the given state."""
+    return f"{CHARM_NAME}.{state.model.name}.svc.cluster.local"
+
+
+def test_active_when_scaled_without_ingress(ctx, otelcol_container):
+    """Scenario: scaling without ingress is fine, because traffic goes to the K8s Service."""
     # GIVEN otelcol is not scaled and has no ingress relation
     state = State(planned_units=1, containers=otelcol_container, leader=True)
 
@@ -26,15 +32,14 @@ def test_blocked_status_when_scaled_without_ingress(ctx, otelcol_container):
     state_out = ctx.run(ctx.on.update_status(), state)
 
     # THEN the charm is Active
-    assert state_out.unit_status.name != "blocked"
+    assert state_out.unit_status.name == "active"
 
-    # AND WHEN otelcol is scaled to 2 units
+    # AND WHEN otelcol is scaled to 2 units without ingress
     state = State(planned_units=2, containers=otelcol_container, leader=True)
     state_out = ctx.run(ctx.on.update_status(), state)
 
-    # THEN the charm is Blocked
-    assert state_out.unit_status.name == "blocked"
-    assert "Ingress missing" in state_out.unit_status.message
+    # THEN the charm is still Active, because the K8s Service load-balances across units
+    assert state_out.unit_status.name == "active"
 
     # AND WHEN otelcol is scaled to 2 units with ingress relation
     ingress = Relation("ingress", remote_app_data={"external_host": "1.2.3.4", "scheme": "http"})
@@ -47,7 +52,7 @@ def test_blocked_status_when_scaled_without_ingress(ctx, otelcol_container):
     state_out = ctx.run(ctx.on.update_status(), state)
 
     # THEN the charm is Active
-    assert state_out.unit_status.name != "blocked"
+    assert state_out.unit_status.name == "active"
     assert not state_out.unit_status.message
 
 
@@ -110,7 +115,9 @@ def test_traefik_sent_config(ctx, otelcol_container):
     # GIVEN otelcol deployed in isolation
     ingress = Relation("ingress", remote_app_data={"external_host": "1.2.3.4", "scheme": "http"})
     state = State(relations=[ingress], containers=otelcol_container, leader=True)
-    charm_name = "opentelemetry-collector-k8s"
+    charm_name = CHARM_NAME
+    # Traefik must load-balance across all units, so the backend is the K8s Service, not a pod
+    backend = service_fqdn(state)
     expected_rel_data = {
         "http": {
             "routers": {
@@ -157,28 +164,28 @@ def test_traefik_sent_config(ctx, otelcol_container):
             },
             "services": {
                 f"juju-{state.model.name}-{charm_name}-service-health": {
-                    "loadBalancer": {"servers": [{"url": f"http://{FQDN}:13133"}]}
+                    "loadBalancer": {"servers": [{"url": f"http://{backend}:13133"}]}
                 },
                 f"juju-{state.model.name}-{charm_name}-service-jaeger-grpc": {
-                    "loadBalancer": {"servers": [{"url": f"http://{FQDN}:14250"}]}
+                    "loadBalancer": {"servers": [{"url": f"http://{backend}:14250"}]}
                 },
                 f"juju-{state.model.name}-{charm_name}-service-jaeger-thrift-http": {
-                    "loadBalancer": {"servers": [{"url": f"http://{FQDN}:14268"}]}
+                    "loadBalancer": {"servers": [{"url": f"http://{backend}:14268"}]}
                 },
                 f"juju-{state.model.name}-{charm_name}-service-loki-http": {
-                    "loadBalancer": {"servers": [{"url": f"http://{FQDN}:3500"}]}
+                    "loadBalancer": {"servers": [{"url": f"http://{backend}:3500"}]}
                 },
                 f"juju-{state.model.name}-{charm_name}-service-metrics": {
-                    "loadBalancer": {"servers": [{"url": f"http://{FQDN}:8888"}]},
+                    "loadBalancer": {"servers": [{"url": f"http://{backend}:8888"}]},
                 },
                 f"juju-{state.model.name}-{charm_name}-service-otlp-grpc": {
-                    "loadBalancer": {"servers": [{"url": f"http://{FQDN}:4317"}]}
+                    "loadBalancer": {"servers": [{"url": f"http://{backend}:4317"}]}
                 },
                 f"juju-{state.model.name}-{charm_name}-service-otlp-http": {
-                    "loadBalancer": {"servers": [{"url": f"http://{FQDN}:4318"}]}
+                    "loadBalancer": {"servers": [{"url": f"http://{backend}:4318"}]}
                 },
                 f"juju-{state.model.name}-{charm_name}-service-zipkin": {
-                    "loadBalancer": {"servers": [{"url": f"http://{FQDN}:9411"}]}
+                    "loadBalancer": {"servers": [{"url": f"http://{backend}:9411"}]}
                 },
             },
         },
@@ -258,9 +265,12 @@ def test_loki_url_in_databag(
 
     # AND WHEN ingress is removed
     out_3 = ctx.run(ctx.on.relation_broken(ingress), state)
-    # THEN the internal URL is present in receive-loki-logs relation databag
+    # THEN the K8s Service URL is present in receive-loki-logs relation databag,
+    # so that logs are load-balanced across units instead of sent to every unit
     receive_logs_out = out_3.get_relations(receive_logs_endpoint.endpoint)[0]
-    expected_data = {"url": f"http://{FQDN}:{Port.loki_http.value}/loki/api/v1/push"}
+    expected_data = {
+        "url": f"http://{service_fqdn(state)}:{Port.loki_http.value}/loki/api/v1/push"
+    }
     assert json.loads(receive_logs_out.local_unit_data["endpoint"]) == expected_data
 
 
@@ -279,7 +289,11 @@ def test_otlp_url_in_databag(
 ):
     def expected_endpoints(traefik: bool, istio: bool) -> List[dict[str, Any]]:
         has_ingress = traefik or istio
-        host = external_host if has_ingress else FQDN
+        # Without ingress, the K8s Service FQDN is advertised so that OTLP data is
+        # load-balanced across units instead of duplicated to each of them.
+        host = (
+            external_host if has_ingress else f"{CHARM_NAME}.{state.model.name}.svc.cluster.local"
+        )
         # since we do not patch integrations.is_tls_ready(container), internal TLS will be False
         insecure = not (tls if has_ingress else False)
         scheme = "http" if insecure else "https"

--- a/tests/unit/test_otlp.py
+++ b/tests/unit/test_otlp.py
@@ -110,29 +110,31 @@ def test_send_otlp(ctx, otelcol_container):
 
 @patch("socket.getfqdn", new=lambda *args: "fqdn")
 def test_receive_otlp(ctx, otelcol_container):
-    expected_endpoints = {
-        "endpoints": [
-            {
-                "protocol": "http",
-                "endpoint": "http://fqdn:4318",
-                "telemetries": ["metrics", "logs", "traces"],
-                "insecure": True,
-            },
-            {
-                "protocol": "grpc",
-                "endpoint": "fqdn:4317",
-                "telemetries": ["metrics", "logs", "traces"],
-                "insecure": True,
-            }
-        ],
-    }
-
     # GIVEN a receive-otlp relation and no TLS relations
     state = State(
         leader=True,
         containers=otelcol_container,
         relations=[RECEIVE_OTLP],
     )
+    # Without ingress, otelcol advertises the K8s Service FQDN so that OTLP data is
+    # load-balanced across units instead of duplicated to each of them.
+    service = f"opentelemetry-collector-k8s.{state.model.name}.svc.cluster.local"
+    expected_endpoints = {
+        "endpoints": [
+            {
+                "protocol": "http",
+                "endpoint": f"http://{service}:4318",
+                "telemetries": ["metrics", "logs", "traces"],
+                "insecure": True,
+            },
+            {
+                "protocol": "grpc",
+                "endpoint": f"{service}:4317",
+                "telemetries": ["metrics", "logs", "traces"],
+                "insecure": True,
+            },
+        ],
+    }
 
     # WHEN any event executes the reconciler
     state_out = ctx.run(ctx.on.update_status(), state=state)

--- a/tests/unit/test_tls_certificates.py
+++ b/tests/unit/test_tls_certificates.py
@@ -9,16 +9,19 @@ from unittest.mock import patch
 import pytest
 from charms.tls_certificates_interface.v4.tls_certificates import (
     Certificate,
+    CertificateSigningRequest,
+    PrivateKey,
     TLSCertificatesRequiresV4,
+    generate_csr,
 )
 from conftest import MockCertificate
-from helpers import get_otelcol_file, trust_stamp_after_reconcile
+from helpers import IssuedCertificate, get_otelcol_file, trust_stamp_after_reconcile
 from ops.testing import Relation, State
 
 from constants import (
     CONFIG_PATH,
-    SERVER_CERT_PATH,
     SERVER_CA_CERT_PATH,
+    SERVER_CERT_PATH,
     SERVER_CERT_PRIVATE_KEY_PATH,
 )
 
@@ -170,3 +173,125 @@ def test_https_endpoint_is_provided(ctx, otelcol_container, cert_obj, private_ke
     for relation in state_out.relations:
         if relation.endpoint == "receive-loki-logs":
             assert "https" in json.loads(relation.local_unit_data["endpoint"])["url"]
+
+
+FQDN = "otelcol-0.otelcol-endpoints.otel.svc.cluster.local"
+CHARM_NAME = "opentelemetry-collector-k8s"
+
+
+@patch("socket.getfqdn", new=lambda *args: FQDN)
+def test_csr_requests_both_the_pod_and_the_service_name(ctx, otelcol_container):
+    """Scenario: otelcol asks the CA for a certificate valid for the K8s Service too.
+
+    Remote charms are handed the Kubernetes Service name, and any unit may terminate that
+    connection, so every unit's certificate must be valid for it.
+    """
+    # GIVEN a tls-certificates relation
+    ssc = Relation(endpoint="receive-server-cert", interface="tls-certificate")
+    state_in = State(relations=[ssc], containers=otelcol_container, leader=True)
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state_in)
+
+    # THEN the CSR sent to the CA lists both the pod name and the K8s Service name
+    csrs = json.loads(
+        state_out.get_relation(ssc.id).local_unit_data["certificate_signing_requests"]
+    )
+    assert csrs
+    sans = CertificateSigningRequest.from_string(csrs[0]["certificate_signing_request"]).sans_dns
+    assert sans == {FQDN, f"{CHARM_NAME}.{state_out.model.name}.svc.cluster.local"}
+
+
+@patch("socket.getfqdn", new=lambda *args: FQDN)
+def test_service_name_advertised_only_once_the_certificate_covers_it(ctx, otelcol_container):
+    """Scenario: a charm refreshed from an older revision still holds a pod-only certificate.
+
+    Advertising the Kubernetes Service name while serving a certificate that does not list it
+    would break hostname verification for every client, so otelcol keeps advertising the pod
+    name until the CA hands back a certificate that covers the Service name.
+    """
+    ssc = Relation(endpoint="receive-server-cert", interface="tls-certificate")
+    receive_logs = Relation(endpoint="receive-loki-logs", interface="loki_push_api")
+    state_in = State(relations=[ssc, receive_logs], containers=otelcol_container, leader=True)
+    service = f"{CHARM_NAME}.{state_in.model.name}.svc.cluster.local"
+
+    def advertised_url(issued) -> str:
+        with (
+            patch.object(
+                TLSCertificatesRequiresV4, "_find_available_certificates", return_value=None
+            ),
+            patch.object(
+                TLSCertificatesRequiresV4,
+                "get_assigned_certificate",
+                return_value=(issued, issued.private_key),
+            ),
+        ):
+            state_out = ctx.run(ctx.on.update_status(), state=state_in)
+        logs_out = state_out.get_relation(receive_logs.id)
+        return json.loads(logs_out.local_unit_data["endpoint"])["url"]
+
+    # GIVEN the certificate on disk predates this feature and only covers the pod name
+    # THEN the pod name is advertised, so that TLS clients can still verify the server
+    assert FQDN in advertised_url(IssuedCertificate("otelcol-0", frozenset({FQDN})))
+
+    # WHEN the CA issues the widened certificate
+    # THEN the K8s Service name is advertised, so traffic is load-balanced across units
+    widened = IssuedCertificate("otelcol-0", frozenset({FQDN, service}))
+    assert service in advertised_url(widened)
+
+
+def test_service_name_advertised_when_tls_is_disabled(ctx, otelcol_container):
+    """Scenario: without TLS there is no certificate to satisfy, so no reason to hold back."""
+    # GIVEN otelcol with no tls-certificates relation
+    receive_logs = Relation(endpoint="receive-loki-logs", interface="loki_push_api")
+    state_in = State(relations=[receive_logs], containers=otelcol_container, leader=True)
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state_in)
+
+    # THEN the K8s Service name is advertised immediately
+    url = json.loads(state_out.get_relation(receive_logs.id).local_unit_data["endpoint"])["url"]
+    assert f"{CHARM_NAME}.{state_out.model.name}.svc.cluster.local" in url
+
+
+@patch("socket.getfqdn", new=lambda *args: FQDN)
+def test_refresh_replaces_a_pod_only_csr(ctx, otelcol_container):
+    """Scenario: refreshing from a revision that only ever asked for the pod name.
+
+    The certificate request is reconciled on every hook, so an existing narrow request is
+    withdrawn and replaced without operator intervention. This is what makes a plain
+    `juju refresh` enough to pick up the fix.
+    """
+    # GIVEN a tls-certificates relation carrying a CSR from the older revision
+    stale_key = PrivateKey.generate()
+    stale_csr = generate_csr(
+        private_key=stale_key, common_name="otelcol-0", sans_dns=frozenset({FQDN})
+    )
+    ssc = Relation(
+        endpoint="receive-server-cert",
+        interface="tls-certificate",
+        local_unit_data={
+            "certificate_signing_requests": json.dumps(
+                [{"certificate_signing_request": str(stale_csr)}]
+            )
+        },
+    )
+    state_in = State(relations=[ssc], containers=otelcol_container, leader=True)
+
+    # WHEN the refreshed charm executes the reconciler
+    state_out = ctx.run(ctx.on.upgrade_charm(), state=state_in)
+
+    # THEN the narrow request is gone, replaced by one that also covers the K8s Service name
+    csrs = json.loads(
+        state_out.get_relation(ssc.id).local_unit_data["certificate_signing_requests"]
+    )
+    all_sans = {
+        san
+        for csr in csrs
+        for san in CertificateSigningRequest.from_string(
+            csr["certificate_signing_request"]
+        ).sans_dns
+    }
+    service = f"{CHARM_NAME}.{state_out.model.name}.svc.cluster.local"
+    assert service in all_sans
+    assert str(stale_csr) not in [csr["certificate_signing_request"] for csr in csrs]


### PR DESCRIPTION
## Summary

Otelcol advertised a per-pod DNS name to charms sending it telemetry. Because that name is published per unit, senders fanned the same data out to every one of them. Otelcol now advertises the Kubernetes Service fronting its units, which load-balances across ready pods, and Traefik is pointed at the same Service.

Fixes #188. Fixes #272.

## Fixed failure modes

- **Duplicated telemetry when scaled.** Every sample, log line and span was stored once per unit, inflating the backends and breaking any query assuming one copy.
- **Scaling made throughput worse.** Adding units multiplied the work instead of sharing it, so otelcol could not be scaled out of a bottleneck.
- **Ingress reached only one unit.** Traefik routed everything to a single pod, leaving the rest idle and that pod a single point of failure.
- **Traces and profiles ignored ingress.** Both published an in-cluster address even when ingressed, so cross-model senders got an endpoint they could not reach.

## Changes

- Advertise the Service name over `receive-otlp`, `receive-loki-logs`, `receive-traces` and `receive-profiles`, and point the Traefik backend at it. Istio already did the right thing.
- Widen each unit's certificate request to cover both its pod name and the Service name, since any unit may terminate a connection made to the Service.
- Keep the collector's own internal telemetry on its own pod, so a unit's self-monitoring is never routed to a sibling. The parameter was renamed to make that hard to undo by accident.
- Drop the "Ingress missing - routing only to leader" blocked status, now that scaling distributes load.
- Second commit moves address resolution onto the charm, leaving only the certificate-reading helper beside the TLS integration that produces it. No behaviour change; reviewable separately.

## Upgrade safety

Advertising the Service name while serving an older certificate would break hostname verification for every TLS client. A refreshed deployment keeps advertising the pod name until the CA returns the wider certificate, then switches over on its own; no operator action needed. Because certificate requests are reconciled on every hook, the narrow request is withdrawn and replaced automatically, so no upgrade-specific code path is required. Both behaviours are covered by tests.

During that window a scaled, TLS-enabled deployment still routes to the leader, so the charm reports a waiting status rather than silently under-performing.

## Testing

Unit tests cover the published endpoints, the CSR SANs, the pod-only-certificate fallback and the refresh path. New integration tests scale the collector out and assert the sender keeps targeting a single load-balanced address and reaches it without certificate errors — neither is observable at scale 1, which is why the existing suite could not catch this.

The integration tests have not been run locally: `charmcraft pack` cannot fetch `cos-tool` from GitHub in this environment, and the only local artifact predates these changes. **CI is their first real execution**; the likeliest issue is timeout tuning, since scaling plus certificate issuance is slower than the existing tests.

## Not addressed here

Traefik entrypoint collisions with Tempo (canonical/observability-stack#382) and gRPC through Traefik (#248) are separate, and still need the COS Terraform-level decision discussed in the former.