### PR TITLE
perf: skip receive-otlp rule staging when no file-based consumer is related

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 65
+LIBPATCH = 66
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1730,6 +1730,9 @@ class MetricsEndpointProvider(Object):
         else:
             if not isinstance(refresh_event, list):
                 refresh_event = [refresh_event]
+
+        # If there is no leader during relation_joined we will still need to set alert rules.
+        self.framework.observe(self._charm.on.leader_elected, self.set_scrape_job_spec)
 
         self.framework.observe(events.relation_joined, self.set_scrape_job_spec)
         for ev in refresh_event:

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -535,6 +535,12 @@ def stage_received_otlp_rules(charm: CharmBase, provider: OtlpProvider) -> None:
     directories with ``dirs_exist_ok=True``) and before `send_loki_logs`/`send_remote_write`
     (which read those directories).
 
+    The staging is skipped when no consumer of the files is related: the promql staging is
+    only used by `send_remote_write` and the logql staging only by `send_loki_logs`, both of
+    which read the rule directories from disk. Without either relation (e.g. an aggregator
+    whose only output is `send-otlp`, which reads rules from relation data instead of disk),
+    the staging would be dead work proportional to the number of relations.
+
     Args:
         charm: the otel-collector charm object
         provider: the ``OtlpProvider`` instantiated in `receive_otlp`, reused here to read the
@@ -542,15 +548,25 @@ def stage_received_otlp_rules(charm: CharmBase, provider: OtlpProvider) -> None:
     """
     if not cast(bool, charm.config.get("forward_alert_rules")):
         return
+
+    has_remote_write = any(charm.model.relations.get("send-remote-write", []))
+    has_loki_logs = any(charm.model.relations.get("send-loki-logs", []))
+
+    if not (has_remote_write or has_loki_logs):
+        logger.debug(
+            "no send-remote-write/send-loki-logs relation: skipping staging of received-otlp rules"
+        )
+        return
+
     charm_root = charm.charm_dir.absolute()
     metrics_dest = charm_root.joinpath(*METRICS_RULES_DEST_PATH.split("/"))
     loki_dest = charm_root.joinpath(*LOKI_RULES_DEST_PATH.split("/"))
     promql_alerts: Dict[str, Dict] = {}
     logql_alerts: Dict[str, Dict] = {}
     for rel_id, rule_store in provider.rules.items():
-        if (promql := rule_store.promql.as_dict()).get("groups"):
+        if has_remote_write and (promql := rule_store.promql.as_dict()).get("groups"):
             promql_alerts[f"otlp_{rel_id}"] = promql
-        if (logql := rule_store.logql.as_dict()).get("groups"):
+        if has_loki_logs and (logql := rule_store.logql.as_dict()).get("groups"):
             logql_alerts[f"otlp_{rel_id}"] = logql
     if promql_alerts:
         _add_alerts(promql_alerts, metrics_dest)

--- a/tests/unit/test_otlp.py
+++ b/tests/unit/test_otlp.py
@@ -123,7 +123,7 @@ def test_receive_otlp(ctx, otelcol_container):
                 "endpoint": "fqdn:4317",
                 "telemetries": ["metrics", "logs", "traces"],
                 "insecure": True,
-            }
+            },
         ],
     }
 
@@ -316,6 +316,80 @@ def test_received_otlp_rules_forwarded_downstream(
         assert not leaked, (
             f"forwarding disabled but received-OTLP alerts leaked into {downstream_endpoint}: {leaked}"
         )
+
+
+@pytest.mark.parametrize(
+    "downstream_endpoint, downstream_remote_app, expect_promql_staged, expect_logql_staged",
+    [
+        pytest.param(
+            "send-otlp",
+            "downstream-otelcol",
+            False,
+            False,
+            id="otlp-only-no-staging",
+        ),
+        pytest.param(
+            "send-remote-write",
+            "prometheus",
+            True,
+            False,
+            id="remote-write-stages-promql",
+        ),
+        pytest.param(
+            "send-loki-logs",
+            "loki",
+            False,
+            True,
+            id="loki-stages-logql",
+        ),
+    ],
+)
+def test_staging_skipped_without_file_consumer(
+    ctx,
+    tmp_path,
+    otelcol_container,
+    all_rules,
+    downstream_endpoint,
+    downstream_remote_app,
+    expect_promql_staged,
+    expect_logql_staged,
+):
+    """Rules are staged to disk only when a downstream that reads the files is related.
+
+    The staged files' only readers are `send-remote-write` (promql) and `send-loki-logs`
+    (logql). When the only output is `send-otlp` (which reads rules from relation data,
+    not disk), the staging must be skipped entirely: it would be dead work proportional
+    to the number of relations (the dominant reconcile cost in aggregator deployments).
+    """
+    # GIVEN a receive-otlp relation carrying compressed alert rules
+    receiver = Relation(
+        "receive-otlp",
+        remote_app_data={
+            "rules": json.dumps(LZMABase64.compress(json.dumps(all_rules))),
+            "metadata": json.dumps(OTELCOL_METADATA),
+        },
+    )
+    # * a single downstream forwarding relation
+    downstream_kwargs = {"remote_app_name": downstream_remote_app}
+    if downstream_endpoint == "send-otlp":
+        downstream_kwargs["remote_app_data"] = {"endpoints": "[]"}
+    downstream = Relation(downstream_endpoint, **downstream_kwargs)
+    state = State(
+        relations=[receiver, downstream],
+        leader=True,
+        containers=otelcol_container,
+        model=MODEL,
+        config={"forward_alert_rules": True},
+    )
+
+    # WHEN any event executes the reconciler
+    ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN juju_otlp_* files are staged only for the dirs a downstream consumer reads
+    promql_staged = list((tmp_path / "prometheus_alert_rules").glob("juju_otlp_*.rules"))
+    logql_staged = list((tmp_path / "loki_alert_rules").glob("juju_otlp_*.rules"))
+    assert bool(promql_staged) == expect_promql_staged
+    assert bool(logql_staged) == expect_logql_staged
 
 
 @pytest.mark.parametrize("forward_rules", [True, False])


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Fixes #360 

## Solution
<!-- A summary of the solution addressing the above issue -->

`stage_received_otlp_rules()` writes the rules received over `receive-otlp` to the `prometheus_alert_rules`/`loki_alert_rules` directories on every event.
Those files are only read by the `send-remote-write` and `send-loki-logs` integrations, so in deployments whose only output is `send-otlp` (e.g. the cross-model aggregator) the staging is dead work proportional to the number of relations and the single most expensive phase of
the reconcile.

The staging is now skipped when no consumer relation exists, and kept granular when one does:

- no `send-remote-write` and no `send-loki-logs` relation → skip entirely (don't even touch `OtlpProvider.rules`: no LZMA decompression, no cos-tool injection, no file writes, on any unit)
- only `send-remote-write` → stage promql only
- only `send-loki-logs` → stage logql only

No functional change: `send-otlp` publishes rules from relation data, and topologies with either consumer keep today's behavior.



### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

### Baseline performance

If we measure (warm cache) with [`bench_reconcile_breakdown.py`](https://github.com/user-attachments/files/31580391/bench_reconcile_breakdown.py) (400 clients × 30 rules, aggregator topology, warm cos-tool cache) the code performance BEFORE the changes in this PR are applied, we get:


```shell
$ UV_PROJECT_ENVIRONMENT=/tmp/venv314 PYTHONPATH=lib:src:. \
  uv run --extra dev python tests/stress/bench_reconcile_breakdown.py --breakdown --n 400 --rules 30 --topology prod

=== _reconcile() breakdown by function @ 400 clients ===
(cumtime of each direct call from _reconcile; they do not overlap)

 cumtime (s) |  % recon | function
------------------------------------------------------------------------------------------
      31.981 |    54.2% | src/integrations.py:525(stage_received_otlp_rules)
      24.793 |    42.1% | src/integrations.py:583(send_otlp)
       2.100 |     3.6% | src/integrations.py:458(forward_dashboards)
       0.033 |     0.1% | src/integrations.py:491(receive_otlp)
       0.009 |     0.0% | src/config_builder.py:201(hash)
       0.007 |     0.0% | src/integrations.py:678(receive_server_cert)
       0.006 |     0.0% | src/config_builder.py:136(build)
       0.001 |     0.0% | src/integrations.py:126(receive_loki_logs)
       0.001 |     0.0% | src/integrations.py:395(send_charm_traces)
       0.001 |     0.0% | src/integrations.py:229(scrape_metrics)
       0.001 |     0.0% | src/integrations.py:772(setup_service_mesh)
       0.001 |     0.0% | src/integrations.py:656(cloud_integrator)
       0.001 |     0.0% | src/integrations.py:259(send_remote_write)
       0.000 |     0.0% | src/integrations.py:160(send_loki_logs)
       0.000 |     0.0% | ops/model.py:2647(add_layer)
       0.000 |     0.0% | v0/kubernetes_compute_resources_patch.py:565(__init__)
       0.000 |     0.0% | src/integrations.py:743(receive_ca_cert)
       0.000 |     0.0% | src/integrations.py:307(receive_traces)
       0.000 |     0.0% | src/charm.py:84(refresh_certs)
       0.000 |     0.0% | ops/model.py:2795(push)
       0.000 |     0.0% | src/integrations.py:978(setup_traefik_ingress)
       0.000 |     0.0% | src/charm.py:557(_otelcol_version)
       0.000 |     0.0% | src/integrations.py:994(setup_istio_ingress)
       0.000 |     0.0% | src/integrations.py:368(send_traces)
       0.000 |     0.0% | src/charm.py:503(_ensure_certs_dir)
       0.000 |     0.0% | re/__init__.py:169(fullmatch)
       0.000 |     0.0% | src/integrations.py:118(receive_external_configs)
       0.000 |     0.0% | src/integrations.py:824(is_tls_ready)
       0.000 |     0.0% | src/charm.py:114(_get_missing_mandatory_relations)
       0.000 |     0.0% | src/charm.py:43(charm_address)
------------------------------------------------------------------------------------------
      58.954 |   100.0% | _reconcile TOTAL
```

### Improved performance

 
> The staging is skipped when no consumer of the files is related: the promql staging is
> only used by `send_remote_write` and the logql staging only by `send_loki_logs`, both of
> which read the rule directories from disk. Without either relation (e.g. an aggregator
> whose only output is `send-otlp`, which reads rules from relation data instead of disk),
> the staging would be dead work proportional to the number of relations.


```shell
$ UV_PROJECT_ENVIRONMENT=/tmp/venv314 PYTHONPATH=lib:src:. \
  uv run --extra dev python tests/stress/bench_reconcile_breakdown.py --breakdown --n 400 --rules 30 --topology prod

=== _reconcile() breakdown by function @ 400 clients ===
(cumtime of each direct call from _reconcile; they do not overlap)

 cumtime (s) |  % recon | function
------------------------------------------------------------------------------------------
      24.801 |    91.8% | src/integrations.py:584(send_otlp)
       2.137 |     7.9% | src/integrations.py:458(forward_dashboards)
       0.030 |     0.1% | src/integrations.py:491(receive_otlp)
       0.009 |     0.0% | src/config_builder.py:201(hash)
       0.006 |     0.0% | src/config_builder.py:136(build)
       0.003 |     0.0% | src/integrations.py:679(receive_server_cert)
       0.001 |     0.0% | src/integrations.py:126(receive_loki_logs)
       0.001 |     0.0% | src/integrations.py:395(send_charm_traces)
       0.001 |     0.0% | src/integrations.py:773(setup_service_mesh)
       0.001 |     0.0% | src/integrations.py:229(scrape_metrics)
       0.000 |     0.0% | src/integrations.py:657(cloud_integrator)
       0.000 |     0.0% | src/integrations.py:259(send_remote_write)
       0.000 |     0.0% | ops/model.py:2647(add_layer)
       0.000 |     0.0% | src/integrations.py:160(send_loki_logs)
       0.000 |     0.0% | v0/kubernetes_compute_resources_patch.py:565(__init__)
       0.000 |     0.0% | src/integrations.py:744(receive_ca_cert)
       0.000 |     0.0% | src/charm.py:84(refresh_certs)
       0.000 |     0.0% | src/charm.py:557(_otelcol_version)
       0.000 |     0.0% | src/integrations.py:979(setup_traefik_ingress)
       0.000 |     0.0% | src/integrations.py:307(receive_traces)
       0.000 |     0.0% | ops/model.py:2795(push)
       0.000 |     0.0% | src/integrations.py:995(setup_istio_ingress)
       0.000 |     0.0% | src/integrations.py:118(receive_external_configs)
       0.000 |     0.0% | src/integrations.py:525(stage_received_otlp_rules)
       0.000 |     0.0% | src/integrations.py:825(is_tls_ready)
       0.000 |     0.0% | src/charm.py:503(_ensure_certs_dir)
       0.000 |     0.0% | re/__init__.py:169(fullmatch)
       0.000 |     0.0% | src/integrations.py:368(send_traces)
       0.000 |     0.0% | src/charm.py:438(_pebble_layer)
       0.000 |     0.0% | src/charm.py:114(_get_missing_mandatory_relations)
------------------------------------------------------------------------------------------
      27.003 |   100.0% | _reconcile TOTAL
```

As we can see, with this improvement we managed to completely avoid the execution of the code inside `stage_received_otlp_rules` and halve the execution time of `_reconcile()` (58,95s vs 27,0s)

## Testing Instructions

```shell
tox -e unit -- tests/unit/test_otlp.py
```

New scenario tests (`test_staging_skipped_without_file_consumer`) verify the three cases: send-otlp-only stages nothing, send-remote-write stages promql only, send-loki-logs stages logql only.



## Upgrade Notes
<!-- To upgrade from an older revision, ... -->

## Upgrade Notes

`juju refresh` to this revision. No config or relation changes are needed; aggregator 
deployments get the speedup, file-based topologies are unaffected.